### PR TITLE
SQL: add yield_value and yield_tuple 

### DIFF
--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -295,8 +295,17 @@ class Compare(Expression):
                           result_types=[Boolean()])
 
 
-@irdl_op_definition
 class Yield(Expression):
+  """
+  Parent class of operations that gridge the gap from expressions back to
+  operators by yielding the result of an expression to the encompassing
+  operator.
+  """
+  ...
+
+
+@irdl_op_definition
+class YieldValue(Expression):
   """
   Bridges the gap from expressions back to operators by yielding the result of
   an expression to the encompassing operator.
@@ -304,17 +313,39 @@ class Yield(Expression):
   Example:
 
   '''
-  rel_impl.yield(%0 : !rel_impl.bool)
+  rel_impl.yield_value(%0 : !rel_impl.bool)
   '''
   """
-  name = "rel_impl.yield"
+  name = "rel_impl.yield_value"
+
+  op = OperandDef(AnyAttr())
+
+  @staticmethod
+  @builder
+  def get(op: Operation) -> 'YieldValue':
+    return YieldValue.create(operands=[op.result])
+
+
+@irdl_op_definition
+class YieldTuple(Expression):
+  """
+  Bridges the gap from expressions back to operators by yielding the result of
+  an expression to the encompassing operator.
+
+  Example:
+
+  '''
+  rel_impl.yield_tuple(%0 : !rel_impl.int32)
+  '''
+  """
+  name = "rel_impl.yield_tuple"
 
   ops = VarOperandDef(AnyAttr())
 
   @staticmethod
   @builder
-  def get(ops: list[Operation]) -> 'Yield':
-    return Yield.create(operands=[o.result for o in ops])
+  def get(ops: list[Operation]) -> 'YieldTuple':
+    return YieldTuple.create(operands=[o.result for o in ops])
 
 
 @irdl_op_definition
@@ -537,6 +568,7 @@ class RelImpl:
     self.ctx.register_op(Literal)
     self.ctx.register_op(Compare)
     self.ctx.register_op(IndexByName)
-    self.ctx.register_op(Yield)
+    self.ctx.register_op(YieldValue)
+    self.ctx.register_op(YieldTuple)
     self.ctx.register_op(And)
     self.ctx.register_op(BinOp)

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -305,7 +305,7 @@ class Yield(Expression):
 
 
 @irdl_op_definition
