### PR TITLE
SQL: parametrize decimals

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -45,6 +45,9 @@ class Decimal(DataType):
   """
   name = "ibis.decimal"
 
+  prec: ParameterDef[IntegerAttr]
+  scale: ParameterDef[IntegerAttr]
+
 
 @irdl_attr_definition
 class Timestamp(DataType):

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -43,7 +43,7 @@ class Decimal(DataType):
 
   https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L344
   """
-  name = "ibis.decimal"
+  name = "ibis.decimal<4 : !i32, 2 : !i32>"
 
   prec: ParameterDef[IntegerAttr]
   scale: ParameterDef[IntegerAttr]

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -43,7 +43,7 @@ class Decimal(DataType):
 
   https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L344
   """
-  name = "ibis.decimal<4 : !i32, 2 : !i32>"
+  name = "ibis.decimal"
 
   prec: ParameterDef[IntegerAttr]
   scale: ParameterDef[IntegerAttr]

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -39,15 +39,19 @@ class Int32(DataType):
 @irdl_attr_definition
 class Decimal(DataType):
   """
-  Models a decimal type in a relational query.
+  Models a decimal type in a relational query with precision `prec` and scale
+  `scale`.
 
   Example:
 
   ```
-  !rel_alg.decimal
+  !rel_alg.decimal<4 : !i32, 2 : !i32>
   ```
   """
   name = "rel_alg.decimal"
+
+  prec: ParameterDef[IntegerAttr]
+  scale: ParameterDef[IntegerAttr]
 
 
 @irdl_attr_definition

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -59,15 +59,18 @@ class Int64(DataType):
 @irdl_attr_definition
 class Decimal(DataType):
   """
-  Models a decimal type in a relational implementation query.
+  Models a decimal type in a relational implementation query with precision `prec` and scale `scale`.
 
   Example:
 
   ```
-  !rel_impl.decimal
+  !rel_impl.decimal<4 : !i32, 2 : !i32>
   ```
   """
   name = "rel_impl.decimal"
+
+  prec: ParameterDef[IntegerAttr]
+  scale: ParameterDef[IntegerAttr]
 
 
 @irdl_attr_definition

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -57,15 +57,18 @@ class Int64(DataType):
 @irdl_attr_definition
 class Decimal(DataType):
   """
