### PR TITLE
Target conv 2d vectorization at specific ops

### DIFF
--- a/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
+++ b/lib/Dialects/LinalgTransform/Transforms/TransformInterpreter.cpp
@@ -214,8 +214,7 @@ executeDecomposeOp(ModuleOp module,
   MLIRContext *ctx = module->getContext();
   RewritePatternSet patterns(ctx);
   // TODO: make this targetable.
-  // populateDecomposeConvolutionPatterns(patterns,
-  //                                      makeTransformationFilter(target));
+  populateDecomposeConvolutionPatterns(patterns, LinalgTransformationFilter());
   if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))
     return failure();
 

--- a/python/examples/conv/conv_2d_bench.py
+++ b/python/examples/conv/conv_2d_bench.py
@@ -35,7 +35,7 @@ all_experts = [
             #           N  H  W  C  KH  KW  F
             tile_sizes=[1, 1, 8, 32, 1, 1, 8],
             peel=[0, 1, 2, 3, 4, 5, 6])
-        .then(Vectorize(fun_name, ''))
+        .then(Vectorize(fun_name, 'linalg.conv_1d_nwc_wcf'))
         .then(Bufferize())
         .then(LowerVectors(transpose_lowering='shuffle'))
         .then(LowerToLLVM()),
@@ -46,7 +46,7 @@ all_experts = [
             tile_sizes=[1, 1, 8, 32, 1, 1, 8],
             pad=True,
             hoist_paddings=[5, 0, 0])
-        .then(Vectorize(fun_name, ''))
+        .then(Vectorize(fun_name, 'linalg.conv_1d_nwc_wcf'))
         .then(Bufferize())
         .then(LowerVectors(transpose_lowering='shuffle'))
         .then(LowerToLLVM()),
@@ -57,7 +57,7 @@ all_experts = [
                                peel=[0, 1, 2, 3, 4, 5, 6],
                                tile_sizes2=[1, 1, 8, 32, 1, 1, 8],
                                peel2=[0, 1, 2, 3, 4, 5, 6])
-          .then(Vectorize(fun_name, ''))
+          .then(Vectorize(fun_name, 'linalg.conv_1d_nwc_wcf'))
           .then(Bufferize())
           .then(LowerVectors())
           .then(LowerToLLVM()),
@@ -69,7 +69,7 @@ all_experts = [
                            pad2=True,
                            pack_paddings2=[1, 0, 0],
                            hoist_paddings2=[4, 0, 0])
-          .then(Vectorize(fun_name, ''))
+          .then(Vectorize(fun_name, 'linalg.conv_1d_nwc_wcf'))
           .then(Bufferize())
           .then(LowerVectors(split_transfers='none',
                              transpose_lowering='shuffle',


### PR DESCRIPTION
Vectorization for 2d convolutions has not been filtered for specific
ops, presumably to avoid exposing the name of the op after
decomposition. Target it at decomposed 1d convolutions instead in
preparation for a better transfromation targeting scheme.

Enable DecomposeOp transformation in the transform dialect.