### PR TITLE
SQL: rewrite projections and implement multiply in rel_ssa

### DIFF
--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -107,6 +107,38 @@ class Expression(Operation):
   ...
 
 
+class BinOp(Expression):
+  """
+  Binary operation on two values.
+  """
+
+  lhs = SingleBlockRegionDef()
+  rhs = SingleBlockRegionDef()
+
+
+@irdl_op_definition
+class Multiply(BinOp):
+  """
+  Multiplies two values.
+
+  Example:
+
+  '''
+  rel_alg.multiply() {
+    rel_alg.column() ...
+  } {
+    rel_alg.column() ...
+  }
+  '''
+  """
+  name = "rel_alg.multiply"
+
+  @builder
+  @staticmethod
+  def get(lhs: Region, rhs: Region) -> 'Multiply':
+    return Multiply.build(regions=[lhs, rhs])
+
+
 @irdl_op_definition
 class Literal(Expression):
   """
@@ -282,32 +314,6 @@ class Project(Operator):
   def get(table: Region, projections: Region, names: ArrayAttr) -> 'Project':
     return Project.build(regions=[table, projections],
                          attributes={"names": names})
-
-
-@irdl_op_definition
-class Multiply(Operator):
-  """
-  Combines two columns into one by element-wise multiplication.
-
-  Example:
-
-  '''
-  rel_alg.multiply() {
-    rel_alg.column() ...
-  } {
-    rel_alg.column() ...
-  }
-  '''
-  """
-  name = "rel_alg.multiply"
-
-  lhs = SingleBlockRegionDef()
-  rhs = SingleBlockRegionDef()
-
-  @builder
-  @staticmethod
-  def get(lhs: Region, rhs: Region) -> 'Multiply':
-    return Multiply.build(regions=[lhs, rhs])
 
 
 @irdl_op_definition

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -117,35 +117,6 @@ class String(DataType):
 
 
 @irdl_attr_definition
-class ProjExpr(ParametrizedAttribute):
-  """
-  Base class for nodes used to define expression trees for projections.
-  """
-  ...
-
-
-@irdl_attr_definition
-class ColExpr(ProjExpr):
-  """
-  Represents a column in a projection expression tree.
-  """
-  name = "rel_ssa.col_expr"
-
-  col_name = ParameterDef(StringAttr)
-
-
-@irdl_attr_definition
-class MulExpr(ProjExpr):
-  """
-  Represents a multiplication of `lhs` * `rhs` in a projection expression tree..
-  """
-  name = "rel_ssa.mul_expr"
-
-  lhs = ParameterDef(ProjExpr)
-  rhs = ParameterDef(ProjExpr)
-
-
-@irdl_attr_definition
 class Boolean(ParametrizedAttribute):
   """
   Models a type that can either be true or false to, e.g., show whether a tuple
@@ -253,6 +224,27 @@ class Column(Expression):
   def get(name: str, res_type: DataType) -> 'Column':
     return Column.build(result_types=[res_type],
                         attributes={"col_name": StringAttr.from_str(name)})
+
+
+@irdl_op_definition
+class BinOp(Expression):
+  name = "rel_ssa.bin_op"
+
+  # TODO: could be restricted to only allow ints/floats
+  lhs = OperandDef(DataType)
+  rhs = OperandDef(DataType)
+
+  # TODO: restrict to only *, +, - ...
+  operator = AttributeDef(StringAttr)
+
+  result = ResultDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(lhs: Operation, rhs: Operation, operator: str):
+    return BinOp.build(operands=[lhs, rhs],
+                       attributes={"operator": StringAttr.from_str(operator)},
+                       result_types=[lhs.result.typ])
 
 
 @irdl_op_definition
@@ -492,9 +484,6 @@ class RelSSA:
     self.ctx.register_attr(String)
     self.ctx.register_attr(Boolean)
     self.ctx.register_attr(SchemaElement)