-  Models a decimal type in a relational SSA query.
+  Models a decimal type in a relational SSA query with precision `prec` and scale `scale`.
 
   Example:
 
   ```
-  !rel_ssa.decimal
+  !rel_ssa.decimal<4 : !i32, 2 : !i32>
   ```
   """
   name = "rel_ssa.decimal"
+
+  prec: ParameterDef[IntegerAttr]
+  scale: ParameterDef[IntegerAttr]
 
 
 @irdl_attr_definition

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -34,7 +34,12 @@ class RelAlgRewriter(RewritePattern):
     if isinstance(type_, RelAlg.Int64):
       return RelSSA.Int64()
     if isinstance(type_, RelAlg.Decimal):
-      return RelSSA.Decimal()
+      return RelSSA.Decimal([
+          IntegerAttr.from_int_and_width(type_.prec.value.data,
+                                         type_.prec.typ.width.data),
+          IntegerAttr.from_int_and_width(type_.scale.value.data,
+                                         type_.scale.typ.width.data)
+      ])
     if isinstance(type_, RelAlg.Timestamp):
       return RelSSA.Timestamp()
     raise Exception(

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -128,6 +128,7 @@ class BinOpRewriter(RelAlgRewriter):
     rewriter.inline_block_before_matched_op(op.rhs.blocks[0])
     right = rewriter.added_operations_before[-1]
 
+    # TODO: Make Decimals change their prec and scale on certain operations.
     new_op = RelSSA.BinOp.get(left, right, self.convert_bin_op_to_str(op))
     rewriter.replace_matched_op([new_op, RelSSA.YieldTuple.get([new_op])])
 

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -31,7 +31,10 @@ def convert_datatype(type_: ibis.expr.datatypes) -> id.DataType:
   if isinstance(type_, ibis.expr.datatypes.Int64):
     return id.Int64()
   if isinstance(type_, ibis.expr.datatypes.Decimal):
-    return id.Decimal()
+    return id.Decimal([
+        IntegerAttr.from_int_and_width(type_.precision, 32),
+        IntegerAttr.from_int_and_width(type_.scale, 32)
+    ])
   if isinstance(type_, ibis.expr.datatypes.Timestamp):
     return id.Timestamp()
   raise KeyError(f"Unknown datatype: {type(type_)}")

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -32,7 +32,12 @@ class IbisRewriter(RewritePattern):
     if isinstance(type_, ibis.Timestamp):
       return RelAlg.Timestamp()
     if isinstance(type_, ibis.Decimal):
-      return RelAlg.Decimal()
+      return RelAlg.Decimal([
+          IntegerAttr.from_int_and_width(type_.prec.value.data,
+                                         type_.prec.typ.width.data),
+          IntegerAttr.from_int_and_width(type_.scale.value.data,
+                                         type_.scale.typ.width.data)
+      ])
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -29,7 +29,12 @@ class RelSSARewriter(RewritePattern):
     if isinstance(type_, RelSSA.Int64):
       return RelImpl.Int64()
     if isinstance(type_, RelSSA.Decimal):
-      return RelImpl.Decimal()
+      return RelImpl.Decimal([
+          IntegerAttr.from_int_and_width(type_.prec.value.data,
+                                         type_.prec.typ.width.data),
+          IntegerAttr.from_int_and_width(type_.scale.value.data,
+                                         type_.scale.typ.width.data)
+      ])
     if isinstance(type_, RelSSA.Timestamp):
       return RelImpl.Timestamp()
     raise Exception(

--- a/experimental/sql/test/alg_to_ssa/datatypes.xdsl
+++ b/experimental/sql/test/alg_to_ssa/datatypes.xdsl
@@ -3,10 +3,10 @@
 module() {
     rel_alg.table() ["table_name" = "some_name"] {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
-        rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal]
+        rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
         rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
         rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
     }
 }
 
-// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]

--- a/experimental/sql/test/frontend/dataTypes.ibis
+++ b/experimental/sql/test/frontend/dataTypes.ibis
@@ -1,12 +1,12 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
-ibis.table([("ORDERKEY", "int64"), ("EXTENDEDPRICE", "decimal"),
+ibis.table([("ORDERKEY", "int64"), ("EXTENDEDPRICE", "decimal(4, 2)"),
                 ("RETURNFLAG", "string"), ("SHIPDATE", "timestamp")],
                 'lineitem')
 
 #      CHECK:  ibis.unbound_table() ["table_name" = "lineitem"] {
 # CHECK-NEXT:    ibis.schema_element() ["elt_name" = "ORDERKEY", "elt_type" = !ibis.int64]
-# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "EXTENDEDPRICE", "elt_type" = !ibis.decimal]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "EXTENDEDPRICE", "elt_type" = !ibis.decimal<4 : !i32, 2 : !i32>]
 # CHECK-NEXT:    ibis.schema_element() ["elt_name" = "RETURNFLAG", "elt_type" = !ibis.string<1 : !i1>]
 # CHECK-NEXT:    ibis.schema_element() ["elt_name" = "SHIPDATE", "elt_type" = !ibis.timestamp]
 # CHECK-NEXT:  }

--- a/experimental/sql/test/frontend/decimal_literal.ibis
+++ b/experimental/sql/test/frontend/decimal_literal.ibis
@@ -1,9 +1,9 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
-table = ibis.table([("EXTENDEDPRICE", "decimal")],
+table = ibis.table([("EXTENDEDPRICE", "decimal(4, 2)")],
                 'lineitem')
 
-table.filter(table['EXTENDEDPRICE'] >= ibis.literal(decimal.Decimal("0.05"), "decimal(6, 2)"))
+table.filter(table['EXTENDEDPRICE'] >= ibis.literal(decimal.Decimal("0.05"), "decimal(4, 2)"))
 
 
-# CHECK: ibis.literal() ["val" = "0.05", "type" = !ibis.decimal]
+# CHECK: ibis.literal() ["val" = "0.05", "type" = !ibis.decimal<4 : !i32, 2 : !i32>]

--- a/experimental/sql/test/ibis_to_alg/datatypes.xdsl
+++ b/experimental/sql/test/ibis_to_alg/datatypes.xdsl
@@ -3,7 +3,7 @@
 module() {
     ibis.unbound_table() ["table_name" = "some_name"] {
         ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int32]
-        ibis.schema_element() ["elt_name" = "price", "elt_type" = !ibis.decimal]
+        ibis.schema_element() ["elt_name" = "price", "elt_type" = !ibis.decimal<4 : !i32, 2 : !i32>]
         ibis.schema_element() ["elt_name" = "time", "elt_type" = !ibis.timestamp]
         ibis.schema_element() ["elt_name" = "name", "elt_type" = !ibis.string<1 : !i1>]
     }
@@ -11,7 +11,7 @@ module() {
 
 //      CHECK: rel_alg.table() ["table_name" = "some_name"] {
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
-// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
 // CHECK-Next: }

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -1,12 +1,12 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
 module() {
-  %0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
-  %1 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal>]>) {
-    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal>]>):
-      %3 : !rel_impl.decimal = rel_impl.literal() ["value" = "0.05" ]
-      %4 : !rel_impl.decimal = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal>]>) ["col_name" = "price"]
-      %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.decimal, %4 : !rel_impl.decimal) ["comparator" = ">"]
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]>):
+      %3 : !rel_impl.decimal<4 : !i32, 2 : !i32> = rel_impl.literal() ["value" = "0.05" ]
+      %4 : !rel_impl.decimal<4 : !i32, 2 : !i32> = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]>) ["col_name" = "price"]
+      %5 : !rel_impl.bool = rel_impl.compare(%3 : !rel_impl.decimal<4 : !i32, 2 : !i32>, %4 : !rel_impl.decimal<4 : !i32, 2 : !i32>) ["comparator" = ">"]
       rel_impl.yield_value(%5 : !rel_impl.bool)
   }
 }

--- a/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
@@ -3,7 +3,7 @@
 module() {
     rel_alg.table() ["table_name" = "some_name"] {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
-        rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal]
+        rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
         rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
         rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
     }
@@ -11,7 +11,7 @@ module() {
 
 //      CHECK: rel_alg.table() ["table_name" = "some_name"] {
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
-// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
 // CHECK-Next: }

--- a/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 }
 
-// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/relational_ssa_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/datatypes.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 
-// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]

--- a/experimental/sql/test/ssa_to_impl/datatypes.xdsl
+++ b/experimental/sql/test/ssa_to_impl/datatypes.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
 module() {
-    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 
-// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]


### PR DESCRIPTION
This PR adds the parametrization of decimals as requested in #546. Currently, there is no change in parameters when operations are performed. I decided to leave this out since, there isn't something like this done for other datatypes aswell. Consider int32. Adding two int32s should give an int33, but MLIR restricts results of addi to be the same as the input type ([here](https://mlir.llvm.org/docs/Dialects/ArithmeticOps/#arithaddi-mlirarithaddiop)).

I am still thinking about how to do this nicely, as I feel like I am in a weird mix of "the top-level should know" vs "aren't these implementation details?". I will probably push a version of something later to this PR.