### PR TITLE
SQL: fix bug in project result type

### DIFF
--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -141,6 +141,7 @@ class BinOpRewriter(RelAlgRewriter):
 @dataclass
 class ProjectRewriter(RelAlgRewriter):
 
+  # TODO: This could be implemented in a more natural way using Analysis Passes in MLIR.
   def find_type_of_expression(self, op: RelAlg.Expression,
                               input_bag: RelSSA.Bag) -> RelSSA.DataType:
     if isinstance(op, RelAlg.Column):

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -141,6 +141,16 @@ class BinOpRewriter(RelAlgRewriter):
 @dataclass
 class ProjectRewriter(RelAlgRewriter):
 
+  def find_type_of_expression(self, op: RelAlg.Expression,
+                              input_bag: RelSSA.Bag) -> RelSSA.DataType:
+    if isinstance(op, RelAlg.Column):
+      return input_bag.lookup_type_in_schema(op.col_name.data)
+    if isinstance(op, RelAlg.Literal):
+      return op.type
+    if isinstance(op, RelAlg.BinOp):
+      return self.find_type_of_expression(op.lhs.op, input_bag)
+    raise Exception(f"expression conversion not yet implemented for {type(op)}")
+
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelAlg.Project, rewriter: PatternRewriter):
     rewriter.inline_block_before_matched_op(op.input)
@@ -149,8 +159,7 @@ class ProjectRewriter(RelAlgRewriter):
         RelSSA.Project.get(
             rewriter.added_operations_before[-1],
             [n.data for n in op.names.data], [
-                input_bag.lookup_type_in_schema(op.col_name.data) if isinstance(
-                    op, RelAlg.Column) else RelSSA.Int64()
+                self.find_type_of_expression(op, input_bag)
                 for op in op.projections.ops
             ], rewriter.move_region_contents_to_new_regions(op.projections)))
     rewriter.erase_matched_op()

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -148,6 +148,7 @@ class ProjectRewriter(RelAlgRewriter):
     if isinstance(op, RelAlg.Literal):
       return op.type
     if isinstance(op, RelAlg.BinOp):
+      # This uses the assumption that the lhs and rhs have the same type.
       return self.find_type_of_expression(op.lhs.op, input_bag)
     raise Exception(f"expression conversion not yet implemented for {type(op)}")
 

--- a/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
+++ b/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
@@ -1,0 +1,20 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+  rel_alg.project() ["names" = ["bc"]] {
+    rel_alg.table() ["table_name" = "t"] {
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.decimal]
+      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.decimal]
+    }
+  } {
+    rel_alg.multiply() {
+      rel_alg.column() ["col_name" = "b"]
+    } {
+      rel_alg.column() ["col_name" = "c"]
+    }
+  }
+}
+
+// CHECK:  %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.decimal>]>
+// CHECK:    rel_ssa.yield(%4 : !rel_ssa.decimal)

--- a/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
+++ b/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
@@ -4,8 +4,8 @@ module() {
   rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
-      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.decimal]
-      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.decimal]
+      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
+      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
     }
   } {
     rel_alg.multiply() {
@@ -16,5 +16,5 @@ module() {
   }
 }
 
-// CHECK:  %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.decimal>]>
-// CHECK:    rel_ssa.yield(%4 : !rel_ssa.decimal)
+// CHECK:  %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.decimal<4 : !i32, 2 : !i32>>]>
+// CHECK:    rel_ssa.yield_tuple(%{{.*}} : !rel_ssa.decimal<4 : !i32, 2 : !i32>)


### PR DESCRIPTION
This PR fixes a nasty problem. So, the rewrite of expression needs the parent operation to be rewritten already, s.t. it knows what types the column operations have. However, the Project operation only knows its result type by introspecting its region, where, well there are no types, since this is still in rel_alg during this stage. This fix crawls over all expression nodes in rel_alg to discover the types if the result columns.