### PR TITLE
SQL: fix nesting of multiply operators

### DIFF
--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -127,7 +127,7 @@ class ProjectRewriter(RelAlgRewriter):
     rewriter.inline_block_before_matched_op(op.input)
     rewriter.insert_op_before_matched_op(
         RelSSA.Project.get(
-            rewriter.added_operations_before[0],
+            rewriter.added_operations_before[-1],
             [n.data for n in op.names.data],
             [self.convert_to_proj_expr(e) for e in op.projections.ops]))
     rewriter.erase_matched_op()
@@ -141,7 +141,7 @@ class SelectRewriter(RelAlgRewriter):
     rewriter.inline_block_before_matched_op(op.input)
     predicates = rewriter.move_region_contents_to_new_regions(op.predicates)
     rewriter.insert_op_before_matched_op(
-        RelSSA.Select.get(rewriter.added_operations_before[0], predicates))
+        RelSSA.Select.get(rewriter.added_operations_before[-1], predicates))
     rewriter.erase_matched_op()
 
 

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -165,7 +165,7 @@ class AggregateRewriter(RelAlgRewriter):
   def match_and_rewrite(self, op: RelAlg.Aggregate, rewriter: PatternRewriter):
     rewriter.inline_block_before_matched_op(op.input.blocks[0])
     rewriter.insert_op_before_matched_op([
-        RelSSA.Aggregate.get(rewriter.added_operations_before[0],
+        RelSSA.Aggregate.get(rewriter.added_operations_before[-1],
                              [c.data for c in op.col_names.data],
                              [f.data for f in op.functions.data],
                              [r.data for r in op.res_names.data])

--- a/experimental/sql/test/alg_to_ssa/multiply.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multiply.xdsl
@@ -1,17 +1,20 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
 module() {
-  rel_alg.project() ["names" = ["a", "b"]] {
+  rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
     }
   } {
-    rel_alg.column() ["col_name" = "a"]
-    rel_alg.column() ["col_name" = "b"]
+    rel_alg.multiply() {
+      rel_alg.column() ["col_name" = "b"]
+    } {
+      rel_alg.column() ["col_name" = "c"]
+    }
   }
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.col_expr<"a">, !rel_ssa.col_expr<"b">]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.mul_expr<!rel_ssa.col_expr<"b">, !rel_ssa.col_expr<"c">>]]

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -1,8 +1,8 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
 module() {
-    rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["idsum"]] {
-        rel_alg.project() ["names" = ["id"]] {
+    rel_alg.aggregate() ["col_names" = ["im"], "functions" = ["sum"], "res_names" = ["idsum"]] {
+        rel_alg.project() ["names" = ["im"]] {
             rel_alg.table() ["table_name" = "t"] {
                 rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
                 rel_alg.schema_element() ["elt_name" = "age", "elt_type" = !rel_alg.int32]
@@ -14,5 +14,5 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) ["col_names" = ["id"]]
-// CHECK-NEXT:  %2 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) ["projections" = [!rel_ssa.col_expr<"id">]]
+// CHECK-NEXT:  %2 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]>) ["col_names" = ["im"], "functions" = ["sum"]]

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -1,0 +1,18 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+    rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["idsum"]] {
+        rel_alg.project() ["names" = ["id"]] {
+            rel_alg.table() ["table_name" = "t"] {
+                rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
+                rel_alg.schema_element() ["elt_name" = "age", "elt_type" = !rel_alg.int32]
+            }
+        } {
+            rel_alg.column() ["col_name" = "id"]
+        }
+    }
+}
+
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) ["col_names" = ["id"]]
+// CHECK-NEXT:  %2 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]

--- a/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
@@ -2,8 +2,8 @@
 
 module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["a", "b"]]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.col_expr<"a">, !rel_ssa.col_expr<"b">]]
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["a", "b"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["projections" = [!rel_ssa.col_expr<"a">, !rel_ssa.col_expr<"b">]]


### PR DESCRIPTION
This PR fixes a bug where when inlining the tree to ssa, always the first operation of the block to be inlined was taken as the result, where it should be the last.

This PR depends on (and includes) #523 