### PR TITLE
SQL: add mul and sub to rel_impl conversion

### DIFF
--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -8,7 +8,7 @@ from typing import List, Type, Optional
 from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr, IntegerType, TupleType
 from xdsl.dialects.llvm import LLVMStructType, LLVMExtractValue, LLVMInsertValue
 from xdsl.dialects.func import FuncOp, Return
-from xdsl.dialects.arith import Addi, Constant, Cmpi
+from xdsl.dialects.arith import Addi, Constant, Cmpi, Muli, Subi
 
 from xdsl.pattern_rewriter import RewritePattern, GreedyRewritePatternApplier, PatternRewriteWalker, PatternRewriter, op_type_rewrite_pattern
 
@@ -173,6 +173,12 @@ class BinOpRewriter(RelImplRewriter):
   def match_and_rewrite(self, op: RelImpl.BinOp, rewriter: PatternRewriter):
     if op.operator.data == "+":
       rewriter.replace_matched_op(Addi.get(op.lhs, op.rhs))
+      return
+    if op.operator.data == "*":
+      rewriter.replace_matched_op(Muli.get(op.lhs, op.rhs))
+      return
+    if op.operator.data == "-":
+      rewriter.replace_matched_op(Subi.get(op.lhs, op.rhs))
       return
     raise Exception(f"BinOp conversion not yet implemented for " +
                     op.operator.data)

--- a/experimental/sql/test/impl_to_iterators/map_mul.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map_mul.xdsl
@@ -1,0 +1,13 @@
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):
+    %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) ["col_name" = "c"]
+    %4 : !rel_impl.int32 = rel_impl.bin_op(%3 : !rel_impl.int32, %3 : !rel_impl.int32) ["operator" = "*"]
+    rel_impl.yield(%4 : !rel_impl.int32)
+ }
+}
+
+// CHECK:       %{{.*}} : !i32 = arith.muli(%{{.*}} : !i32, %{{.*}} : !i32)

--- a/experimental/sql/test/impl_to_iterators/map_sub.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map_sub.xdsl
@@ -1,0 +1,13 @@
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):
+    %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) ["col_name" = "c"]
+    %4 : !rel_impl.int32 = rel_impl.bin_op(%3 : !rel_impl.int32, %3 : !rel_impl.int32) ["operator" = "-"]
+    rel_impl.yield(%4 : !rel_impl.int32)
+ }
+}
+
+// CHECK:       %{{.*}} : !i32 = arith.subi(%{{.*}} : !i32, %{{.*}} : !i32)


### PR DESCRIPTION
This PR adds mul and sub to the conversion from rel_impl to iterators, since Q6 needs mul.