-class YieldValue(Expression):
+class YieldValue(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
   an expression to the encompassing operator.
@@ -327,7 +327,7 @@ class YieldValue(Expression):
 
 
 @irdl_op_definition
-class YieldTuple(Expression):
+class YieldTuple(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
   an expression to the encompassing operator.

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -308,7 +308,8 @@ class Yield(Expression):
 class YieldValue(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
-  an expression to the encompassing operator.
+  an expression to the encompassing operator. This `yield` is used for
+  operations that want a value as the result of executing the region.
 
   Example:
 
@@ -330,7 +331,10 @@ class YieldValue(Yield):
 class YieldTuple(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
-  an expression to the encompassing operator.
+  an expression to the encompassing operator. This `yield` is used for
+  operations that want new tuples as the result of executing the region. This
+  resulting tuple consists of the variadic operands of the `YieldTuple` in that
+  order.
 
   Example:
 

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -297,7 +297,8 @@ class Yield(Expression):
 class YieldValue(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
-  an expression to the encompassing operator.
+  an expression to the encompassing operator. This `yield` is used for
+  operations that want a value as the result of executing the region.
 
   Example:
 
@@ -319,7 +320,10 @@ class YieldValue(Yield):
 class YieldTuple(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
-  an expression to the encompassing operator.
+  an expression to the encompassing operator. This `yield` is used for
+  operations that want new tuples as the result of executing the region. This
+  resulting tuple consists of the variadic operands of the `YieldTuple` in that
+  order.
 
   Example:
 

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -294,7 +294,7 @@ class Yield(Expression):
 
 
 @irdl_op_definition
-class YieldValue(Expression):
+class YieldValue(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
   an expression to the encompassing operator.
@@ -316,7 +316,7 @@ class YieldValue(Expression):
 
 
 @irdl_op_definition
-class YieldTuple(Expression):
+class YieldTuple(Yield):
   """
   Bridges the gap from expressions back to operators by yielding the result of
   an expression to the encompassing operator.

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -284,8 +284,17 @@ class Compare(Expression):
                           result_types=[Boolean()])
 
 
-@irdl_op_definition
 class Yield(Expression):
+  """
+  Parent class of operations that gridge the gap from expressions back to
+  operators by yielding the result of an expression to the encompassing
+  operator.
+  """
+  ...
+
+
+@irdl_op_definition
+class YieldValue(Expression):
   """
   Bridges the gap from expressions back to operators by yielding the result of
   an expression to the encompassing operator.
@@ -293,17 +302,39 @@ class Yield(Expression):
   Example:
 
   '''
-  rel_ssa.yield(%0 : !rel_ssa.bool)
+  rel_ssa.yield_value(%0 : !rel_impl.bool)
   '''
   """
-  name = "rel_ssa.yield"
+  name = "rel_ssa.yield_value"
+
+  op = OperandDef(AnyAttr())
+
+  @staticmethod
+  @builder
+  def get(op: Operation) -> 'YieldValue':
+    return YieldValue.create(operands=[op.result])
+
+
+@irdl_op_definition
+class YieldTuple(Expression):
+  """
+  Bridges the gap from expressions back to operators by yielding the result of
+  an expression to the encompassing operator.
+
+  Example:
+
+  '''
+  rel_ssa.yield_tuple(%0 : !rel_impl.int32)
+  '''
+  """
+  name = "rel_ssa.yield_tuple"
 
   ops = VarOperandDef(AnyAttr())
 
   @staticmethod
   @builder
-  def get(ops: list[Operation]) -> 'Yield':
-    return Yield.create(operands=[o.result for o in ops])
+  def get(ops: list[Operation]) -> 'YieldTuple':
+    return YieldTuple.create(operands=[o.result for o in ops])
 
 
 @irdl_op_definition
@@ -526,6 +557,7 @@ class RelSSA:
     self.ctx.register_op(Literal)
     self.ctx.register_op(Compare)
     self.ctx.register_op(Column)
-    self.ctx.register_op(Yield)
+    self.ctx.register_op(YieldValue)
+    self.ctx.register_op(YieldTuple)
     self.ctx.register_op(And)
     self.ctx.register_op(BinOp)

--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,7 +1,7 @@
 filecheck==0.0.18
 lit==14.0.0
 pytest==6.2.5
-xdsl==0.5.1
+xdsl==0.5.2
 yapf==0.32.0
 pyright==0.0.13
 frozenlist==1.2.*

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -172,27 +172,32 @@ class CompareRewriter(RelImplRewriter):
 
 
 @dataclass
-class YieldRewriter(RelImplRewriter):
+class YieldValueRewriter(RelImplRewriter):
 
   @op_type_rewrite_pattern
-  def match_and_rewrite(self, op: RelImpl.Yield, rewriter: PatternRewriter):
-    if isinstance(op.parent_op(), RelImpl.Select):
-      rewriter.replace_matched_op(Return.get(*op.ops))
-    else:
-      assert (isinstance(op.parent_op(), RelImpl.Project))
-      for i, o in zip(range(len(op.ops)), op.ops):
-        rewriter.insert_op_before_matched_op(
-            LLVMInsertValue.build(
-                operands=[op.parent_block().args[0], o],
-                attributes={
-                    "position":
-                        ArrayAttr.from_list(
-                            [IntegerAttr.from_index_int_value(i)])
-                },
-                result_types=[
-                    self.convert_bag(op.parent_op().results[0].typ).types
-                ]))
-      rewriter.replace_matched_op(Return.get(op.parent_block().args[0]))
+  def match_and_rewrite(self, op: RelImpl.YieldValue,
+                        rewriter: PatternRewriter):
+    rewriter.replace_matched_op(Return.get(op.op.op))
+
+
+@dataclass
+class YieldTupleRewriter(RelImplRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelImpl.YieldTuple,
+                        rewriter: PatternRewriter):
+    for i, o in zip(range(len(op.ops)), op.ops):
+      rewriter.insert_op_before_matched_op(
+          LLVMInsertValue.build(
+              operands=[op.parent_block().args[0], o],
+              attributes={
+                  "position":
+                      ArrayAttr.from_list([IntegerAttr.from_index_int_value(i)])
+              },
+              result_types=[
+                  self.convert_bag(op.parent_op().results[0].typ).types
+              ]))
+    rewriter.replace_matched_op(Return.get(op.parent_block().args[0]))
 
 
 @dataclass
@@ -305,12 +310,12 @@ def impl_to_iterators(ctx: MLContext, query: ModuleOp):
       it.SinkOp.get(query.body.blocks[0].ops[0].body.blocks[0].ops[-1]))
   # Adding the return
   query.body.blocks[0].ops[0].body.blocks[0].add_op(Return.get())
-  # IndexByNames and Yields need to be rewritten first, since both need access
-  # to the rel_impl schemas to find the right position in the case of
+  # IndexByNames and YieldTuples need to be rewritten first, since both need
+  # access to the rel_impl schemas to find the right position in the case of
   # IndexByName or to find the right result type in the case of  Yield
   # respectively.
   index_walker = PatternRewriteWalker(GreedyRewritePatternApplier(
-      [IndexByNameRewriter(), YieldRewriter()]),
+      [IndexByNameRewriter(), YieldTupleRewriter()]),
                                       walk_regions_first=False,
                                       apply_recursively=False,
                                       walk_reverse=False)
@@ -322,7 +327,8 @@ def impl_to_iterators(ctx: MLContext, query: ModuleOp):
       LiteralRewriter(),
       CompareRewriter(),
       ProjectRewriter(),
-      BinOpRewriter()
+      BinOpRewriter(),
+      YieldValueRewriter()
   ]),
                                 walk_regions_first=False,
                                 apply_recursively=False,

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -198,7 +198,7 @@ class YieldTupleRewriter(RelImplRewriter):
           },
           result_types=[res_type])
       rewriter.insert_op_before_matched_op(new_tuple)
-    rewriter.replace_matched_op(Return.get(op.parent_block().args[0]))
+    rewriter.replace_matched_op(Return.get(new_tuple))
 
 
 @dataclass

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -100,13 +100,22 @@ class BinOpRewriter(RelSSARewriter):
 
 
 @dataclass
-class YieldRewriter(RelSSARewriter):
+class YieldTupleRewriter(RelSSARewriter):
 
   @op_type_rewrite_pattern
-  def match_and_rewrite(self, op: RelSSA.Yield, rewriter: PatternRewriter):
+  def match_and_rewrite(self, op: RelSSA.YieldTuple, rewriter: PatternRewriter):
     # TODO: This is a hack to circumvent the FrozenList. Could this be done cleaner?
     rewriter.replace_matched_op(
-        [RelImpl.Yield.get([o.op for o in op.operands])])
+        [RelImpl.YieldTuple.get([o.op for o in op.operands])])
+
+
+@dataclass
+class YieldValueRewriter(RelSSARewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelSSA.YieldValue, rewriter: PatternRewriter):
+    # TODO: This is a hack to circumvent the FrozenList. Could this be done cleaner?
+    rewriter.replace_matched_op([RelImpl.YieldValue.get(op.op.op)])
 
 
 #===------------------------------------------------------------------------===#
@@ -181,7 +190,8 @@ def ssa_to_impl(ctx: MLContext, query: ModuleOp):
       LiteralRewriter(),
       ColumnRewriter(),
       CompareRewriter(),
-      YieldRewriter(),
+      YieldTupleRewriter(),
+      YieldValueRewriter(),
       ProjectRewriter(),
       AndRewriter(),
       BinOpRewriter()

--- a/experimental/sql/test/alg_to_ssa/multi_cond.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multi_cond.xdsl
@@ -29,5 +29,5 @@ module() {
 // CHECK-NEXT:        %6 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 7 : !i64]
 // CHECK-NEXT:        %7 : !rel_ssa.bool = rel_ssa.compare(%5 : !rel_ssa.int32, %6 : !rel_ssa.int32) ["comparator" = ">"]
 // CHECK-NEXT:        %8 : !rel_ssa.bool = rel_ssa.and(%7 : !rel_ssa.bool, %4 : !rel_ssa.bool)
-// CHECK-NEXT:        rel_ssa.yield(%8 : !rel_ssa.bool)
+// CHECK-NEXT:        rel_ssa.yield_value(%8 : !rel_ssa.bool)
 // CHECK-NEXT:    }

--- a/experimental/sql/test/alg_to_ssa/multiply.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multiply.xdsl
@@ -21,5 +21,5 @@ module() {
 // CHECK-NEXT:    %2 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "c"]
 // CHECK-NEXT:    %4 : !rel_ssa.int64 = rel_ssa.bin_op(%2 : !rel_ssa.int64, %3 : !rel_ssa.int64) ["operator" = "*"]
-// CHECK-NEXT:    rel_ssa.yield(%4 : !rel_ssa.int64)
+// CHECK-NEXT:    rel_ssa.yield_tuple(%4 : !rel_ssa.int64)
 // CHECK-NEXT:  }

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -16,6 +16,6 @@ module() {
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
 // CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"age", !rel_ssa.int32>]>) {
 // CHECK-NEXT:    %2 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
-// CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.int32)
+// CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.int32)
 // CHECK-NEXT:  }
 // CHECK-NEXT:  %3 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]>) ["col_names" = ["im"], "functions" = ["sum"]]

--- a/experimental/sql/test/alg_to_ssa/projection.xdsl
+++ b/experimental/sql/test/alg_to_ssa/projection.xdsl
@@ -17,5 +17,5 @@ module() {
 // CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
 // CHECK-NEXT:    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-// CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+// CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
 // CHECK-NEXT:  }

--- a/experimental/sql/test/alg_to_ssa/selection_op.xdsl
+++ b/experimental/sql/test/alg_to_ssa/selection_op.xdsl
@@ -19,5 +19,5 @@ module() {
 // CHECK-NEXT:        %2 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
 // CHECK-NEXT:        %3 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 5 : !i64]
 // CHECK-NEXT:        %4 : !rel_ssa.bool = rel_ssa.compare(%2 : !rel_ssa.int32, %3 : !rel_ssa.int32) ["comparator" = "="]
-// CHECK-NEXT:        rel_ssa.yield(%4 : !rel_ssa.bool)
+// CHECK-NEXT:        rel_ssa.yield_value(%4 : !rel_ssa.bool)
 // CHECK-NEXT:    }

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -1,4 +1,4 @@
-// RUN: rel_opt.py -p impl-to-iterators %s | FileCheck %s
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
 module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -1,4 +1,4 @@
-// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+// RUN: rel_opt.py -p impl-to-iterators %s | FileCheck %s
 
 module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
@@ -7,7 +7,7 @@ module() {
       %3 : !rel_impl.decimal = rel_impl.literal() ["value" = "0.05" ]
       %4 : !rel_impl.decimal = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal>]>) ["col_name" = "price"]
       %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.decimal, %4 : !rel_impl.decimal) ["comparator" = ">"]
-      rel_impl.yield(%5 : !rel_impl.bool)
+      rel_impl.yield_value(%5 : !rel_impl.bool)
   }
 }
 

--- a/experimental/sql/test/impl_to_iterators/filter.xdsl
+++ b/experimental/sql/test/impl_to_iterators/filter.xdsl
@@ -7,7 +7,7 @@ module() {
       %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 0 : !i32]
       %4 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_name" = "id"]
       %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["comparator" = ">"]
-      rel_impl.yield(%5 : !rel_impl.bool)
+      rel_impl.yield_value(%5 : !rel_impl.bool)
   }
 }
 

--- a/experimental/sql/test/impl_to_iterators/map.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map.xdsl
@@ -20,6 +20,7 @@ module() {
 // CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
 // CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
 // CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
+// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.mlir.undef()
 // CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
 // CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
 // CHECK-NEXT:

--- a/experimental/sql/test/impl_to_iterators/map.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map.xdsl
@@ -6,7 +6,7 @@ module() {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):
     %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) ["col_name" = "c"]
     %4 : !rel_impl.int32 = rel_impl.bin_op(%3 : !rel_impl.int32, %3 : !rel_impl.int32) ["operator" = "+"]
-    rel_impl.yield(%4 : !rel_impl.int32)
+    rel_impl.yield_tuple(%4 : !rel_impl.int32)
  }
 }
 

--- a/experimental/sql/test/impl_to_iterators/map.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map.xdsl
@@ -1,4 +1,4 @@
-// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+// RUN: rel_opt.py -p impl-to-iterators %s | FileCheck %s
 
 module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
@@ -11,7 +11,7 @@ module() {
 }
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = {{.*}}[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
 // CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @m0]
 // CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
 // CHECK-NEXT:     func.return()
@@ -20,7 +20,7 @@ module() {
 // CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
 // CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
 // CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
-// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.mlir.undef()
-// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
-// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
-// CHECK-NEXT:
+// CHECK-NEXT:       %[[V1:[0-9]]] : !llvm.struct<"", [!i32]> = llvm.mlir.undef()
+// CHECK-NEXT:       %[[V2:[0-9]]] : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}}[[V1]] : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:       func.return(%{{.*}}[[V2]] : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:   }

--- a/experimental/sql/test/impl_to_iterators/map_mul.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map_mul.xdsl
@@ -6,7 +6,7 @@ module() {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):
     %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) ["col_name" = "c"]
     %4 : !rel_impl.int32 = rel_impl.bin_op(%3 : !rel_impl.int32, %3 : !rel_impl.int32) ["operator" = "*"]
-    rel_impl.yield(%4 : !rel_impl.int32)
+    rel_impl.yield_tuple(%4 : !rel_impl.int32)
  }
 }
 

--- a/experimental/sql/test/impl_to_iterators/map_sub.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map_sub.xdsl
@@ -6,7 +6,7 @@ module() {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):
     %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) ["col_name" = "c"]
     %4 : !rel_impl.int32 = rel_impl.bin_op(%3 : !rel_impl.int32, %3 : !rel_impl.int32) ["operator" = "-"]
-    rel_impl.yield(%4 : !rel_impl.int32)
+    rel_impl.yield_tuple(%4 : !rel_impl.int32)
  }
 }
 

--- a/experimental/sql/test/impl_to_iterators/timestamp.xdsl
+++ b/experimental/sql/test/impl_to_iterators/timestamp.xdsl
@@ -7,7 +7,7 @@ module() {
       %3 : !rel_impl.timestamp = rel_impl.literal() ["value" = "1994-10-10" ]
       %4 : !rel_impl.timestamp = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]>) ["col_name" = "date"]
       %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.timestamp, %4 : !rel_impl.timestamp) ["comparator" = ">"]
-      rel_impl.yield(%5 : !rel_impl.bool)
+      rel_impl.yield_value(%5 : !rel_impl.bool)
   }
 }
 

--- a/experimental/sql/test/relational_implementation_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/projection.xdsl
@@ -6,7 +6,7 @@ module() {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
     %3 : !rel_impl.string<1 : !i1> = rel_impl.index_by_name( %2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
     %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
-    rel_impl.yield(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
+    rel_impl.yield_tuple(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
  }
 }
 
@@ -15,5 +15,5 @@ module() {
 // CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
 // CHECK-NEXT:    %3 : !rel_impl.string<1 : !i1> = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
 // CHECK-NEXT:    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
-// CHECK-NEXT:    rel_impl.yield(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
+// CHECK-NEXT:    rel_impl.yield_tuple(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
 // CHECK-NEXT: }

--- a/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
@@ -7,7 +7,7 @@ module() {
         %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]
         %4 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_name" = "id"]
         %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["comparator" = "="]
-        rel_impl.yield(%5 : !rel_impl.bool)
+        rel_impl.yield_value(%5 : !rel_impl.bool)
     }
 }
 
@@ -17,5 +17,5 @@ module() {
 // CHECK-NEXT:        %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]
 // CHECK-NEXT:        %4 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_name" = "id"]
 // CHECK-NEXT:        %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["comparator" = "="]
-// CHECK-NEXT:        rel_impl.yield(%5 : !rel_impl.bool)
+// CHECK-NEXT:        rel_impl.yield_value(%5 : !rel_impl.bool)
 // CHECK-NEXT:    }

--- a/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
@@ -5,7 +5,7 @@ module() {
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
  }
 }
 
@@ -13,5 +13,5 @@ module() {
 // CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
 // CHECK-NEXT:    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-// CHECK-NEXT:    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+// CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
 // CHECK-NEXT:  }

--- a/experimental/sql/test/relational_ssa_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/selection_op.xdsl
@@ -6,7 +6,7 @@ module() {
         %2 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 5 : !i32]
         %3 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
         %4 : !rel_ssa.bool = rel_ssa.compare(%2 : !rel_ssa.int32, %3 : !rel_ssa.int32) ["comparator" = "="]
-        rel_ssa.yield(%4 : !rel_ssa.bool)
+        rel_ssa.yield_value(%4 : !rel_ssa.bool)
     }
 }
 
@@ -15,5 +15,5 @@ module() {
 // CHECK-NEXT:        %2 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 5 : !i32]
 // CHECK-NEXT:        %3 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
 // CHECK-NEXT:        %4 : !rel_ssa.bool = rel_ssa.compare(%2 : !rel_ssa.int32, %3 : !rel_ssa.int32) ["comparator" = "="]
-// CHECK-NEXT:        rel_ssa.yield(%4 : !rel_ssa.bool)
+// CHECK-NEXT:        rel_ssa.yield_value(%4 : !rel_ssa.bool)
 // CHECK-NEXT:    }

--- a/experimental/sql/test/ssa_to_impl/multi_cond.xdsl
+++ b/experimental/sql/test/ssa_to_impl/multi_cond.xdsl
@@ -10,7 +10,7 @@ module() {
       %6 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 7 : !i64]
       %7 : !rel_ssa.bool = rel_ssa.compare(%5 : !rel_ssa.int32, %6 : !rel_ssa.int32) ["comparator" = ">"]
       %8 : !rel_ssa.bool = rel_ssa.and(%7 : !rel_ssa.bool, %4 : !rel_ssa.bool)
-      rel_ssa.yield(%8 : !rel_ssa.bool)
+      rel_ssa.yield_value(%8 : !rel_ssa.bool)
   }
 }
 

--- a/experimental/sql/test/ssa_to_impl/multiply.xdsl
+++ b/experimental/sql/test/ssa_to_impl/multiply.xdsl
@@ -6,7 +6,7 @@ module() {
     %2 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "c"]
     %4 : !rel_ssa.int64 = rel_ssa.bin_op(%2 : !rel_ssa.int64, %3 : !rel_ssa.int64) ["operator" = "*"]
-    rel_ssa.yield(%4 : !rel_ssa.int64)
+    rel_ssa.yield_tuple(%4 : !rel_ssa.int64)
   }
 }
 
@@ -16,5 +16,5 @@ module() {
 // CHECK-NEXT:      %3 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
 // CHECK-NEXT:      %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "c"]
 // CHECK-NEXT:      %5 : !rel_impl.int64 = rel_impl.bin_op(%3 : !rel_impl.int64, %4 : !rel_impl.int64) ["operator" = "*"]
-// CHECK-NEXT:      rel_impl.yield(%5 : !rel_impl.int64)
+// CHECK-NEXT:      rel_impl.yield_tuple(%5 : !rel_impl.int64)
 // CHECK-NEXT:  }

--- a/experimental/sql/test/ssa_to_impl/projection.xdsl
+++ b/experimental/sql/test/ssa_to_impl/projection.xdsl
@@ -5,7 +5,7 @@ module() {
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-    rel_ssa.yield(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
  }
 }
 
@@ -14,5 +14,5 @@ module() {
 // CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
 // CHECK-NEXT:    %3 : !rel_impl.string<1 : !i1> = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
 // CHECK-NEXT:    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
-// CHECK-NEXT:    rel_impl.yield(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
+// CHECK-NEXT:    rel_impl.yield_tuple(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
 // CHECK-NEXT: }

--- a/experimental/sql/test/ssa_to_impl/selection_op.xdsl
+++ b/experimental/sql/test/ssa_to_impl/selection_op.xdsl
@@ -6,7 +6,7 @@ module() {
         %2 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 5 : !i32]
         %3 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
         %4 : !rel_ssa.bool = rel_ssa.compare(%2 : !rel_ssa.int32, %3 : !rel_ssa.int32) ["comparator" = "="]
-        rel_ssa.yield(%4 : !rel_ssa.bool)
+        rel_ssa.yield_value(%4 : !rel_ssa.bool)
     }
 }
 
@@ -16,5 +16,5 @@ module() {
 // CHECK-NEXT:        %3 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i32]
 // CHECK-NEXT:        %4 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_name" = "id"]
 // CHECK-NEXT:        %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["comparator" = "="]
-// CHECK-NEXT:        rel_impl.yield(%5 : !rel_impl.bool)
+// CHECK-NEXT:        rel_impl.yield_value(%5 : !rel_impl.bool)
 // CHECK-NEXT:    }

--- a/experimental/sql/test_mlir/FileCheckVariables/map.xdsl
+++ b/experimental/sql/test_mlir/FileCheckVariables/map.xdsl
@@ -1,4 +1,4 @@
-// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+// RUN: rel_opt.py -p impl-to-iterators %s | FileCheck %s
 
 module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
@@ -20,7 +20,7 @@ module() {
 // CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
 // CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
 // CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
-// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.mlir.undef()
-// CHECK-NEXT:       %{{.*}}: !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
-// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:       %[[V1:[0-9]]] : !llvm.struct<"", [!i32]> = llvm.mlir.undef()
+// CHECK-NEXT:       %[[V2:[0-9]]] : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}}[[V1]] : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:       func.return(%{{.*}}[[V2]] : !llvm.struct<"", [!i32]>)
 // CHECK-NEXT:   }


### PR DESCRIPTION
This PR diversifies the semantics of the current yield. It splits it into `yield_value`, to yield values such as booleans for filters, and `yield_tuple` to yield results for maps, e.g.