### PR TITLE
SQL: nullable handling

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -37,6 +37,16 @@ class DataType(ParametrizedAttribute):
 
 
 @irdl_attr_definition
+class Nullable(DataType):
+  """
+  Models the fact that an ibis datatype is nullable.
+  """
+  name = "ibis.nullable"
+
+  datatype: ParameterDef[DataType]
+
+
+@irdl_attr_definition
 class Decimal(DataType):
   """
   Models the ibis decimal type.
@@ -102,17 +112,10 @@ class String(DataType):
   Example:
 
   ```
-  !ibis.string<0 : !i1>
+  !ibis.string
   ```
   """
   name = "ibis.string"
-
-  nullable: ParameterDef[IntegerAttr]
-
-  @builder
-  @staticmethod
-  def get(val: int) -> 'String':
-    return String([IntegerAttr.from_int_and_width(val, 1)])
 
 
 @irdl_op_definition
@@ -512,6 +515,7 @@ class Ibis:
     self.ctx.register_attr(Int64)
     self.ctx.register_attr(Decimal)
     self.ctx.register_attr(Timestamp)
+    self.ctx.register_attr(Nullable)
 
     self.ctx.register_op(UnboundTable)
     self.ctx.register_op(SchemaElement)

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -91,19 +91,25 @@ class String(DataType):
   Example:
 
   ```
-  !rel_alg.string<0: !i1>
+  !rel_alg.string
   ```
   """
   name = "rel_alg.string"
 
-  nullable: ParameterDef[IntegerAttr]
 
-  @staticmethod
-  @builder
-  def get(val: Union[int, IntegerAttr]) -> 'String':
-    if isinstance(val, IntegerAttr):
-      return String([val])
-    return String([IntegerAttr.from_int_and_width(val, 1)])
+@irdl_attr_definition
+class Nullable(DataType):
+  """
+  Models a type that is nullable.
+
+  Example:
+  ```
+  !rel_alg.nullable<!rel_alg.string>
+  ```
+  """
+  name = "rel_alg.nullable"
+
+  type: ParameterDef[DataType]
 
 
 class Expression(Operation):
@@ -381,6 +387,7 @@ class RelationalAlg:
     self.ctx.register_attr(Timestamp)
     self.ctx.register_attr(Decimal)
     self.ctx.register_attr(Int64)
+    self.ctx.register_attr(Nullable)
 
     self.ctx.register_op(Table)
     self.ctx.register_op(SchemaElement)

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -96,20 +96,25 @@ class String(DataType):
   Example:
 
   ```
-  !rel_impl.string<0: !i1>
+  !rel_impl.string
   ```
   """
   name = "rel_impl.string"
 
-  # TODO: redefine nullable as a property of all fields
-  nullable: ParameterDef[IntegerAttr]
 
-  @staticmethod
-  @builder
-  def get(val: Union[int, IntegerAttr]) -> 'String':
-    if isinstance(val, IntegerAttr):
-      return String([val])
-    return String([IntegerAttr.from_int_and_width(val, 1)])
+@irdl_attr_definition
+class Nullable(DataType):
+  """
+  Models a type that is nullable.
+
+  Example:
+  ```
+  !rel_impl.nullable<!rel_impl.string>
+  ```
+  """
+  name = "rel_impl.nullable"
+
+  type: ParameterDef[DataType]
 
 
 #===------------------------------------------------------------------------===#
@@ -561,6 +566,7 @@ class RelImpl:
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(Int32)
     self.ctx.register_attr(Int64)
+    self.ctx.register_attr(Nullable)
     self.ctx.register_attr(Decimal)
     self.ctx.register_attr(Timestamp)
     self.ctx.register_attr(String)

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -94,23 +94,25 @@ class String(DataType):
   Example:
 
   ```
-  !rel_ssa.string<0: !i1>
+  !rel_ssa.string
   ```
   """
   name = "rel_ssa.string"
 
-  # TODO: redefine nullable as a property of all fields
-  nullable: ParameterDef[IntegerAttr]
 
-  @staticmethod
-  @builder
-  def from_int(is_nullable: int) -> 'String':
-    return String([IntegerAttr.from_int_and_width(is_nullable, 1)])
+@irdl_attr_definition
+class Nullable(DataType):
+  """
+  Models a type that is nullable.
 
