### PR TITLE
SQL: add map to iterators

### DIFF
--- a/experimental/sql/dialects/iterators.py
+++ b/experimental/sql/dialects/iterators.py
@@ -118,6 +118,34 @@ class FilterOp(Operation):
 
 
 @irdl_op_definition
+class MapOp(Operation):
+  """
+  Reads the elements of its operand stream and maps each of them to a new
+  element, i.e., transforms the input stream elementwise.
+
+  Example:
+  ```mlir
+  %mapped : (!iterators.stream<i32>) = iterators.map(%input : ... ) {"mapFuncRef" = @abs} :
+              (!iterators.stream<i32>)
+  ```
+  """
+  name = "iterators.map"
+
+  input = OperandDef(Stream)
+  mapFuncRef = AttributeDef(FlatSymbolRefAttr)
+
+  result = ResultDef(Stream)
+
+  @builder
+  @staticmethod
+  def get(input: Operation, func: StringAttr,
+          res_type: Attribute) -> 'FilterOp':
+    return MapOp.build(operands=[input],
+                       attributes={"mapFuncRef": FlatSymbolRefAttr([func])},
+                       result_types=[res_type])
+
+
+@irdl_op_definition
 class ConstantStreamOp(Operation):
   """
   Produces a stream of LLVM structs given in the array of arrays attribute
@@ -174,5 +202,6 @@ class Iterators:
     self.ctx.register_op(SampleInputOp)
     self.ctx.register_op(ReduceOp)
     self.ctx.register_op(FilterOp)
+    self.ctx.register_op(MapOp)
     self.ctx.register_op(SinkOp)
     self.ctx.register_op(ConstantStreamOp)

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -269,9 +269,10 @@ def impl_to_iterators(ctx: MLContext, query: ModuleOp):
       it.SinkOp.get(query.body.blocks[0].ops[0].body.blocks[0].ops[-1]))
   # Adding the return
   query.body.blocks[0].ops[0].body.blocks[0].add_op(Return.get())
-  # IndexByNames need to be rewritten first, since otherwise, their respective
-  # operand type does not contain the schema anymore, making it impossible to
-  # lookup the position in their tuple struct.
+  # IndexByNames and Yields need to be rewritten first, since both need access
+  # to the rel_impl schemas to find the right position in the case of
+  # IndexByName or to find the right result type in the case of  Yield
+  # respectively.
   index_walker = PatternRewriteWalker(GreedyRewritePatternApplier(
       [IndexByNameRewriter(), YieldRewriter()]),
                                       walk_regions_first=False,

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -147,7 +147,35 @@ class YieldRewriter(RelImplRewriter):
 
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelImpl.Yield, rewriter: PatternRewriter):
-    rewriter.replace_matched_op(Return.get(*op.ops))
+    if isinstance(op.parent_op(), RelImpl.Select):
+      rewriter.replace_matched_op(Return.get(*op.ops))
+    else:
+      assert (isinstance(op.parent_op(), RelImpl.Project))
+      for i, o in zip(range(len(op.ops)), op.ops):
+        rewriter.insert_op_before_matched_op(
+            LLVMInsertValue.build(
+                operands=[op.parent_block().args[0], o],
+                attributes={
+                    "position":
+                        ArrayAttr.from_list(
+                            [IntegerAttr.from_index_int_value(i)])
+                },
+                result_types=[
+                    self.convert_bag(op.parent_op().results[0].typ).types
+                ]))
+      rewriter.replace_matched_op(Return.get(op.parent_block().args[0]))
+
+
+@dataclass
+class BinOpRewriter(RelImplRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelImpl.BinOp, rewriter: PatternRewriter):
+    if op.operator.data == "+":
+      rewriter.replace_matched_op(Addi.get(op.lhs, op.rhs))
+      return
+    raise Exception(f"BinOp conversion not yet implemented for " +
+                    op.operator.data)
 
 
 #===------------------------------------------------------------------------===#
@@ -204,6 +232,27 @@ class SelectRewriter(RelImplRewriter):
     self.count = self.count + 1
 
 
+@dataclass
+class ProjectRewriter(RelImplRewriter):
+
+  count: int = 0
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelImpl.Project, rewriter: PatternRewriter):
+    rewriter.modify_block_argument_type(
+        op.projection.blocks[0].args[0],
+        self.convert_tuple(op.projection.blocks[0].args[0].typ))
+    new_reg = rewriter.move_region_contents_to_new_regions(op.projection)
+    op.parent_op().parent_region().blocks[0].add_op(
+        FuncOp.from_region("m" + str(self.count),
+                           [new_reg.blocks[0].args[0].typ],
+                           [self.convert_bag(op.result.typ).types], new_reg))
+    rewriter.replace_matched_op(
+        it.MapOp.get(op.input.op, StringAttr.from_str("m" + str(self.count)),
+                     self.convert_bag(op.result.typ)))
+    self.count = self.count + 1
+
+
 #===------------------------------------------------------------------------===#
 # Conversion setup
 #===------------------------------------------------------------------------===#
@@ -223,9 +272,8 @@ def impl_to_iterators(ctx: MLContext, query: ModuleOp):
   # IndexByNames need to be rewritten first, since otherwise, their respective
   # operand type does not contain the schema anymore, making it impossible to
   # lookup the position in their tuple struct.
-  index_walker = PatternRewriteWalker(GreedyRewritePatternApplier([
-      IndexByNameRewriter(),
-  ]),
+  index_walker = PatternRewriteWalker(GreedyRewritePatternApplier(
+      [IndexByNameRewriter(), YieldRewriter()]),
                                       walk_regions_first=False,
                                       apply_recursively=False,
                                       walk_reverse=False)
@@ -236,7 +284,8 @@ def impl_to_iterators(ctx: MLContext, query: ModuleOp):
       SelectRewriter(),
       LiteralRewriter(),
       CompareRewriter(),
-      YieldRewriter()
+      ProjectRewriter(),
+      BinOpRewriter()
   ]),
                                 walk_regions_first=False,
                                 apply_recursively=False,

--- a/experimental/sql/test/impl_to_iterators/map.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map.xdsl
@@ -1,0 +1,25 @@
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):
+    %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) ["col_name" = "c"]
+    %4 : !rel_impl.int32 = rel_impl.bin_op(%3 : !rel_impl.int32, %3 : !rel_impl.int32) ["operator" = "+"]
+    rel_impl.yield(%4 : !rel_impl.int32)
+ }
+}
+
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @m0]
+// CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
+// CHECK-NEXT:     func.return()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func() ["sym_name" = "m0", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
+// CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
+// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:

--- a/experimental/sql/test/iterators_dialect_tests/map.xdsl
+++ b/experimental/sql/test/iterators_dialect_tests/map.xdsl
@@ -1,0 +1,29 @@
+// RUN: rel_opt.py %s | filecheck %s
+
+module() {
+  func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
+    %input : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+    %map : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%input : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @double_struct]
+    func.return()
+  }
+  func.func() ["sym_name" = "double_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
+    ^0(%struct : !llvm.struct<"", [!i32]>):
+      %i : !i32 = llvm.extractvalue(%struct : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+      %doubled : !i32 = arith.addi(%i : !i32, %i : !i32)
+      %result : !llvm.struct<"", [!i32]> = llvm.insertvalue(%struct : !llvm.struct<"", [!i32]>, %i : !i32) ["position" = [0 : !index]]
+      func.return(%result : !llvm.struct<"", [!i32]>)
+  }
+}
+
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @double_struct]
+// CHECK-NEXT:     func.return()
+// CHECK-NEXT:   }
+// CHECK-NEXT:   func.func() ["sym_name" = "double_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
+// CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
+// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:   }

--- a/experimental/sql/test_mlir/conversion_tests/map.xdsl
+++ b/experimental/sql/test_mlir/conversion_tests/map.xdsl
@@ -1,0 +1,30 @@
+// RUN: rel_opt.py -t mlir %s | filecheck %s
+
+module() {
+  func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
+    %input : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+    %map : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%input : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @double_struct]
+    func.return()
+  }
+  func.func() ["sym_name" = "double_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
+    ^0(%struct : !llvm.struct<"", [!i32]>):
+      %i : !i32 = llvm.extractvalue(%struct : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+      %doubled : !i32 = arith.addi(%i :!i32, %i : !i32)
+      %result : !llvm.struct<"", [!i32]> = llvm.insertvalue(%struct : !llvm.struct<"", [!i32]>, %i : !i32) ["position" = [0 : !index]]
+      func.return(%result : !llvm.struct<"", [!i32]>)
+  }
+}
+
+
+//      CHECK: func.func public @main() {
+// CHECK-NEXT:   %{{.*}} = "iterators.constantstream"() {value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]]} : () -> !iterators.stream<!llvm.struct<(i32)>>
+// CHECK-NEXT:   %{{.*}} = "iterators.map"(%{{.*}}) {mapFuncRef = @double_struct} : (!iterators.stream<!llvm.struct<(i32)>>) -> !iterators.stream<!llvm.struct<(i32)>>
+// CHECK-NEXT:   return
+// CHECK-NEXT: }
+// CHECK-NEXT: func.func private @double_struct(%{{.*}}: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+// CHECK-NEXT:   %{{.*}} = llvm.extractvalue %{{.*}}[0 : index] : !llvm.struct<(i32)>
+// CHECK-NEXT:   %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
+// CHECK-NEXT:   %{{.*}} = llvm.insertvalue %{{.*}}, %{{.*}}[0 : index] : !llvm.struct<(i32)>
+// CHECK-NEXT:   return %{{.*}} : !llvm.struct<(i32)>
+// CHECK-NEXT: }
+// CHECK-NEXT:


### PR DESCRIPTION
This PR introduces the `map` operation to the iterators mirror and adds its lowering from a `rel_impl.project`.

This PR and its conversion works with #539.