### PR TITLE
SQL: datatype conversion on the iterators level

### DIFF
--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -37,7 +37,10 @@ class RelImplRewriter(RewritePattern):
     if isinstance(type_, RelImpl.Timestamp):
       return IntegerType.from_width(32)
     if isinstance(type_, RelImpl.String):
-      return LLVMStructType(["", [IntegerType.from_width(8)] * 8])
+      return LLVMStructType([
+          StringAttr.from_str(""),
+          ArrayAttr.from_list([IntegerType.from_width(8)] * 8)
+      ])
     raise Exception(f"type conversion not yet implemented for {type(type_)}")
 
   def convert_bag(self, bag: RelImpl.Bag) -> it.Stream:

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -37,6 +37,8 @@ class RelImplRewriter(RewritePattern):
     if isinstance(type_, RelImpl.Timestamp):
       return IntegerType.from_width(32)
     if isinstance(type_, RelImpl.String):
+      # TODO: This is a shortcut to represent strings in some way. Adjust this
+      # to a) non-fixed length strings or b) dynamically fixed size strings.
       return LLVMStructType([
           StringAttr.from_str(""),
           ArrayAttr.from_list([IntegerType.from_width(8)] * 8)
@@ -198,6 +200,7 @@ class BinOpRewriter(RelImplRewriter):
 
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelImpl.BinOp, rewriter: PatternRewriter):
+    # TODO: Decimals might change precision here. Reflect that somehow.
     if op.operator.data == "+":
       rewriter.replace_matched_op(Addi.get(op.lhs, op.rhs))
       return

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -30,6 +30,10 @@ class RelImplRewriter(RewritePattern):
     if isinstance(type_, RelImpl.Int64):
       # TODO: this is obviously broken, but the backend currently only support i32
       return IntegerType.from_width(32)
+    if isinstance(type_, RelImpl.Decimal):
+      return IntegerType.from_width(32)
+    if isinstance(type_, RelImpl.Timestamp):
+      return IntegerType.from_width(32)
     raise Exception(f"type conversion not yet implemented for {type(type_)}")
 
   def convert_bag(self, bag: RelImpl.Bag) -> it.Stream:

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -36,6 +36,8 @@ class RelImplRewriter(RewritePattern):
       return IntegerType.from_width(32)
     if isinstance(type_, RelImpl.Timestamp):
       return IntegerType.from_width(32)
+    if isinstance(type_, RelImpl.String):
+      return LLVMStructType(["", [IntegerType.from_width(8)] * 8])
     raise Exception(f"type conversion not yet implemented for {type(type_)}")
 
   def convert_bag(self, bag: RelImpl.Bag) -> it.Stream:

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -11,4 +11,4 @@ module() {
   }
 }
 
-// CHECK-NEXT:     %3 : !i32 = arith.constant() ["value" = 5 : !i32]
+// CHECK:     %3 : !i32 = arith.constant() ["value" = 5 : !i32]

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -1,0 +1,14 @@
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal>]>):
+      %3 : !rel_impl.decimal = rel_impl.literal() ["value" = "0.05" ]
+      %4 : !rel_impl.decimal = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal>]>) ["col_name" = "price"]
+      %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.decimal, %4 : !rel_impl.decimal) ["comparator" = ">"]
+      rel_impl.yield(%5 : !rel_impl.bool)
+  }
+}
+
+// CHECK-NEXT:     %3 : !i32 = arith.constant() ["value" = 5 : !i32]

--- a/experimental/sql/test/impl_to_iterators/timestamp.xdsl
+++ b/experimental/sql/test/impl_to_iterators/timestamp.xdsl
@@ -11,4 +11,4 @@ module() {
   }
 }
 
-// CHECK-NEXT:     %3 : !i32 = arith.constant() ["value" = 9048 : !i32]
+// CHECK:     %3 : !i32 = arith.constant() ["value" = 9048 : !i32]

--- a/experimental/sql/test/impl_to_iterators/timestamp.xdsl
+++ b/experimental/sql/test/impl_to_iterators/timestamp.xdsl
@@ -1,0 +1,14 @@
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]>):
+      %3 : !rel_impl.timestamp = rel_impl.literal() ["value" = "1994-10-10" ]
+      %4 : !rel_impl.timestamp = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]>) ["col_name" = "date"]
+      %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.timestamp, %4 : !rel_impl.timestamp) ["comparator" = ">"]
+      rel_impl.yield(%5 : !rel_impl.bool)
+  }
+}
+
+// CHECK-NEXT:     %3 : !i32 = arith.constant() ["value" = 9048 : !i32]


### PR DESCRIPTION
This PR adds the conversion of all `decimal`, `timestamp` and `string` to the conversion to iterators. It also adds lowering for decimal and timestamp literals.