-
-    self.ctx.register_attr(ColExpr)
-    self.ctx.register_attr(MulExpr)
 
     self.ctx.register_op(Select)
     self.ctx.register_op(Table)

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -117,6 +117,35 @@ class String(DataType):
 
 
 @irdl_attr_definition
+class ProjExpr(ParametrizedAttribute):
+  """
+  Base class for nodes used to define expression trees for projections.
+  """
+  ...
+
+
+@irdl_attr_definition
+class ColExpr(ProjExpr):
+  """
+  Represents a column in a projection expression tree.
+  """
+  name = "rel_ssa.col_expr"
+
+  col_name = ParameterDef(StringAttr)
+
+
+@irdl_attr_definition
+class MulExpr(ProjExpr):
+  """
+  Represents a multiplication of `lhs` * `rhs` in a projection expression tree..
+  """
+  name = "rel_ssa.mul_expr"
+
+  lhs = ParameterDef(ProjExpr)
+  rhs = ParameterDef(ProjExpr)
+
+
+@irdl_attr_definition
 class Boolean(ParametrizedAttribute):
   """
   Models a type that can either be true or false to, e.g., show whether a tuple
@@ -463,6 +492,9 @@ class RelSSA:
     self.ctx.register_attr(String)
     self.ctx.register_attr(Boolean)
     self.ctx.register_attr(SchemaElement)
+
+    self.ctx.register_attr(ColExpr)
+    self.ctx.register_attr(MulExpr)
 
     self.ctx.register_op(Select)
     self.ctx.register_op(Table)

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -102,6 +102,29 @@ class CompareRewriter(RelAlgRewriter):
     rewriter.replace_matched_op([new_op, RelSSA.Yield.get([new_op])])
 
 
+@dataclass
+class BinOpRewriter(RelAlgRewriter):
+
+  def convert_bin_op_to_str(self, op: RelAlg.BinOp) -> str:
+    if isinstance(op, RelAlg.Multiply):
+      return "*"
+    raise Exception(f"bin op conversion not yet implemented for {type(op)}")
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelAlg.BinOp, rewriter: PatternRewriter):
+    # Remove the yield and inline the rest of the block.
+    rewriter.erase_op(op.lhs.blocks[0].ops[-1])
+    rewriter.inline_block_before_matched_op(op.lhs.blocks[0])
+    left = rewriter.added_operations_before[-1]
+
+    rewriter.erase_op(op.rhs.blocks[0].ops[-1])
+    rewriter.inline_block_before_matched_op(op.rhs.blocks[0])
+    right = rewriter.added_operations_before[-1]
+
+    new_op = RelSSA.BinOp.get(left, right, self.convert_bin_op_to_str(op))
+    rewriter.replace_matched_op([new_op, RelSSA.Yield.get([new_op])])
+
+
 #===------------------------------------------------------------------------===#
 # Operators
 #===------------------------------------------------------------------------===#
@@ -109,16 +132,6 @@ class CompareRewriter(RelAlgRewriter):
 
 @dataclass
 class ProjectRewriter(RelAlgRewriter):
-
-  def convert_to_proj_expr(self, expr_op: Operation) -> RelSSA.ProjExpr:
-    if isinstance(expr_op, RelAlg.Column):
-      return RelSSA.ColExpr([expr_op.col_name])
-    if isinstance(expr_op, RelAlg.Multiply):
-      return RelSSA.MulExpr([
-          self.convert_to_proj_expr(expr_op.lhs.op),
-          self.convert_to_proj_expr(expr_op.rhs.op)
-      ])
-    raise Exception(f"conversion not implemented: {type(expr_op)}")
 
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelAlg.Project, rewriter: PatternRewriter):
@@ -211,11 +224,11 @@ def alg_to_ssa(ctx: MLContext, query: ModuleOp):
                                          apply_recursively=True,
                                          walk_reverse=False)
   operator_walker.rewrite_module(query)
-  expression_walker = PatternRewriteWalker(GreedyRewritePatternApplier([
-      LiteralRewriter(),
-      ColumnRewriter(),
-      CompareRewriter(),
-  ]),
+  expression_walker = PatternRewriteWalker(GreedyRewritePatternApplier(
+      [LiteralRewriter(),
+       ColumnRewriter(),
+       CompareRewriter(),
+       BinOpRewriter()]),
                                            walk_regions_first=True,
                                            apply_recursively=True,
                                            walk_reverse=False)

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -110,6 +110,16 @@ class CompareRewriter(RelAlgRewriter):
 @dataclass
 class ProjectRewriter(RelAlgRewriter):
 
+  def convert_to_proj_expr(self, expr_op: Operation) -> RelSSA.ProjExpr:
+    if isinstance(expr_op, RelAlg.Column):
+      return RelSSA.ColExpr([expr_op.col_name])
+    if isinstance(expr_op, RelAlg.Multiply):
+      return RelSSA.MulExpr([
+          self.convert_to_proj_expr(expr_op.lhs.op),
+          self.convert_to_proj_expr(expr_op.rhs.op)
+      ])
+    raise Exception(f"conversion not implemented: {type(expr_op)}")
+
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelAlg.Project, rewriter: PatternRewriter):
     rewriter.inline_block_before_matched_op(op.input)

--- a/experimental/sql/test/alg_to_ssa/multiply.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multiply.xdsl
@@ -17,4 +17,9 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.mul_expr<!rel_ssa.col_expr<"b">, !rel_ssa.col_expr<"c">>]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+// CHECK-NEXT:    %2 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
+// CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "c"]
+// CHECK-NEXT:    %4 : !rel_ssa.int64 = rel_ssa.bin_op(%2 : !rel_ssa.int64, %3 : !rel_ssa.int64) ["operator" = "*"]
+// CHECK-NEXT:    rel_ssa.yield(%4 : !rel_ssa.int64)
+// CHECK-NEXT:  }

--- a/experimental/sql/test/alg_to_ssa/multiply.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multiply.xdsl
@@ -1,0 +1,20 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+  rel_alg.project() ["names" = ["bc"]] {
+    rel_alg.table() ["table_name" = "t"] {
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
+      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
+    }
+  } {
+    rel_alg.multiply() {
+      rel_alg.column() ["col_name" = "b"]
+    } {
+      rel_alg.column() ["col_name" = "c"]
+    }
+  }
+}
+
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.mul_expr<!rel_ssa.col_expr<"b">, !rel_ssa.col_expr<"c">>]]

--- a/experimental/sql/test/alg_to_ssa/projection.xdsl
+++ b/experimental/sql/test/alg_to_ssa/projection.xdsl
@@ -14,4 +14,8 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["a", "b"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+// CHECK-NEXT:    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
+// CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
+// CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+// CHECK-NEXT:  }

--- a/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
@@ -2,8 +2,16 @@
 
 module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["a", "b"]]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
+    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
+    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+ }
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["a", "b"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+// CHECK-NEXT:    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
+// CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
+// CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+// CHECK-NEXT:  }

--- a/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
@@ -2,7 +2,6 @@
 
 module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-<<<<<<< HEAD
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
@@ -16,10 +15,3 @@ module() {
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
 // CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
 // CHECK-NEXT:  }
-=======
-  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.col_expr<"a">, !rel_ssa.col_expr<"b">]]
-}
-
-//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.col_expr<"a">, !rel_ssa.col_expr<"b">]]
->>>>>>> 47d3b23 (first version)

--- a/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
@@ -2,6 +2,7 @@
 
 module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+<<<<<<< HEAD
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
@@ -15,3 +16,10 @@ module() {
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
 // CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
 // CHECK-NEXT:  }
+=======
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.col_expr<"a">, !rel_ssa.col_expr<"b">]]
+}
+
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.col_expr<"a">, !rel_ssa.col_expr<"b">]]
+>>>>>>> 47d3b23 (first version)


### PR DESCRIPTION
This PR rewrites projections in rel_ssa to use regions that compute the new tuples. It introduces a third pass over the IR, that combines all the yields into one. Additionally, it introduces a binary operation to rel_ssa and introduces the lowering for multiplications.