### PR TITLE
SQL: add datatpyes rel_impl

### DIFF
--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -58,6 +58,34 @@ class Int64(DataType):
 
 
 @irdl_attr_definition
+class Decimal(DataType):
+  """
+  Models a decimal type in a relational implementation query.
+
+  Example:
+
+  ```
+  !rel_impl.decimal
+  ```
+  """
+  name = "rel_impl.decimal"
+
+
+@irdl_attr_definition
+class Timestamp(DataType):
+  """
+  Models a timestamp type in a relational implementation query.
+
+  Example:
+
+  ```
+  !rel_impl.timestamp
+  ```
+  """
+  name = "rel_impl.timestamp"
+
+
+@irdl_attr_definition
 class String(DataType):
   """
   Models a string type in a relational implementation query, that can be either
@@ -401,6 +429,8 @@ class RelImpl:
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(Int32)
     self.ctx.register_attr(Int64)
+    self.ctx.register_attr(Decimal)
+    self.ctx.register_attr(Timestamp)
     self.ctx.register_attr(String)
     self.ctx.register_attr(Boolean)
     self.ctx.register_attr(SchemaElement)

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -28,6 +28,10 @@ class RelSSARewriter(RewritePattern):
       return RelImpl.Int32()
     if isinstance(type_, RelSSA.Int64):
       return RelImpl.Int64()
+    if isinstance(type_, RelSSA.Decimal):
+      return RelImpl.Decimal()
+    if isinstance(type_, RelSSA.Timestamp):
+      return RelImpl.Timestamp()
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
@@ -1,0 +1,7 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+}
+
+// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/ssa_to_impl/datatypes.xdsl
+++ b/experimental/sql/test/ssa_to_impl/datatypes.xdsl
@@ -1,0 +1,7 @@
+// RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
+
+module() {
+    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+}
+
+// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]


### PR DESCRIPTION
This patch introduces the decimal and timestamp data types to rel_impl and introduces their lowerings.