### PR TITLE
SQL: update project to use ibis v3.0.0

### DIFF
--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -6,5 +6,5 @@ yapf==0.32.0
 pyright==0.0.13
 frozenlist==1.2.*
 psutil==5.9.0
-ibis-framework==2.1.1
+ibis-framework==3.0.0
 multipledispatch==0.6


### PR DESCRIPTION
This patch updates the project to work on ibis v3.0.0. Among other things, this will allow us to build decimal literals, which is required to run Q6.