-  @staticmethod
-  @builder
-  def from_attr(is_nullable: IntegerAttr) -> 'String':
-    return String([is_nullable])
+  Example:
+  ```
+  !rel_ssa.nullable<!rel_ssa.string>
+  ```
+  """
+  name = "rel_ssa.nullable"
+
+  type: ParameterDef[DataType]
 
 
 #===------------------------------------------------------------------------===#
@@ -550,6 +552,7 @@ class RelSSA:
     self.ctx.register_attr(DataType)
     self.ctx.register_attr(Int32)
     self.ctx.register_attr(Int64)
+    self.ctx.register_attr(Nullable)
     self.ctx.register_attr(Timestamp)
     self.ctx.register_attr(Decimal)
     self.ctx.register_attr(String)

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -28,7 +28,7 @@ class RelAlgRewriter(RewritePattern):
 
   def convert_datatype(self, type_: RelAlg.DataType) -> RelSSA.DataType:
     if isinstance(type_, RelAlg.String):
-      return RelSSA.String.from_attr(type_.nullable)
+      return RelSSA.String()
     if isinstance(type_, RelAlg.Int32):
       return RelSSA.Int32()
     if isinstance(type_, RelAlg.Int64):
@@ -42,6 +42,8 @@ class RelAlgRewriter(RewritePattern):
       ])
     if isinstance(type_, RelAlg.Timestamp):
       return RelSSA.Timestamp()
+    if isinstance(type_, RelAlg.Nullable):
+      return RelSSA.Nullable([self.convert_datatype(type_.type)])
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -24,20 +24,24 @@ import dialects.ibis_dialect as id
 
 
 def convert_datatype(type_: ibis.expr.datatypes) -> id.DataType:
+  ret_type = None
   if isinstance(type_, ibis.expr.datatypes.String):
-    return id.String.get(1 if type_.nullable else 0)
-  if isinstance(type_, ibis.expr.datatypes.Int32):
-    return id.Int32()
-  if isinstance(type_, ibis.expr.datatypes.Int64):
-    return id.Int64()
-  if isinstance(type_, ibis.expr.datatypes.Decimal):
-    return id.Decimal([
+    ret_type = id.String()
+  elif isinstance(type_, ibis.expr.datatypes.Int32):
+    ret_type = id.Int32()
+  elif isinstance(type_, ibis.expr.datatypes.Int64):
+    ret_type = id.Int64()
+  elif isinstance(type_, ibis.expr.datatypes.Timestamp):
+    ret_type = id.Timestamp()
+  elif isinstance(type_, ibis.expr.datatypes.Decimal):
+    ret_type = id.Decimal([
         IntegerAttr.from_int_and_width(type_.precision, 32),
         IntegerAttr.from_int_and_width(type_.scale, 32)
     ])
-  if isinstance(type_, ibis.expr.datatypes.Timestamp):
-    return id.Timestamp()
-  raise KeyError(f"Unknown datatype: {type(type_)}")
+  else:
+    raise Exception(
+        f"datatype conversion not yet implemented for {type(type_)}")
+  return id.Nullable([ret_type]) if type_.nullable else ret_type
 
 
 def convert_literal(literal) -> Attribute:

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -24,7 +24,7 @@ class IbisRewriter(RewritePattern):
 
   def convert_datatype(self, type_: ibis.DataType) -> RelAlg.DataType:
     if isinstance(type_, ibis.String):
-      return RelAlg.String.get(type_.nullable)
+      return RelAlg.String()
     if isinstance(type_, ibis.Int32):
       return RelAlg.Int32()
     if isinstance(type_, ibis.Int64):
@@ -38,6 +38,8 @@ class IbisRewriter(RewritePattern):
           IntegerAttr.from_int_and_width(type_.scale.value.data,
                                          type_.scale.typ.width.data)
       ])
+    if isinstance(type_, ibis.Nullable):
+      return RelAlg.Nullable([self.convert_datatype(type_.datatype)])
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -23,7 +23,7 @@ class RelSSARewriter(RewritePattern):
 
   def convert_datatype(self, type_: RelSSA.DataType) -> RelImpl.DataType:
     if isinstance(type_, RelSSA.String):
-      return RelImpl.String.get(type_.nullable)
+      return RelImpl.String()
     if isinstance(type_, RelSSA.Int32):
       return RelImpl.Int32()
     if isinstance(type_, RelSSA.Int64):
@@ -37,6 +37,8 @@ class RelSSARewriter(RewritePattern):
       ])
     if isinstance(type_, RelSSA.Timestamp):
       return RelImpl.Timestamp()
+    if isinstance(type_, RelSSA.Nullable):
+      return RelImpl.Nullable([self.convert_datatype(type_.type)])
     raise Exception(
         f"datatype conversion not yet implemented for {type(type_)}")
 

--- a/experimental/sql/test/alg_to_ssa/datatypes.xdsl
+++ b/experimental/sql/test/alg_to_ssa/datatypes.xdsl
@@ -5,8 +5,9 @@ module() {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
         rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
         rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
-        rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
+        rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string]
+        rel_alg.schema_element() ["elt_name" = "second_name", "elt_type" = !rel_alg.nullable<!rel_alg.string>]
     }
 }
 
-// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>]> = rel_ssa.table() ["table_name" = "some_name"]

--- a/experimental/sql/test/alg_to_ssa/multiply.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multiply.xdsl
@@ -3,7 +3,7 @@
 module() {
   rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
-      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
     }
@@ -16,8 +16,8 @@ module() {
   }
 }
 
-//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
 // CHECK-NEXT:    %2 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "c"]
 // CHECK-NEXT:    %4 : !rel_ssa.int64 = rel_ssa.bin_op(%2 : !rel_ssa.int64, %3 : !rel_ssa.int64) ["operator" = "*"]

--- a/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
+++ b/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
@@ -3,7 +3,7 @@
 module() {
   rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
-      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
     }

--- a/experimental/sql/test/alg_to_ssa/projection.xdsl
+++ b/experimental/sql/test/alg_to_ssa/projection.xdsl
@@ -3,7 +3,7 @@
 module() {
   rel_alg.project() ["names" = ["a", "b"]] {
     rel_alg.table() ["table_name" = "t"] {
-      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
     }
@@ -13,9 +13,9 @@ module() {
   }
 }
 
-//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
-// CHECK-NEXT:    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+// CHECK-NEXT:    %2 : !rel_ssa.string = rel_ssa.column() ["col_name" = "a"]
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-// CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+// CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.string, %3 : !rel_ssa.int64)
 // CHECK-NEXT:  }

--- a/experimental/sql/test/frontend/dataTypes.ibis
+++ b/experimental/sql/test/frontend/dataTypes.ibis
@@ -5,8 +5,8 @@ ibis.table([("ORDERKEY", "int64"), ("EXTENDEDPRICE", "decimal(4, 2)"),
                 'lineitem')
 
 #      CHECK:  ibis.unbound_table() ["table_name" = "lineitem"] {
-# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "ORDERKEY", "elt_type" = !ibis.int64]
-# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "EXTENDEDPRICE", "elt_type" = !ibis.decimal<4 : !i32, 2 : !i32>]
-# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "RETURNFLAG", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "SHIPDATE", "elt_type" = !ibis.timestamp]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "ORDERKEY", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "EXTENDEDPRICE", "elt_type" = !ibis.nullable<!ibis.decimal<4 : !i32, 2 : !i32>>]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "RETURNFLAG", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "SHIPDATE", "elt_type" = !ibis.nullable<!ibis.timestamp>]
 # CHECK-NEXT:  }

--- a/experimental/sql/test/frontend/decimal_literal.ibis
+++ b/experimental/sql/test/frontend/decimal_literal.ibis
@@ -6,4 +6,4 @@ table = ibis.table([("EXTENDEDPRICE", "decimal(4, 2)")],
 table.filter(table['EXTENDEDPRICE'] >= ibis.literal(decimal.Decimal("0.05"), "decimal(4, 2)"))
 
 
-# CHECK: ibis.literal() ["val" = "0.05", "type" = !ibis.decimal<4 : !i32, 2 : !i32>]
+# CHECK: ibis.literal() ["val" = "0.05", "type" = !ibis.nullable<!ibis.decimal<4 : !i32, 2 : !i32>>]

--- a/experimental/sql/test/frontend/multiply.ibis
+++ b/experimental/sql/test/frontend/multiply.ibis
@@ -5,25 +5,25 @@ table[(table['b'] * table['c']).name('d')]
 
 #      CHECK: ibis.selection() ["names" = ["d"]] {
 # CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:     }
 # CHECK-NEXT:   } {} {
-# CHECK-NEXT:     ibis.multiply() ["output_type" = !ibis.int64] {
+# CHECK-NEXT:     ibis.multiply() ["output_type" = !ibis.nullable<!ibis.int64>] {
 # CHECK-NEXT:       ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:         ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:         }
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }  {
 # CHECK-NEXT:       ibis.table_column() ["col_name" = "c"] {
 # CHECK-NEXT:         ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:         }
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }

--- a/experimental/sql/test/frontend/naming.ibis
+++ b/experimental/sql/test/frontend/naming.ibis
@@ -5,16 +5,16 @@ table[table['b'].name('d')]
 
 #      CHECK: ibis.selection() ["names" = ["d"]] {
 # CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:     }
 # CHECK-NEXT:   } {} {
 # CHECK-NEXT:     ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:       ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }
 # CHECK-NEXT:   }

--- a/experimental/sql/test/frontend/projection.ibis
+++ b/experimental/sql/test/frontend/projection.ibis
@@ -5,23 +5,23 @@ table['a', 'b']
 
 #      CHECK: ibis.selection() ["names" = ["a", "b"]] {
 # CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:     }
 # CHECK-NEXT:   } {} {
 # CHECK-NEXT:     ibis.table_column() ["col_name" = "a"] {
 # CHECK-NEXT:       ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }
 # CHECK-NEXT:     ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:       ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }
 # CHECK-NEXT:   }

--- a/experimental/sql/test/frontend/selection.ibis
+++ b/experimental/sql/test/frontend/selection.ibis
@@ -5,20 +5,20 @@ table.filter(table['a'] == 'AS')
 
 #      CHECK: ibis.selection() ["names" = []] {
 # CHECK-NEXT:    ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:    }
 # CHECK-NEXT:  } {
 # CHECK-NEXT:    ibis.equals() {
 # CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
 # CHECK-NEXT:        ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:        }
 # CHECK-NEXT:      }
 # CHECK-NEXT:    } {
-# CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.nullable<!ibis.string>]
 # CHECK-NEXT:    }
 # CHECK-NEXT:  } {}

--- a/experimental/sql/test/frontend/sum.ibis
+++ b/experimental/sql/test/frontend/sum.ibis
@@ -5,17 +5,17 @@ table.aggregate(table.b.sum().name('b'))
 
 #      CHECK: ibis.aggregation() ["names" = ["b"]] {
 # CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:     }
 # CHECK-NEXT:   } {
 # CHECK-NEXT:     ibis.sum() {
 # CHECK-NEXT:       ibis.table_column() ["col_name" = "b"] {
 # CHECK-NEXT:         ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:         }
 # CHECK-NEXT:       }
 # CHECK-NEXT:     }

--- a/experimental/sql/test/frontend/var_def.ibis
+++ b/experimental/sql/test/frontend/var_def.ibis
@@ -6,20 +6,20 @@ table.filter(cond)
 
 #      CHECK: ibis.selection() ["names" = []] {
 # CHECK-NEXT:    ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:    }
 # CHECK-NEXT:  } {
 # CHECK-NEXT:    ibis.equals() {
 # CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
 # CHECK-NEXT:        ibis.unbound_table() ["table_name" = "t"] {
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 # CHECK-NEXT:        }
 # CHECK-NEXT:      }
 # CHECK-NEXT:    } {
-# CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+# CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.nullable<!ibis.string>]
 # CHECK-NEXT:    }
 # CHECK-NEXT:  } {}

--- a/experimental/sql/test/ibis_dialect_tests/multiply.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/multiply.xdsl
@@ -3,25 +3,25 @@
 module() {
   ibis.selection() ["names" = ["d"]] {
       ibis.unbound_table() ["table_name" = "t"] {
-        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-        ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-        ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+        ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+        ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
       }
     } {} {
-      ibis.multiply() ["output_type" = !ibis.int64] {
+      ibis.multiply() ["output_type" = !ibis.nullable<!ibis.int64>] {
         ibis.table_column() ["col_name" = "b"] {
           ibis.unbound_table() ["table_name" = "t"] {
-            ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-            ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-            ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+            ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+            ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+            ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
           }
         }
       }  {
         ibis.table_column() ["col_name" = "c"] {
           ibis.unbound_table() ["table_name" = "t"] {
-            ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-            ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-            ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+            ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+            ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+            ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
           }
         }
       }
@@ -31,25 +31,25 @@ module() {
 
 //      CHECK: ibis.selection() ["names" = ["d"]] {
 // CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:     }
 // CHECK-NEXT:   } {} {
-// CHECK-NEXT:     ibis.multiply() ["output_type" = !ibis.int64] {
+// CHECK-NEXT:     ibis.multiply() ["output_type" = !ibis.nullable<!ibis.int64>] {
 // CHECK-NEXT:       ibis.table_column() ["col_name" = "b"] {
 // CHECK-NEXT:         ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }  {
 // CHECK-NEXT:       ibis.table_column() ["col_name" = "c"] {
 // CHECK-NEXT:         ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }

--- a/experimental/sql/test/ibis_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/projection.xdsl
@@ -5,24 +5,24 @@ module() {
   ibis.selection() ["names" = ["a", "b"]] {
     // selection input
     ibis.unbound_table() ["table_name" = "t"] {
-      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
     }
   } {} {
     // projections
     ibis.table_column() ["col_name" = "a"] {
       ibis.unbound_table() ["table_name" = "t"] {
-        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-        ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-        ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+        ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+        ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
       }
     }
     ibis.table_column() ["col_name" = "b"] {
       ibis.unbound_table() ["table_name" = "t"] {
-        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-        ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-        ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+        ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+        ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
       }
     }
   }
@@ -30,23 +30,23 @@ module() {
 
 //      CHECK: ibis.selection() ["names" = ["a", "b"]] {
 // CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:     }
 // CHECK-NEXT:   } {} {
 // CHECK-NEXT:     ibis.table_column() ["col_name" = "a"] {
 // CHECK-NEXT:       ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }
 // CHECK-NEXT:     ibis.table_column() ["col_name" = "b"] {
 // CHECK-NEXT:       ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }
 // CHECK-NEXT:   }

--- a/experimental/sql/test/ibis_dialect_tests/selection.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/selection.xdsl
@@ -5,9 +5,9 @@ module() {
   ibis.selection() ["names" = []] {
     // selection input
     ibis.unbound_table() ["table_name" = "t"] {
-      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
     }
   } {
     // selection predicate
@@ -15,34 +15,34 @@ module() {
       // predicate column
       ibis.table_column() ["col_name" = "a"] {
         ibis.unbound_table() ["table_name" = "t"] {
-          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
         }
       }
     } {
       // predicate literal
-      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+      ibis.literal() ["val" = "AS", "type" = !ibis.nullable<!ibis.string>]
     }
   } {}
 }
 
 //      CHECK: ibis.selection() ["names" = []] {
 // CHECK-NEXT:    ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  } {
 // CHECK-NEXT:    ibis.equals() {
 // CHECK-NEXT:      ibis.table_column() ["col_name" = "a"] {
 // CHECK-NEXT:        ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:    } {
-// CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.string<1 : !i1>]
+// CHECK-NEXT:      ibis.literal() ["val" = "AS", "type" = !ibis.nullable<!ibis.string>]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  } {}

--- a/experimental/sql/test/ibis_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/sum.xdsl
@@ -3,17 +3,17 @@
 module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
-      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
     }
   } {
     ibis.sum() {
       ibis.table_column() ["col_name" = "b"] {
         ibis.unbound_table() ["table_name" = "t"] {
-          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
         }
       }
     }
@@ -22,17 +22,17 @@ ibis.aggregation() ["names" = ["b"]] {
 
 //      CHECK: ibis.aggregation() ["names" = ["b"]] {
 // CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:     }
 // CHECK-NEXT:   } {
 // CHECK-NEXT:     ibis.sum() {
 // CHECK-NEXT:       ibis.table_column() ["col_name" = "b"] {
 // CHECK-NEXT:         ibis.unbound_table() ["table_name" = "t"] {
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
-// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+// CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
 // CHECK-NEXT:         }
 // CHECK-NEXT:       }
 // CHECK-NEXT:     }

--- a/experimental/sql/test/ibis_to_alg/datatypes.xdsl
+++ b/experimental/sql/test/ibis_to_alg/datatypes.xdsl
@@ -5,7 +5,8 @@ module() {
         ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int32]
         ibis.schema_element() ["elt_name" = "price", "elt_type" = !ibis.decimal<4 : !i32, 2 : !i32>]
         ibis.schema_element() ["elt_name" = "time", "elt_type" = !ibis.timestamp]
-        ibis.schema_element() ["elt_name" = "name", "elt_type" = !ibis.string<1 : !i1>]
+        ibis.schema_element() ["elt_name" = "name", "elt_type" = !ibis.string]
+        ibis.schema_element() ["elt_name" = "second_name", "elt_type" = !ibis.nullable<!ibis.string>]
     }
 }
 
@@ -13,5 +14,6 @@ module() {
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
-// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "second_name", "elt_type" = !rel_alg.nullable<!rel_alg.string>]
 // CHECK-Next: }

--- a/experimental/sql/test/ibis_to_alg/multiply.xdsl
+++ b/experimental/sql/test/ibis_to_alg/multiply.xdsl
@@ -3,7 +3,7 @@
 module() {
 ibis.selection() ["names" = ["bc"]] {
     ibis.unbound_table() ["table_name" = "t"] {
-      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
     }
@@ -11,7 +11,7 @@ ibis.selection() ["names" = ["bc"]] {
     ibis.multiply() ["output_type" = !ibis.int64] {
       ibis.table_column() ["col_name" = "b"] {
         ibis.unbound_table() ["table_name" = "t"] {
-          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
         }
@@ -19,7 +19,7 @@ ibis.selection() ["names" = ["bc"]] {
     }  {
       ibis.table_column() ["col_name" = "c"] {
         ibis.unbound_table() ["table_name" = "t"] {
-          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
         }
@@ -30,7 +30,7 @@ ibis.selection() ["names" = ["bc"]] {
 
 //      CHECK:  rel_alg.project() ["names" = ["bc"]] {
 // CHECK-NEXT:    rel_alg.table() ["table_name" = "t"] {
-// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:    }

--- a/experimental/sql/test/ibis_to_alg/projection.xdsl
+++ b/experimental/sql/test/ibis_to_alg/projection.xdsl
@@ -4,7 +4,7 @@ module() {
   ibis.selection() ["names" = ["a", "b"]] {
     // selection input
     ibis.unbound_table() ["table_name" = "t"] {
-      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
     }
@@ -12,14 +12,14 @@ module() {
     // projections
     ibis.table_column() ["col_name" = "a"] {
       ibis.unbound_table() ["table_name" = "t"] {
-        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
       }
     }
     ibis.table_column() ["col_name" = "b"] {
       ibis.unbound_table() ["table_name" = "t"] {
-        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
         ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
         ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
       }
@@ -29,7 +29,7 @@ module() {
 
 //      CHECK:  rel_alg.project() ["names" = ["a", "b"]] {
 // CHECK-NEXT:    rel_alg.table() ["table_name" = "t"] {
-// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:    }

--- a/experimental/sql/test/ibis_to_alg/sum.xdsl
+++ b/experimental/sql/test/ibis_to_alg/sum.xdsl
@@ -3,7 +3,7 @@
 module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
-      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
     }
@@ -11,7 +11,7 @@ ibis.aggregation() ["names" = ["b"]] {
     ibis.sum() {
       ibis.table_column() ["col_name" = "b"] {
         ibis.unbound_table() ["table_name" = "t"] {
-          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
         }
@@ -22,7 +22,7 @@ ibis.aggregation() ["names" = ["b"]] {
 
 //      CHECK: rel_alg.aggregate() ["col_names" = ["b"], "functions" = ["sum"], "res_names" = ["b"]] {
 // CHECK-NEXT:         rel_alg.table() ["table_name" = "t"] {
-// CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
 // CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
 // CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
 // CHECK-NEXT:         }

--- a/experimental/sql/test/ibis_to_alg/table_op.xdsl
+++ b/experimental/sql/test/ibis_to_alg/table_op.xdsl
@@ -2,10 +2,10 @@
 
 module() {
   ibis.unbound_table() ["table_name" = "t"] {
-    ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string<1 : !i1>]
+    ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
   }
 }
 
 //      CHECK:  rel_alg.table() ["table_name" = "t"] {
-// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
 // CHECK-NEXT:  }

--- a/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
@@ -5,7 +5,7 @@ module() {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
         rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
         rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
-        rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
+        rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string]
     }
 }
 
@@ -13,5 +13,5 @@ module() {
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
-// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string]
 // CHECK-Next: }

--- a/experimental/sql/test/relational_algebra_dialect_tests/multiply.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/multiply.xdsl
@@ -3,7 +3,7 @@
 module() {
   rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
-      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
     }
@@ -18,7 +18,7 @@ module() {
 
 //      CHECK:  rel_alg.project() ["names" = ["bc"]] {
 // CHECK-NEXT:    rel_alg.table() ["table_name" = "t"] {
-// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:    }

--- a/experimental/sql/test/relational_algebra_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/projection.xdsl
@@ -3,7 +3,7 @@
 module() {
   rel_alg.project() ["names" = ["a", "b"]] {
     rel_alg.table() ["table_name" = "t"] {
-      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
     }
@@ -15,7 +15,7 @@ module() {
 
 //      CHECK:  rel_alg.project() ["names" = ["a", "b"]] {
 // CHECK-NEXT:    rel_alg.table() ["table_name" = "t"] {
-// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string<1 : !i1>]
+// CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:    }

--- a/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+    %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 }
 
-// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/relational_implementation_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/projection.xdsl
@@ -1,19 +1,20 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
-  %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
-    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
-    %3 : !rel_impl.string<1 : !i1> = rel_impl.index_by_name( %2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
-    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
-    rel_impl.yield_tuple(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+    %3 : !rel_impl.string = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
+    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+    rel_impl.yield_tuple(%3 : !rel_impl.string, %4 : !rel_impl.int64)
  }
 }
 
-//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
-// CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
-// CHECK-NEXT:    %3 : !rel_impl.string<1 : !i1> = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
-// CHECK-NEXT:    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
-// CHECK-NEXT:    rel_impl.yield_tuple(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
-// CHECK-NEXT: }
+
+//      CHECK:   %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+// CHECK-NEXT:   %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+// CHECK-NEXT:     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+// CHECK-NEXT:     %3 : !rel_impl.string = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
+// CHECK-NEXT:     %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+// CHECK-NEXT:     rel_impl.yield_tuple(%3 : !rel_impl.string, %4 : !rel_impl.int64)
+// CHECK-NEXT:  }

--- a/experimental/sql/test/relational_ssa_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/datatypes.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 
-// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>]> = rel_ssa.table() ["table_name" = "some_name"]

--- a/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
@@ -1,17 +1,17 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 module() {
-  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
-    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+    %2 : !rel_ssa.string = rel_ssa.column() ["col_name" = "a"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+    rel_ssa.yield_tuple(%2 : !rel_ssa.string, %3 : !rel_ssa.int64)
  }
 }
 
-//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
-// CHECK-NEXT:    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+// CHECK-NEXT:    %2 : !rel_ssa.string = rel_ssa.column() ["col_name" = "a"]
 // CHECK-NEXT:    %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-// CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+// CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.string, %3 : !rel_ssa.int64)
 // CHECK-NEXT:  }

--- a/experimental/sql/test/ssa_to_impl/datatypes.xdsl
+++ b/experimental/sql/test/ssa_to_impl/datatypes.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
 module() {
-    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string<1 : !i1>>]> = rel_ssa.table() ["table_name" = "some_name"]
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 
-// CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string<1 : !i1>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+// CHECK: %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>, !rel_impl.schema_element<"second_name", !rel_impl.nullable<!rel_impl.string>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/ssa_to_impl/multiply.xdsl
+++ b/experimental/sql/test/ssa_to_impl/multiply.xdsl
@@ -1,8 +1,8 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
 module() {
-  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "c"]
     %4 : !rel_ssa.int64 = rel_ssa.bin_op(%2 : !rel_ssa.int64, %3 : !rel_ssa.int64) ["operator" = "*"]
@@ -10,11 +10,11 @@ module() {
   }
 }
 
-//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"bc", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
-// CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
-// CHECK-NEXT:      %3 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
-// CHECK-NEXT:      %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "c"]
+//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"bc", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+// CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+// CHECK-NEXT:      %3 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+// CHECK-NEXT:      %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "c"]
 // CHECK-NEXT:      %5 : !rel_impl.int64 = rel_impl.bin_op(%3 : !rel_impl.int64, %4 : !rel_impl.int64) ["operator" = "*"]
 // CHECK-NEXT:      rel_impl.yield_tuple(%5 : !rel_impl.int64)
 // CHECK-NEXT:  }

--- a/experimental/sql/test/ssa_to_impl/projection.xdsl
+++ b/experimental/sql/test/ssa_to_impl/projection.xdsl
@@ -1,18 +1,18 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
 module() {
-  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
-  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string<1 : !i1>>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
-    %2 : !rel_ssa.string<1 : !i1> = rel_ssa.column() ["col_name" = "a"]
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
+    %2 : !rel_ssa.string = rel_ssa.column() ["col_name" = "a"]
     %3 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]
-    rel_ssa.yield_tuple(%2 : !rel_ssa.string<1 : !i1>, %3 : !rel_ssa.int64)
+    rel_ssa.yield_tuple(%2 : !rel_ssa.string, %3 : !rel_ssa.int64)
  }
 }
 
-//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
-// CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
-// CHECK-NEXT:    %3 : !rel_impl.string<1 : !i1> = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
-// CHECK-NEXT:    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string<1 : !i1>>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
-// CHECK-NEXT:    rel_impl.yield_tuple(%3 : !rel_impl.string<1 : !i1>, %4 : !rel_impl.int64)
+//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+// CHECK-NEXT:    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+// CHECK-NEXT:    %3 : !rel_impl.string = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
+// CHECK-NEXT:    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+// CHECK-NEXT:    rel_impl.yield_tuple(%3 : !rel_impl.string, %4 : !rel_impl.int64)
 // CHECK-NEXT: }


### PR DESCRIPTION
This PR rewrites nullable handling. For the ibis dialect, it introduces a parameter that shows whether a given datatype is nullable. For all other dialects it introduces a new datatype `nullable` that is parametrized by another datatype.