### PR TITLE
SQL: fix nesting

### DIFF
--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -215,7 +215,7 @@ class AggregateRewriter(RelAlgRewriter):
   def match_and_rewrite(self, op: RelAlg.Aggregate, rewriter: PatternRewriter):
     rewriter.inline_block_before_matched_op(op.input.blocks[0])
     rewriter.insert_op_before_matched_op([
-        RelSSA.Aggregate.get(rewriter.added_operations_before[0],
+        RelSSA.Aggregate.get(rewriter.added_operations_before[-1],
                              [c.data for c in op.col_names.data],
                              [f.data for f in op.functions.data],
                              [r.data for r in op.res_names.data])

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -139,7 +139,7 @@ class ProjectRewriter(RelAlgRewriter):
     input_bag = rewriter.added_operations_before[0].result.typ
     rewriter.insert_op_before_matched_op(
         RelSSA.Project.get(
-            rewriter.added_operations_before[0],
+            rewriter.added_operations_before[-1],
             [n.data for n in op.names.data], [
                 input_bag.lookup_type_in_schema(op.col_name.data) if isinstance(
                     op, RelAlg.Column) else RelSSA.Int64()
@@ -191,7 +191,7 @@ class SelectRewriter(RelAlgRewriter):
     rewriter.inline_block_before_matched_op(op.input)
     predicates = rewriter.move_region_contents_to_new_regions(op.predicates)
     rewriter.insert_op_before_matched_op(
-        RelSSA.Select.get(rewriter.added_operations_before[0], predicates))
+        RelSSA.Select.get(rewriter.added_operations_before[-1], predicates))
     rewriter.erase_matched_op()
 
 

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -14,5 +14,8 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) ["col_names" = ["id"]]
-// CHECK-NEXT:  %2 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) {
+// CHECK-NEXT:    %2 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
+// CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.int32)
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %3 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -1,0 +1,18 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+    rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["idsum"]] {
+        rel_alg.project() ["names" = ["id"]] {
+            rel_alg.table() ["table_name" = "t"] {
+                rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
+                rel_alg.schema_element() ["elt_name" = "age", "elt_type" = !rel_alg.int32]
+            }
+        } {
+            rel_alg.column() ["col_name" = "id"]
+        }
+    }
+}
+
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) ["col_names" = ["id"]]
+// CHECK-NEXT:  %2 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -1,8 +1,8 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
 module() {
-    rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["idsum"]] {
-        rel_alg.project() ["names" = ["id"]] {
+    rel_alg.aggregate() ["col_names" = ["im"], "functions" = ["sum"], "res_names" = ["idsum"]] {
+        rel_alg.project() ["names" = ["im"]] {
             rel_alg.table() ["table_name" = "t"] {
                 rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
                 rel_alg.schema_element() ["elt_name" = "age", "elt_type" = !rel_alg.int32]
@@ -14,8 +14,8 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) {
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) {
 // CHECK-NEXT:    %2 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
 // CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.int32)
 // CHECK-NEXT:  }
-// CHECK-NEXT:  %3 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %3 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]>) ["col_names" = ["im"], "functions" = ["sum"]]


### PR DESCRIPTION
This patch fixes a bug that made nesting of operations fail. In the earlier version it was the case that I always matched on the first inlined operation, whereas in reality, I should always match on the last one.