### PR TITLE
SQL: multiply in rel_impl

### DIFF
--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -237,6 +237,36 @@ class IndexByName(Expression):
 
 
 @irdl_op_definition
+class BinOp(Expression):
+  """
+  Models a binary operation of `lhs` `operator` `rhs`.
+
+  Example:
+
+  '''
+  %1 : !rel_impl.int32 = rel_impl.bin_op(%0 : !rel_impl.int32, %2 : !rel_impl.int32) ["operator" = "*"]
+  '''
+  """
+  name = "rel_impl.bin_op"
+
+  # TODO: could be restricted to only allow ints/floats
+  lhs = OperandDef(DataType)
+  rhs = OperandDef(DataType)
+
+  # TODO: restrict to only *, +, - ...
+  operator = AttributeDef(StringAttr)
+
+  result = ResultDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(lhs: Operation, rhs: Operation, operator: str):
+    return BinOp.build(operands=[lhs, rhs],
+                       attributes={"operator": StringAttr.from_str(operator)},
+                       result_types=[lhs.result.typ])
+
+
+@irdl_op_definition
 class Compare(Expression):
   """
   Returns `left` 'comparator' `right`.
@@ -508,3 +538,4 @@ class RelImpl:
     self.ctx.register_op(IndexByName)
     self.ctx.register_op(Yield)
     self.ctx.register_op(And)
+    self.ctx.register_op(BinOp)

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -228,6 +228,15 @@ class Column(Expression):
 
 @irdl_op_definition
 class BinOp(Expression):
+  """
+  Models a binary operation of `lhs` `operator` `rhs`.
+
+  Example:
+
+  '''
+  %1 : !rel_ssa.int32 = rel_ssa.bin_op(%0 : !rel_ssa.int32, %2 : !rel_ssa.int32) ["operator" = "*"]
+  '''
+  """
   name = "rel_ssa.bin_op"
 
   # TODO: could be restricted to only allow ints/floats
@@ -519,3 +528,4 @@ class RelSSA:
     self.ctx.register_op(Column)
     self.ctx.register_op(Yield)
     self.ctx.register_op(And)
+    self.ctx.register_op(BinOp)

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -91,6 +91,15 @@ class AndRewriter(RelSSARewriter):
 
 
 @dataclass
+class BinOpRewriter(RelSSARewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelSSA.BinOp, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        [RelImpl.BinOp.get(op.lhs.op, op.rhs.op, op.operator.data)])
+
+
+@dataclass
 class YieldRewriter(RelSSARewriter):
 
   @op_type_rewrite_pattern
@@ -173,7 +182,8 @@ def ssa_to_impl(ctx: MLContext, query: ModuleOp):
       CompareRewriter(),
       YieldRewriter(),
       ProjectRewriter(),
-      AndRewriter()
+      AndRewriter(),
+      BinOpRewriter()
   ]),
                                 walk_regions_first=False,
                                 apply_recursively=True,

--- a/experimental/sql/test/ssa_to_impl/multiply.xdsl
+++ b/experimental/sql/test/ssa_to_impl/multiply.xdsl
@@ -1,0 +1,20 @@
+// RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
+
+module() {
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+    %2 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
+    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "c"]
+    %4 : !rel_ssa.int64 = rel_ssa.bin_op(%2 : !rel_ssa.int64, %3 : !rel_ssa.int64) ["operator" = "*"]
+    rel_ssa.yield(%4 : !rel_ssa.int64)
+  }
+}
+
+//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"bc", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+// CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+// CHECK-NEXT:      %3 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+// CHECK-NEXT:      %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "c"]
+// CHECK-NEXT:      %5 : !rel_impl.int64 = rel_impl.bin_op(%3 : !rel_impl.int64, %4 : !rel_impl.int64) ["operator" = "*"]
+// CHECK-NEXT:      rel_impl.yield(%5 : !rel_impl.int64)
+// CHECK-NEXT:  }


### PR DESCRIPTION
This patch introduces mulitplication to rel_impl and its lowering form rel_alg. With this patch, all of Q6 can be lowered to rel_impl.