### PR TITLE
SQL: fix aggregation result name bug in ssa to impl

### DIFF
--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -535,8 +535,8 @@ class Aggregate(Operator):
 
   @builder
   @staticmethod
-  def get(input: Operation, col_names: List[str],
-          functions: List[str]) -> 'Aggregate':
+  def get(input: Operation, col_names: List[str], functions: List[str],
+          res_names: List[str]) -> 'Aggregate':
     return Aggregate.create(
         operands=[input.result],
         attributes={
@@ -546,7 +546,7 @@ class Aggregate(Operator):
             "functions":
                 ArrayAttr.from_list([StringAttr.from_str(f) for f in functions])
         },
-        result_types=[Bag.get([Int32()] * len(functions), col_names)])
+        result_types=[Bag.get([Int32()] * len(functions), res_names)])
 
 
 @dataclass

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -172,8 +172,10 @@ class AggregateRewriter(RelSSARewriter):
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelSSA.Aggregate, rewriter: PatternRewriter):
     rewriter.replace_matched_op(
-        RelImpl.Aggregate.get(op.input.op, [c.data for c in op.col_names.data],
-                              [f.data for f in op.functions.data]))
+        RelImpl.Aggregate.get(
+            op.input.op, [c.data for c in op.col_names.data],
+            [f.data for f in op.functions.data],
+            [s.elt_name.data for s in op.result.typ.schema.data]))
 
 
 #===------------------------------------------------------------------------===#

--- a/experimental/sql/test/ssa_to_impl/sum.xdsl
+++ b/experimental/sql/test/ssa_to_impl/sum.xdsl
@@ -2,8 +2,8 @@
 
 module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
-    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
 }
 
 //      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
-// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"idsum", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]


### PR DESCRIPTION
This PR fixes a bug in ssa_to_impl, where the result name would always be the same as the input name, even with other names specified for the result.