### PR TITLE
SQL: add constantstreamOp to iterators mirror

### DIFF
--- a/experimental/sql/dialects/iterators.py
+++ b/experimental/sql/dialects/iterators.py
@@ -57,7 +57,7 @@ class SampleInputOp(Operation):
 
 
 @irdl_op_definition
-class ConstantstreamOp(Operation):
+class ConstantStreamOp(Operation):
   """
   Produces a stream of LLVM structs given in the array of arrays attribute
   (each inner array being returned as a literal LLVM struct with the values
@@ -127,4 +127,4 @@ class Iterators:
     self.ctx.register_op(SampleInputOp)
     self.ctx.register_op(ReduceOp)
     self.ctx.register_op(SinkOp)
-    self.ctx.register_op(ConstantstreamOp)
+    self.ctx.register_op(ConstantStreamOp)

--- a/experimental/sql/dialects/iterators.py
+++ b/experimental/sql/dialects/iterators.py
@@ -28,11 +28,11 @@ class Stream(ParametrizedAttribute):
   """
   name = "iterators.stream"
 
-  types = ParameterDef(TupleType)
+  types = ParameterDef(AnyAttr())
 
   @builder
   @staticmethod
-  def get(elem_type: TupleType) -> 'Stream':
+  def get(elem_type: Attribute) -> 'Stream':
     return Stream([elem_type])  #type: ignore
 
 
@@ -54,6 +54,29 @@ class SampleInputOp(Operation):
   @staticmethod
   def get(type: Attribute) -> 'SampleInputOp':
     return SampleInputOp.build(result_types=[type])
+
+
+@irdl_op_definition
+class ConstantstreamOp(Operation):
+  """
+  Produces a stream of LLVM structs given in the array of arrays attribute
+  (each inner array being returned as a literal LLVM struct with the values
+  and types of the elements of that array). The inner arrays all have to have
+  matching types, i.e., the element at position i has to be the same for all
+  inner arrays, and the element type of the return Stream has to be the
+  corresponding literal LLVM struct. An empty array is allowed (in which case
+  the return Stream does not need to match anything).
+
+  Example:
+  ```mlir
+  %0 = "iterators.constantstream"() { value = [[42 : i32]] } :
+          () -> (!iterators.stream<!llvm.struct<(i32)>>)
+  ```
+  """
+  name = "iterators.constantstream"
+
+  value = AttributeDef(ArrayOfConstraint(ArrayOfConstraint(AnyAttr())))
+  result = ResultDef(Stream)
 
 
 @irdl_op_definition
@@ -104,3 +127,4 @@ class Iterators:
     self.ctx.register_op(SampleInputOp)
     self.ctx.register_op(ReduceOp)
     self.ctx.register_op(SinkOp)
+    self.ctx.register_op(ConstantstreamOp)

--- a/experimental/sql/test_mlir/conversion_tests/constant_stream.xdsl
+++ b/experimental/sql/test_mlir/conversion_tests/constant_stream.xdsl
@@ -1,0 +1,20 @@
+// RUN: rel_opt.py -t mlir %s | filecheck %s
+
+module() {
+  func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
+    %input : !iterators.stream<!llvm.struct<"", [!i32], "opaque">> = iterators.constantstream() ["value" = [[42 : !i32]]]
+    func.return()
+  }
+}
+
+//      CHECK: func.func @main() {
+// CHECK-NEXT:   %empty = "iterators.constantstream"() { value = [] }
+// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(i32)>>)
+// CHECK-NEXT:   %i32 = "iterators.constantstream"() { value = [[42 : i32]] }
+// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(i32)>>)
+// CHECK-NEXT:   %f32 = "iterators.constantstream"() { value = [[42. : f32]] }
+// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(f32)>>)
+// CHECK-NEXT:   %i32i64 = "iterators.constantstream"() { value = [[42 : i32, 1337 : i64]] }
+// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(i32, i64)>>)
+// CHECK-NEXT:   return
+// CHECK-NEXT: }

--- a/experimental/sql/test_mlir/conversion_tests/constant_stream.xdsl
+++ b/experimental/sql/test_mlir/conversion_tests/constant_stream.xdsl
@@ -2,19 +2,18 @@
 
 module() {
   func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
-    %input : !iterators.stream<!llvm.struct<"", [!i32], "opaque">> = iterators.constantstream() ["value" = [[42 : !i32]]]
+    %empty : !iterators.stream<!llvm.struct<"", []>> = iterators.constantstream() ["value" = [[]]]
+    %i32 : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[42 : !i32]]]
+    %i32i64 : !iterators.stream<!llvm.struct<"", [!i32, !i64]>> = iterators.constantstream() ["value" = [[42 : !i32, 1337 : !i64]]]
+    %two_elems : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[42 : !i32], [1337 : !i32]]]
     func.return()
   }
 }
 
-//      CHECK: func.func @main() {
-// CHECK-NEXT:   %empty = "iterators.constantstream"() { value = [] }
-// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(i32)>>)
-// CHECK-NEXT:   %i32 = "iterators.constantstream"() { value = [[42 : i32]] }
-// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(i32)>>)
-// CHECK-NEXT:   %f32 = "iterators.constantstream"() { value = [[42. : f32]] }
-// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(f32)>>)
-// CHECK-NEXT:   %i32i64 = "iterators.constantstream"() { value = [[42 : i32, 1337 : i64]] }
-// CHECK-NEXT:       : () -> (!iterators.stream<!llvm.struct<(i32, i64)>>)
-// CHECK-NEXT:   return
-// CHECK-NEXT: }
+//      CHECK: func.func public @main() {
+// CHECK-NEXT:     %0 = "iterators.constantstream"() {value = [[]]} : () -> !iterators.stream<!llvm.struct<()>>
+// CHECK-NEXT:     %1 = "iterators.constantstream"() {value = [[42 : i32]]} : () -> !iterators.stream<!llvm.struct<(i32)>>
+// CHECK-NEXT:     %2 = "iterators.constantstream"() {value = [[42 : i32, 1337]]} : () -> !iterators.stream<!llvm.struct<(i32, i64)>>
+// CHECK-NEXT:     %3 = "iterators.constantstream"() {value = [[42 : i32], [1337 : i32]]} : () -> !iterators.stream<!llvm.struct<(i32)>>
+// CHECK-NEXT:     return
+// CHECK-NEXT:   }


### PR DESCRIPTION
This PR updates the iterators mirrored dialect with the constantstreamOp. This is mainly an operation used for testing purposes, which makes it a sensible first target to get to work.

Notice that we do not run any testcases for the mlir_conversion on our CI currently. With this PR there is no actual xdsl version that can handle this specific conversion. It has to be the xdsl checked out from [here](https://github.com/xdslproject/xdsl/tree/llvm_struct_hack).