### PR TITLE
SQL: handle decimal literals

### DIFF
--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -11,6 +11,8 @@ from multipledispatch import dispatch
 import ibis
 import numpy as np
 
+from decimal import Decimal
+
 import dialects.ibis_dialect as id
 
 # This file contains the translation from ibis to the ibis_dialect. This
@@ -41,6 +43,8 @@ def convert_literal(literal) -> Attribute:
   if isinstance(literal, int):
     # np.int64 are parsed as int by ibis
     return IntegerAttr.from_int_and_width(literal, 64)
+  if isinstance(literal, Decimal):
+    return StringAttr.from_str(literal)
   raise Exception(f"literal conversion not yet implemented for {type(literal)}")
 
 

--- a/experimental/sql/test/frontend/decimal_literal.ibis
+++ b/experimental/sql/test/frontend/decimal_literal.ibis
@@ -1,0 +1,9 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("EXTENDEDPRICE", "decimal")],
+                'lineitem')
+
+table.filter(table['EXTENDEDPRICE'] >= ibis.literal(decimal.Decimal("0.05"), "decimal(6, 2)"))
+
+
+# CHECK: ibis.literal() ["val" = "0.05", "type" = !ibis.decimal]

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -39,6 +39,7 @@ class RelOptMain(xDSLOptMain):
     def parse_ibis(f: IOBase):
       import ibis
       import numpy as np
+      import decimal
 
       def exec_then_eval(query: str):
         """
@@ -53,6 +54,7 @@ class RelOptMain(xDSLOptMain):
 
         _locals["np"] = np
         _locals["ibis"] = ibis
+        _locals["decimal"] = decimal
 
         ast_query = ast.parse(query)
         last = ast.Expression(ast_query.body.pop().value)


### PR DESCRIPTION
This PR adds handling of decimal literals. Currently, the value is represented as a string as the Decimal framewok also uses strings to build decimals.