### PR TITLE
SQL: add and to iterators, fix int64 lowering

### DIFF
--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -119,7 +119,6 @@ class LiteralRewriter(RelImplRewriter):
       rewriter.replace_matched_op(
           Constant.from_int_constant(op.value.value, op.value.typ))
     elif isinstance(op.result.typ, RelImpl.Decimal):
-      print(op.value.data)
       rewriter.replace_matched_op(
           Constant.from_int_constant(int(Decimal(op.value.data) * Decimal(100)),
                                      32))

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -8,7 +8,7 @@ from typing import List, Type, Optional
 from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr, IntegerType, TupleType
 from xdsl.dialects.llvm import LLVMStructType, LLVMExtractValue, LLVMInsertValue, LLVMMLIRUndef
 from xdsl.dialects.func import FuncOp, Return
-from xdsl.dialects.arith import Addi, Constant, Cmpi, Muli, Subi
+from xdsl.dialects.arith import Addi, Constant, Cmpi, Muli, Subi, AndI
 
 from xdsl.pattern_rewriter import RewritePattern, GreedyRewritePatternApplier, PatternRewriteWalker, PatternRewriter, op_type_rewrite_pattern
 
@@ -27,11 +27,12 @@ from numpy import datetime64, timedelta64
 class RelImplRewriter(RewritePattern):
 
   def convert_datatype(self, type_: RelImpl.DataType) -> Attribute:
+    if isinstance(type_, RelImpl.Boolean):
+      return IntegerType.from_width(1)
     if isinstance(type_, RelImpl.Int32):
       return IntegerType.from_width(32)
     if isinstance(type_, RelImpl.Int64):
-      # TODO: this is obviously broken, but the backend currently only support i32
-      return IntegerType.from_width(32)
+      return IntegerType.from_width(64)
     if isinstance(type_, RelImpl.Decimal):
       return IntegerType.from_width(32)
     if isinstance(type_, RelImpl.Timestamp):
@@ -101,6 +102,14 @@ class RelImplRewriter(RewritePattern):
 
 
 @dataclass
+class AndRewriter(RelImplRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelImpl.And, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(AndI.get(op.lhs, op.rhs))
+
+
+@dataclass
 class LiteralRewriter(RelImplRewriter):
 
   @op_type_rewrite_pattern
@@ -149,7 +158,7 @@ class IndexByNameRewriter(RelImplRewriter):
 class CompareRewriter(RelImplRewriter):
 
   def convert_comparator(self, comparator: str) -> int:
-    if comparator == "==":
+    if comparator == "=":
       return 0
     elif comparator == "!=":
       return 1
@@ -329,7 +338,8 @@ def impl_to_iterators(ctx: MLContext, query: ModuleOp):
       CompareRewriter(),
       ProjectRewriter(),
       BinOpRewriter(),
-      YieldValueRewriter()
+      YieldValueRewriter(),
+      AndRewriter()
   ]),
                                 walk_regions_first=False,
                                 apply_recursively=False,

--- a/experimental/sql/test/impl_to_iterators/filter_and.xdsl
+++ b/experimental/sql/test/impl_to_iterators/filter_and.xdsl
@@ -1,0 +1,18 @@
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>) {
+  ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>):
+    %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>) ["col_name" = "id"]
+    %4 : !rel_impl.int32 = rel_impl.literal() ["value" = 5 : !i64]
+    %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["comparator" = "="]
+    %6 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>) ["col_name" = "b"]
+    %7 : !rel_impl.int32 = rel_impl.literal() ["value" = 7 : !i64]
+    %8 : !rel_impl.bool = rel_impl.compare(%6 : !rel_impl.int32, %7 : !rel_impl.int32) ["comparator" = ">"]
+    %9 : !rel_impl.bool = rel_impl.and(%8 : !rel_impl.bool, %5 : !rel_impl.bool)
+    rel_impl.yield_value(%9 : !rel_impl.bool)
+  }
+}
+
+// CHECK: %{{.*}} : !i1 = arith.andi(%{{.*}} : !i1, %{{.*}} : !i1)


### PR DESCRIPTION
This PR adds the lowering of and to the conversion from rel_impl to iterators and fixes the lowering of int64.