### PR TITLE
Iterators: Create FilterOp and MapOp.

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -105,7 +105,7 @@ class LookupFuncType<string opName, string symbolName>
             "       .getFunctionType()">;
 
 /// A predicate, that is, a function with a signature of the form (T) -> i1.
-class Iterators_Predicate
+class Iterators_PredicateFunctionType
   : Type<And<[FunctionType.predicate,
               CPred<"$_self.dyn_cast<FunctionType>().getInputs().size() == 1">,
               CPred<"$_self.dyn_cast<FunctionType>().getResults().size() == 1">,
@@ -117,14 +117,14 @@ class Iterators_Predicate
          "FunctionType">;
 
 /// A FlatSymbolRef referring to a predicate.
-def Iterators_PredicateRefAttr
+def Iterators_PredicateFunctionSymbol
   : Confined<FlatSymbolRefAttr, [
         ReferToOp<"func::FuncOp">,
         AttrConstraint<
           SubstLeaves<"$_self",
                       LookupFuncType<"_op", "$_self.dyn_cast<FlatSymbolRefAttr>()">.result,
-                      Iterators_Predicate<>.predicate>,
-          "referring to a " # Iterators_Predicate<>.summary>
+                      Iterators_PredicateFunctionType<>.predicate>,
+          "referring to a " # Iterators_PredicateFunctionType<>.summary>
       ]>;
 
 def Iterators_FilterOp : Iterators_Op<"filter",
@@ -145,7 +145,7 @@ def Iterators_FilterOp : Iterators_Op<"filter",
   }];
   let arguments = (ins
       Iterators_StreamOfLLVMStructOfNumerics:$input,
-      Iterators_PredicateRefAttr:$predicateRef
+      Iterators_PredicateFunctionSymbol:$predicateRef
     );
   let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
   let extraClassDeclaration = [{
@@ -157,7 +157,7 @@ def Iterators_FilterOp : Iterators_Op<"filter",
 }
 
 /// A predicate, that is, a function with a signature of the form (T) -> i1.
-class Iterators_MapFunc
+class Iterators_MapFunctionType
   : Type<And<[FunctionType.predicate,
               CPred<"$_self.dyn_cast<FunctionType>().getInputs().size() == 1">,
               CPred<"$_self.dyn_cast<FunctionType>().getResults().size() == 1">
@@ -166,14 +166,14 @@ class Iterators_MapFunc
          "FunctionType">;
 
 /// A FlatSymbolRef referring to a predicate.
-def Iterators_MapFuncRefAttr
+def Iterators_MapFunctionSymbol
   : Confined<FlatSymbolRefAttr, [
         ReferToOp<"func::FuncOp">,
         AttrConstraint<
           SubstLeaves<"$_self",
                       LookupFuncType<"_op", "$_self.dyn_cast<FlatSymbolRefAttr>()">.result,
-                      Iterators_MapFunc<>.predicate>,
-          "referring to a " # Iterators_MapFunc<>.summary>
+                      Iterators_MapFunctionType<>.predicate>,
+          "referring to a " # Iterators_MapFunctionType<>.summary>
       ]>;
 
 def Iterators_MapOp : Iterators_Op<"map",
@@ -196,7 +196,7 @@ def Iterators_MapOp : Iterators_Op<"map",
   }];
   let arguments = (ins
       Iterators_StreamOfLLVMStructOfNumerics:$input,
-      Iterators_MapFuncRefAttr:$mapFuncRef
+      Iterators_MapFunctionSymbol:$mapFuncRef
     );
   let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
   let extraClassDeclaration = [{
@@ -209,7 +209,7 @@ def Iterators_MapOp : Iterators_Op<"map",
 
 /// A reduce function, that is, a function with a signature of the form
 /// (T, T) -> T.
-class Iterators_ReduceFunc
+class Iterators_ReduceFunctionType
   : Type<And<[FunctionType.predicate,
               CPred<"$_self.dyn_cast<FunctionType>().getInputs().size() == 2">,
               CPred<"$_self.dyn_cast<FunctionType>().getResults().size() == 1">,
@@ -223,14 +223,14 @@ class Iterators_ReduceFunc
          "FunctionType">;
 
 /// A FlatSymbolRef referring to a reduce function.
-def Iterators_ReduceFuncRefAttr
+def Iterators_ReduceFunctionSymbol
   : Confined<FlatSymbolRefAttr, [
         ReferToOp<"func::FuncOp">,
         AttrConstraint<
           SubstLeaves<"$_self",
                       LookupFuncType<"_op", "$_self.dyn_cast<FlatSymbolRefAttr>()">.result,
-                      Iterators_ReduceFunc<>.predicate>,
-          "referring to a " # Iterators_ReduceFunc<>.summary>
+                      Iterators_ReduceFunctionType<>.predicate>,
+          "referring to a " # Iterators_ReduceFunctionType<>.summary>
       ]>;
 
 def Iterators_ReduceOp : Iterators_Op<"reduce",
@@ -254,7 +254,7 @@ def Iterators_ReduceOp : Iterators_Op<"reduce",
   }];
   let arguments = (ins
       Iterators_StreamOfLLVMStructOfNumerics:$input,
-      Iterators_ReduceFuncRefAttr:$reduceFuncRef
+      Iterators_ReduceFunctionSymbol:$reduceFuncRef
     );
   let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
   let extraClassDeclaration = [{

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -104,7 +104,7 @@ class LookupFuncType<string opName, string symbolName>
             "    " # symbolName # ".dyn_cast<FlatSymbolRefAttr>())"
             "       .getFunctionType()">;
 
-/// A reduce function, that is a function with a signature of the form
+/// A reduce function, that is, a function with a signature of the form
 /// (T, T) -> T.
 class Iterators_ReduceFunc
   : Type<And<[FunctionType.predicate,
@@ -133,7 +133,7 @@ def Iterators_ReduceFuncRefAttr
 def Iterators_ReduceOp : Iterators_Op<"reduce",
     [AllMatch<["getReduceFunc().getResultTypes().front()",
                "$input.getType().dyn_cast<StreamType>().getElementType()"],
-              "the reduce function signature must match its element type">]> {
+              "the signature of the reduce function must match the element type">]> {
   let summary = "Reduce the input to a single tuple";
   let description = [{
     Reads the elements of its operand stream and reduces them to a single

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -104,6 +104,58 @@ class LookupFuncType<string opName, string symbolName>
             "    " # symbolName # ".dyn_cast<FlatSymbolRefAttr>())"
             "       .getFunctionType()">;
 
+/// A predicate, that is, a function with a signature of the form (T) -> i1.
+class Iterators_Predicate
+  : Type<And<[FunctionType.predicate,
+              CPred<"$_self.dyn_cast<FunctionType>().getInputs().size() == 1">,
+              CPred<"$_self.dyn_cast<FunctionType>().getResults().size() == 1">,
+              SubstLeaves<"$_self",
+                      "$_self.dyn_cast<FunctionType>().getResult(0)",
+                      I1.predicate>
+             ]>,
+         "function with signature (T) -> i1",
+         "FunctionType">;
+
+/// A FlatSymbolRef referring to a predicate.
+def Iterators_PredicateRefAttr
+  : Confined<FlatSymbolRefAttr, [
+        ReferToOp<"func::FuncOp">,
+        AttrConstraint<
+          SubstLeaves<"$_self",
+                      LookupFuncType<"_op", "$_self.dyn_cast<FlatSymbolRefAttr>()">.result,
+                      Iterators_Predicate<>.predicate>,
+          "referring to a " # Iterators_Predicate<>.summary>
+      ]>;
+
+def Iterators_FilterOp : Iterators_Op<"filter",
+    [AllMatch<["getPredicate().getArgumentTypes().front()",
+               "$input.getType().dyn_cast<StreamType>().getElementType()"],
+              "the signature of the predicate must match the element type">]> {
+  let summary = "Filter the elements of the input using a predicate";
+  let description = [{
+    Reads the elements of its operand stream and produces a stream consisting of
+    those that match the provided predicate (i.e., those on which the provided
+    predicate returns true).
+
+    Example:
+    ```mlir
+    %filtered = "iterators.filter"(%input) {predicateRef = @is_positive} :
+                   (!iterators.stream<i32>) -> (!iterators.stream<i32>)
+    ```
+  }];
+  let arguments = (ins
+      Iterators_StreamOfLLVMStructOfNumerics:$input,
+      Iterators_PredicateRefAttr:$predicateRef
+    );
+  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let extraClassDeclaration = [{
+    func::FuncOp getPredicate() {
+      return SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+          *this, predicateRefAttr());
+    }
+  }];
+}
+
 /// A reduce function, that is, a function with a signature of the form
 /// (T, T) -> T.
 class Iterators_ReduceFunc

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -156,6 +156,57 @@ def Iterators_FilterOp : Iterators_Op<"filter",
   }];
 }
 
+/// A predicate, that is, a function with a signature of the form (T) -> i1.
+class Iterators_MapFunc
+  : Type<And<[FunctionType.predicate,
+              CPred<"$_self.dyn_cast<FunctionType>().getInputs().size() == 1">,
+              CPred<"$_self.dyn_cast<FunctionType>().getResults().size() == 1">
+             ]>,
+         "function with signature (T1) -> T2",
+         "FunctionType">;
+
+/// A FlatSymbolRef referring to a predicate.
+def Iterators_MapFuncRefAttr
+  : Confined<FlatSymbolRefAttr, [
+        ReferToOp<"func::FuncOp">,
+        AttrConstraint<
+          SubstLeaves<"$_self",
+                      LookupFuncType<"_op", "$_self.dyn_cast<FlatSymbolRefAttr>()">.result,
+                      Iterators_MapFunc<>.predicate>,
+          "referring to a " # Iterators_MapFunc<>.summary>
+      ]>;
+
+def Iterators_MapOp : Iterators_Op<"map",
+    [AllMatch<["getMapFunc().getArgumentTypes().front()",
+               "$input.getType().dyn_cast<StreamType>().getElementType()"],
+              "the argument of the map function must match the input element type">,
+     AllMatch<["getMapFunc().getResultTypes().front()",
+               "$result.getType().dyn_cast<StreamType>().getElementType()"],
+              "the return type of the map function must match the result element type">]> {
+  let summary = "Maps (or transforms) each element of the input to another one.";
+  let description = [{
+    Reads the elements of its operand stream and maps each of them to a new
+    element, i.e., transforms the input stream elementwise.
+
+    Example:
+    ```mlir
+    %mapped = "iterators.map"(%input) {mapFuncRef = @abs} :
+                   (!iterators.stream<i32>) -> (!iterators.stream<i32>)
+    ```
+  }];
+  let arguments = (ins
+      Iterators_StreamOfLLVMStructOfNumerics:$input,
+      Iterators_MapFuncRefAttr:$mapFuncRef
+    );
+  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let extraClassDeclaration = [{
+    func::FuncOp getMapFunc() {
+      return SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(
+          *this, mapFuncRefAttr());
+    }
+  }];
+}
+
 /// A reduce function, that is, a function with a signature of the form
 /// (T, T) -> T.
 class Iterators_ReduceFunc

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -443,7 +443,7 @@ static Value buildStateCreation(ConstantStreamOp op, RewriterBase &rewriter,
 ///
 /// %0 = llvm.extractvalue %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", !nested_state>
-/// %1 = call @iterators.constantstream.open.0(%0) :
+/// %1 = call @iterators.upstream.open.0(%0) :
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
@@ -483,13 +483,13 @@ static Value buildOpenBody(ReduceOp op, RewriterBase &rewriter,
 ///
 /// %0 = llvm.extractvalue %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
-/// %1:3 = call @iterators.constantstream.next.0(%0) :
+/// %1:3 = call @iterators.upstream.next.0(%0) :
 ///            (!nested_state) -> (!nested_state, i1, !element_type)
 /// %2:3 = scf.if %1#1 -> (!nested_state, i1, !element_type) {
 ///   %4:3 = scf.while (%arg1 = %1#0, %arg2 = %1#2) :
 ///              (!nested_state, !element_type) ->
 ///                 (!nested_state, !element_type, !element_type) {
-///     %5:3 = call @iterators.constantstream.next.0(%arg1) :
+///     %5:3 = call @iterators.upstream.next.0(%arg1) :
 ///                (!nested_state) -> (!nested_state, i1, !element_type)
 ///     scf.condition(%5#1) %5#0, %5#2, %arg2 :
 ///         !nested_state, !element_type, !element_type
@@ -546,7 +546,7 @@ buildNextBody(ReduceOp op, RewriterBase &rewriter, Value initialState,
                 Block::BlockArgListType args) {
               Value upstreamState = args[0];
               Value accumulator = args[1];
-              func::CallOp nextCall = builder.create<func::CallOp>(
+              auto nextCall = builder.create<func::CallOp>(
                   loc, nextFunc, nextResultTypes, upstreamState);
 
               Value updatedUpstreamState = nextCall->getResult(0);
@@ -605,7 +605,7 @@ buildNextBody(ReduceOp op, RewriterBase &rewriter, Value initialState,
 ///
 /// %0 = llvm.extractvalue %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
-/// %1 = call @iterators.constantstream.close.0(%0) :
+/// %1 = call @iterators.upstream.close.0(%0) :
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
@@ -1,0 +1,66 @@
+// RUN: mlir-proto-opt %s -convert-iterators-to-llvm \
+// RUN: | FileCheck --enable-var-scope %s
+
+!element_type = !llvm.struct<(i32)>
+
+// CHECK-LABEL: func.func private @iterators.filter.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})> {
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
+// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: func.func private @iterators.filter.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>) -> (!llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-NEXT:    %[[V1:.*]]:3 = scf.while (%[[arg1:.*]] = %[[V0]]) : ([[upstreamStateType:.*]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>) {
+// CHECK-NEXT:      %[[V3:.*]]:3 = func.call @iterators.{{[a-zA-Z]+}}.next.0(%[[arg1]]) : ([[upstreamStateType]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:      %[[V4:.*]] = scf.if %[[V3]]#1 -> (i1) {
+// CHECK-NEXT:        %[[V7:.*]] = func.call @is_positive_struct(%[[V3]]#2) : (!llvm.struct<(i32)>) -> i1
+// CHECK-NEXT:        scf.yield %[[V7]] : i1
+// CHECK-NEXT:      } else {
+// CHECK-NEXT:        scf.yield %[[V3]]#1 : i1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[Vtrue:.*]] = arith.constant true
+// CHECK-NEXT:      %[[V5:.*]] = arith.xori %[[V4]], %[[Vtrue]] : i1
+// CHECK-NEXT:      %[[V6:.*]] = arith.andi %[[V3]]#1, %[[V5]] : i1
+// CHECK-NEXT:      scf.condition(%[[V6]]) %[[V3]]#0, %[[V3]]#1, %[[V3]]#2 : [[upstreamStateType]], i1, !llvm.struct<(i32)>
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:    ^bb0(%[[arg2:.*]]: [[upstreamStateType]], %arg2: i1, %arg3: !llvm.struct<(i32)>):
+// CHECK-NEXT:      scf.yield %[[arg2]] : [[upstreamStateType]]
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]]#0, %arg0[0 : index] : !llvm.struct<"iterators.filter_state", (struct<"iterators.constant_stream_state", (i32)>)>
+// CHECK-NEXT:    return %[[V2]], %[[V1]]#1, %[[V1]]#2 : !llvm.struct<"iterators.filter_state", (struct<"iterators.constant_stream_state", (i32)>)>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: func.func private @iterators.filter.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
+// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:  }
+
+func.func private @is_positive_struct(%struct : !element_type) -> i1 {
+// CHECK-LABEL: func.func private @is_positive_struct(%{{.*}}: !llvm.struct<(i32)>) -> i1 {
+  %i = llvm.extractvalue %struct[0 : index] : !element_type
+// CHECK-NEXT:    %[[i:.*]] = llvm.extractvalue %[[struct:.*]][0 : index] : !llvm.struct<(i32)>
+  %zero = arith.constant 0 : i32
+// CHECK-NEXT:    %[[zero:.*]] = arith.constant 0 : i32
+  %cmp = arith.cmpi "sgt", %i, %zero : i32
+// CHECK-NEXT:    %[[cmp:.*]] = arith.cmpi sgt, %[[i]], %[[zero]] : i32
+  return %cmp : i1
+// CHECK-NEXT:    return %[[cmp]] : i1
+}
+// CHECK-NEXT:  }
+
+func.func @main() {
+  // CHECK-LABEL: func.func @main()
+  %input = "iterators.constantstream"() { value = [] } : () -> (!iterators.stream<!element_type>)
+  %filter = "iterators.filter"(%input) {predicateRef = @is_positive_struct}
+    : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
+  // CHECK:        %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
+  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0:.*]], %[[V1]][0 : index] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+  return
+  // CHECK-NEXT:   return
+}
+// CHECK-NEXT:   }
+// CHECK-NEXT: }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
@@ -1,0 +1,58 @@
+// RUN: mlir-proto-opt %s -convert-iterators-to-llvm \
+// RUN: | FileCheck --enable-var-scope %s
+
+!element_type = !llvm.struct<(i32)>
+
+// CHECK-LABEL: func.func private @iterators.map.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})> {
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[mapStateName:iterators\.map_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
+// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: func.func private @iterators.map.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>) -> (!llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"iterators.map_state", (struct<"iterators.constant_stream_state", (i32)>)>
+// CHECK-NEXT:    %[[V1:.*]]:3 = call @iterators.constantstream.next.0(%[[V0]]) : (!llvm.struct<"iterators.constant_stream_state", (i32)>) -> (!llvm.struct<"iterators.constant_stream_state", (i32)>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V2:.*]] = scf.if %[[V1]]#1 -> (!llvm.struct<(i32)>) {
+// CHECK-NEXT:      %[[V4:.*]] = func.call @double_struct(%[[V1]]#2) : (!llvm.struct<(i32)>) -> !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[V4]] : !llvm.struct<(i32)>
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      %[[V4]] = llvm.mlir.undef : !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[V4]] : !llvm.struct<(i32)>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    %[[V3:.*]] = llvm.insertvalue %[[V1]]#0, %arg0[0 : index] : !llvm.struct<"iterators.map_state", (struct<"iterators.constant_stream_state", (i32)>)>
+// CHECK-NEXT:    return %[[V3]], %[[V1]]#1, %[[V2]] : !llvm.struct<"iterators.map_state", (struct<"iterators.constant_stream_state", (i32)>)>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: func.func private @iterators.map.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[mapStateName:iterators\.map_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
+// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:  }
+
+func.func private @double_struct(%struct : !element_type) -> !element_type {
+// CHECK-LABEL: func.func private @double_struct(%{{.*}}: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+  %i = llvm.extractvalue %struct[0 : index] : !element_type
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<(i32)>
+  %doubled = arith.addi %i, %i : i32
+// CHECK-NEXT:    %[[V1:.*]] = arith.addi %[[V0]], %[[V0]] : i32
+  %result = llvm.insertvalue %doubled, %struct[0 : index] : !element_type
+// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<(i32)>
+  return %result : !element_type
+// CHECK-NEXT:    return %[[V2]] : !llvm.struct<(i32)>
+}
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: func.func @main() {
+func.func @main() {
+  %input = "iterators.constantstream"()
+      { value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]] }
+      : () -> (!iterators.stream<!element_type>)
+  %reduce = "iterators.map"(%input) {mapFuncRef = @double_struct}
+    : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
+  "iterators.sink"(%reduce) : (!iterators.stream<!element_type>) -> ()
+  // CHECK:        %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[mapStateName:iterators\.map_state.*]]", ([[nestedUpstreamStateType:.*]])>
+  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0:.*]], %[[V1]][0 : index] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+  return
+}

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
@@ -1,0 +1,27 @@
+// RUN: mlir-proto-opt %s \
+// RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-func-to-llvm \
+// RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN: | FileCheck %s
+
+!element_type = !llvm.struct<(i32)>
+
+func.func private @is_positive_struct(%struct : !element_type) -> i1 {
+  %i = llvm.extractvalue %struct[0 : index] : !element_type
+  %zero = arith.constant 0 : i32
+  %cmp = arith.cmpi "sgt", %i, %zero : i32
+  return %cmp : i1
+}
+
+func.func @main() {
+  %input = "iterators.constantstream"()
+    { value = [[0: i32], [1: i32], [-1: i32], [2: i32], [-2: i32]] }
+    : () -> (!iterators.stream<!element_type>)
+  %filter = "iterators.filter"(%input) {predicateRef = @is_positive_struct}
+    : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
+  "iterators.sink"(%filter) : (!iterators.stream<!element_type>) -> ()
+  // CHECK:      (1)
+  // CHECK-NEXT: (2)
+  return
+}

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
@@ -1,0 +1,59 @@
+// RUN: mlir-proto-opt %s \
+// RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-func-to-llvm \
+// RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN: | FileCheck %s
+
+!i32_struct = !llvm.struct<(i32)>
+
+func.func private @double_struct(%struct : !i32_struct) -> !i32_struct {
+  %i = llvm.extractvalue %struct[0 : index] : !i32_struct
+  %doubled = arith.addi %i, %i : i32
+  %result = llvm.insertvalue %doubled, %struct[0 : index] : !i32_struct
+  return %result : !i32_struct
+}
+
+func.func @query1() {
+  %input = "iterators.constantstream"()
+      { value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]] }
+      : () -> (!iterators.stream<!i32_struct>)
+  %reduce = "iterators.map"(%input) {mapFuncRef = @double_struct}
+    : (!iterators.stream<!i32_struct>) -> (!iterators.stream<!i32_struct>)
+  "iterators.sink"(%reduce) : (!iterators.stream<!i32_struct>) -> ()
+  // CHECK:      (0)
+  // CHECK-NEXT: (2)
+  // CHECK-NEXT: (4)
+  // CHECK-NEXT: (6)
+  return
+}
+
+!i32f32_struct = !llvm.struct<(i32, f32)>
+
+func.func private @add_field(%input : !i32_struct) -> !i32f32_struct {
+  %i = llvm.extractvalue %input[0 : index] : !i32_struct
+  %f = arith.sitofp %i : i32 to f32
+  %undef = llvm.mlir.undef : !i32f32_struct
+  %extended =  llvm.insertvalue %i, %undef[0 : index] : !i32f32_struct
+  %result =  llvm.insertvalue %f, %extended[1 : index] : !i32f32_struct
+  return %result : !i32f32_struct
+}
+
+func.func @query2() {
+  %input = "iterators.constantstream"()
+      { value = [[0 : i32], [1 : i32], [2 : i32]] }
+      : () -> (!iterators.stream<!i32_struct>)
+  %mapped = "iterators.map"(%input) {mapFuncRef = @add_field}
+    : (!iterators.stream<!i32_struct>) -> (!iterators.stream<!i32f32_struct>)
+  "iterators.sink"(%mapped) : (!iterators.stream<!i32f32_struct>) -> ()
+  // CHECK:      (0, 0)
+  // CHECK-NEXT: (1, 1)
+  // CHECK-NEXT: (2, 2)
+  return
+}
+
+func.func @main() {
+  call @query1() : () -> ()
+  call @query2() : () -> ()
+  return
+}


### PR DESCRIPTION
This PR implements to new iterators (`map` and `filter`) with an almost identical structure as the existing `reduce` iterator.