### PR TITLE
SQL: update to xdsl v0.5

### DIFF
--- a/.github/workflows/testSQLDialect.yml
+++ b/.github/workflows/testSQLDialect.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.10
+        python-version: "3.10"
 
     - name: Checkout project
       uses: actions/checkout@v2

--- a/.github/workflows/testSQLDialect.yml
+++ b/.github/workflows/testSQLDialect.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: 3.10
 
     - name: Checkout project
       uses: actions/checkout@v2

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -27,7 +27,6 @@ from xdsl.irdl import AttributeDef, OperandDef, ResultDef, RegionDef, SingleBloc
 # not single region terminators.
 
 
-@irdl_attr_definition
 class DataType(ParametrizedAttribute):
   """
   Models an ibis datatype.
@@ -105,7 +104,7 @@ class String(DataType):
   """
   name = "ibis.string"
 
-  nullable = ParameterDef(IntegerAttr)
+  nullable: ParameterDef[IntegerAttr]
 
   @builder
   @staticmethod
@@ -135,7 +134,7 @@ class TableColumn(Operation):
   @builder
   @staticmethod
   def get(table: Region, col_name: str) -> 'TableColumn':
-    return TableColumn.build(
+    return TableColumn.create(
         attributes={"col_name": StringAttr.from_str(col_name)}, regions=[table])
 
 
@@ -171,8 +170,8 @@ class Multiply(Operation):
   @staticmethod
   @builder
   def get(lhs: Region, rhs: Region, output_type: DataType) -> 'Multiply':
-    return Multiply.build(regions=[lhs, rhs],
-                          attributes={"output_type": output_type})
+    return Multiply.create(regions=[lhs, rhs],
+                           attributes={"output_type": output_type})
 
 
 @irdl_op_definition
@@ -221,12 +220,12 @@ class Selection(Operation):
   @builder
   def get(table: Region, predicates: Region, projections: Region,
           names: list[str]) -> 'Selection':
-    return Selection.build(regions=[table, predicates, projections],
-                           attributes={
-                               "names":
-                                   ArrayAttr.from_list(
-                                       [StringAttr.from_str(n) for n in names])
-                           })
+    return Selection.create(regions=[table, predicates, projections],
+                            attributes={
+                                "names":
+                                    ArrayAttr.from_list(
+                                        [StringAttr.from_str(n) for n in names])
+                            })
 
 
 @irdl_op_definition
@@ -262,7 +261,7 @@ class Aggregation(Operation):
   @staticmethod
   @builder
   def get(table: Region, metrics: Region, names: list[str]) -> 'Aggregation':
-    return Aggregation.build(
+    return Aggregation.create(
         regions=[table, metrics],
         attributes={
             "names":
@@ -297,7 +296,7 @@ class Sum(Operation):
   @staticmethod
   @builder
   def get(arg: Region) -> 'Sum':
-    return Sum.build(regions=[arg])
+    return Sum.create(regions=[arg])
 
 
 @irdl_op_definition
@@ -327,7 +326,7 @@ class Equals(Operation):
   @builder
   @staticmethod
   def get(left: Region, right: Region) -> 'Equals':
-    return Equals.build(regions=[left, right])
+    return Equals.create(regions=[left, right])
 
 
 @irdl_op_definition
@@ -357,7 +356,7 @@ class GreaterEqual(Operation):
   @builder
   @staticmethod
   def get(left: Region, right: Region) -> 'GreaterEqual':
-    return GreaterEqual.build(regions=[left, right])
+    return GreaterEqual.create(regions=[left, right])
 
 
 @irdl_op_definition
@@ -387,7 +386,7 @@ class LessThan(Operation):
   @builder
   @staticmethod
   def get(left: Region, right: Region) -> 'LessThan':
-    return LessThan.build(regions=[left, right])
+    return LessThan.create(regions=[left, right])
 
 
 @irdl_op_definition
@@ -417,7 +416,7 @@ class LessEqual(Operation):
   @builder
   @staticmethod
   def get(left: Region, right: Region) -> 'LessEqual':
-    return LessEqual.build(regions=[left, right])
+    return LessEqual.create(regions=[left, right])
 
 
 @irdl_op_definition
@@ -444,7 +443,7 @@ class UnboundTable(Operation):
   @staticmethod
   @builder
   def get(name: str, Schema: Region) -> 'UnboundTable':
-    return UnboundTable.build(
+    return UnboundTable.create(
         attributes={"table_name": StringAttr.from_str(name)}, regions=[Schema])
 
 
@@ -466,9 +465,10 @@ class SchemaElement(Operation):
   elt_name = AttributeDef(StringAttr)
   elt_type = AttributeDef(DataType)
 
+  @builder
   @staticmethod
   def get(name: str, type: DataType):
-    return SchemaElement.build(attributes={
+    return SchemaElement.create(attributes={
         "elt_name": StringAttr.from_str(name),
         "elt_type": type
     })
@@ -495,7 +495,7 @@ class Literal(Operation):
   @builder
   @staticmethod
   def get(val: Attribute, type: DataType) -> 'Literal':
-    return Literal.build(attributes={"val": val, "type": type})
+    return Literal.create(attributes={"val": val, "type": type})
 
 
 @dataclass

--- a/experimental/sql/dialects/iterators.py
+++ b/experimental/sql/dialects/iterators.py
@@ -28,7 +28,7 @@ class Stream(ParametrizedAttribute):
   """
   name = "iterators.stream"
 
-  types = ParameterDef(AnyAttr())
+  types: ParameterDef[Attribute]
 
   @builder
   @staticmethod
@@ -53,7 +53,7 @@ class SampleInputOp(Operation):
   @builder
   @staticmethod
   def get(type: Attribute) -> 'SampleInputOp':
-    return SampleInputOp.build(result_types=[type])
+    return SampleInputOp.create(result_types=[type])
 
 
 @irdl_op_definition
@@ -93,8 +93,8 @@ class ReduceOp(Operation):
   @builder
   @staticmethod
   def get(argument: Operation) -> 'ReduceOp':
-    return ReduceOp.build(
-        operands=[argument],
+    return ReduceOp.create(
+        operands=[argument.result],
         result_types=[
             Stream([
                 TupleType([ArrayAttr.from_list([IntegerType.from_width(32)])])
@@ -114,7 +114,7 @@ class SinkOp(Operation):
   @builder
   @staticmethod
   def get(arguments: Operation) -> 'SinkOp':
-    return SinkOp.build(operands=[arguments])
+    return SinkOp.create(operands=[arguments.result])
 
 
 @dataclass

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -15,7 +15,6 @@ from xdsl.irdl import AttributeDef, OperandDef, ResultDef, RegionDef, SingleBloc
 # can have both operators and expressions in their subtrees.
 
 
-@irdl_attr_definition
 class DataType(ParametrizedAttribute):
   """
   Models a datatype in a relational query.
@@ -93,7 +92,7 @@ class String(DataType):
   """
   name = "rel_alg.string"
 
-  nullable = ParameterDef(IntegerAttr)
+  nullable: ParameterDef[IntegerAttr]
 
   @staticmethod
   @builder
@@ -136,7 +135,7 @@ class Multiply(BinOp):
   @builder
   @staticmethod
   def get(lhs: Region, rhs: Region) -> 'Multiply':
-    return Multiply.build(regions=[lhs, rhs])
+    return Multiply.create(regions=[lhs, rhs])
 
 
 @irdl_op_definition
@@ -158,7 +157,7 @@ class Literal(Expression):
   @builder
   @staticmethod
   def get(val: Attribute, type: DataType) -> 'Literal':
-    return Literal.build(attributes={"val": val, "type": type})
+    return Literal.create(attributes={"val": val, "type": type})
 
 
 @irdl_op_definition
@@ -179,7 +178,7 @@ class Column(Expression):
   @builder
   @staticmethod
   def get(col_name: str) -> 'Column':
-    return Column.build(attributes={"col_name": StringAttr.from_str(col_name)})
+    return Column.create(attributes={"col_name": StringAttr.from_str(col_name)})
 
 
 @irdl_op_definition
@@ -206,7 +205,7 @@ class Compare(Expression):
   @builder
   @staticmethod
   def get(comparator: str, left: Region, right: Region) -> 'Compare':
-    return Compare.build(
+    return Compare.create(
         attributes={"comparator": StringAttr.from_str(comparator)},
         regions=[left, right])
 
@@ -247,7 +246,7 @@ class Aggregate(Operator):
   @builder
   def get(input: Region, col_names: List[str], functions: List[str],
           res_names: List[str]) -> 'Aggregate':
-    return Aggregate.build(
+    return Aggregate.create(
         regions=[input],
         attributes={
             "col_names":
@@ -284,7 +283,7 @@ class Select(Operator):
   @staticmethod
   @builder
   def get(input: Region, predicates: Region) -> 'Select':
-    return Select.build(regions=[input, predicates])
+    return Select.create(regions=[input, predicates])
 
 
 @irdl_op_definition
@@ -312,8 +311,8 @@ class Project(Operator):
   @staticmethod
   @builder
   def get(table: Region, projections: Region, names: ArrayAttr) -> 'Project':
-    return Project.build(regions=[table, projections],
-                         attributes={"names": names})
+    return Project.create(regions=[table, projections],
+                          attributes={"names": names})
 
 
 @irdl_op_definition
@@ -338,8 +337,8 @@ class Table(Operator):
   @staticmethod
   @builder
   def get(name: str, Schema: Region) -> 'Table':
-    return Table.build(attributes={"table_name": StringAttr.from_str(name)},
-                       regions=[Schema])
+    return Table.create(attributes={"table_name": StringAttr.from_str(name)},
+                        regions=[Schema])
 
 
 @irdl_op_definition
@@ -359,8 +358,9 @@ class SchemaElement(Operator):
   elt_type = AttributeDef(DataType)
 
   @staticmethod
+  @builder
   def get(name: str, type: DataType):
-    return SchemaElement.build(attributes={
+    return SchemaElement.create(attributes={
         "elt_name": StringAttr.from_str(name),
         "elt_type": type
     })

--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,7 +1,7 @@
 filecheck==0.0.18
 lit==14.0.0
 pytest==6.2.5
-xdsl==0.5.0
+xdsl==0.5.1
 yapf==0.32.0
 pyright==0.0.13
 frozenlist==1.2.*

--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,7 +1,7 @@
 filecheck==0.0.18
 lit==14.0.0
 pytest==6.2.5
-xdsl==0.4.3
+xdsl==0.5.0
 yapf==0.32.0
 pyright==0.0.13
 frozenlist==1.2.*

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -156,12 +156,12 @@ class ProjectYieldCombiner(RewritePattern):
     yielded_ops = []
     for operation in op.projection.ops:
       if isinstance(operation, RelSSA.Yield):
-        yielded_ops.extend(operation.ops)
+        yielded_ops.extend([o.op for o in operation.ops])
         op.projection.blocks[0].erase_op(operation)
     new_region = rewriter.move_region_contents_to_new_regions(op.projection)
     new_region.blocks[0].add_op(RelSSA.Yield.get(yielded_ops))
     rewriter.replace_matched_op(
-        RelSSA.Project.from_result_type(op.input, op.result.typ, new_region))
+        RelSSA.Project.from_result_type(op.input.op, op.result.typ, new_region))
 
 
 @dataclass
@@ -172,7 +172,7 @@ class SelectYieldCombiner(RewritePattern):
     yielded_ops = []
     for operation in op.predicates.ops:
       if isinstance(operation, RelSSA.Yield):
-        yielded_ops.extend(operation.ops)
+        yielded_ops.extend([o.op for o in operation.ops])
         op.predicates.blocks[0].erase_op(operation)
     new_region = rewriter.move_region_contents_to_new_regions(op.predicates)
     while (len(yielded_ops) > 1):

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -44,7 +44,7 @@ def convert_literal(literal) -> Attribute:
     # np.int64 are parsed as int by ibis
     return IntegerAttr.from_int_and_width(literal, 64)
   if isinstance(literal, Decimal):
-    return StringAttr.from_str(literal)
+    return StringAttr.from_str(str(literal))
   raise Exception(f"literal conversion not yet implemented for {type(literal)}")
 
 

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -77,8 +77,7 @@ def impl_to_iterators(ctx: MLContext, query: ModuleOp):
                                 walk_reverse=False)
   walker.rewrite_module(query)
   # Adding the sink
-  query.body.blocks[0].add_op(
-      it.SinkOp.get(query.body.blocks[0].ops[-1].results[0]))
+  query.body.blocks[0].add_op(it.SinkOp.get(query.body.blocks[0].ops[-1]))
   # Adding the return
   query.body.blocks[0].add_op(Return.get())
   # Wrapping everything into a main function

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -105,7 +105,8 @@ class YieldRewriter(RelSSARewriter):
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelSSA.Yield, rewriter: PatternRewriter):
     # TODO: This is a hack to circumvent the FrozenList. Could this be done cleaner?
-    rewriter.replace_matched_op([RelImpl.Yield.get([o for o in op.operands])])
+    rewriter.replace_matched_op(
+        [RelImpl.Yield.get([o.op for o in op.operands])])
 
 
 #===------------------------------------------------------------------------===#


### PR DESCRIPTION
This PR updates the project to work with xdsl v0.5, which gives on one hand more IDE support and on the other hand the crucial LLVMStructType.

Currently, xdsl v0.5 is not yet released, so the CI currently breaks. 