### PR TITLE
Iterators: Improve analysis

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.cpp
@@ -110,7 +110,14 @@ mlir::iterators::IteratorAnalysis::IteratorAnalysis(Operation *rootOp)
   rootOp->walk([&](IteratorOpInterface iteratorOp) {
     llvm::TypeSwitch<Operation *, void>(iteratorOp)
         // TODO: Verify that operands do not come from bbArgs.
-        .Case<ConstantStreamOp, FilterOp, MapOp, ReduceOp>([&](auto op) {
+        .Case<
+            // clang-format off
+            ConstantStreamOp,
+            FilterOp,
+            MapOp,
+            ReduceOp
+            // clang-format on
+            >([&](auto op) {
           llvm::SmallVector<LLVM::LLVMStructType> upstreamStateTypes;
           llvm::transform(op->getOperands(),
                           std::back_inserter(upstreamStateTypes),

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.cpp
@@ -116,6 +116,8 @@ mlir::iterators::IteratorAnalysis::IteratorAnalysis(Operation *rootOp)
                           std::back_inserter(upstreamStateTypes),
                           [&](auto operand) {
                             Operation *def = operand.getDefiningOp();
+                            if (!def || !llvm::isa<IteratorOpInterface>(def))
+                              return LLVM::LLVMStructType();
                             return getExpectedIteratorInfo(def).stateType;
                           });
           LLVM::LLVMStructType stateType =

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
@@ -20,12 +20,19 @@ namespace iterators {
 
 class IteratorOpInterface;
 
-/// Information about each op constructed by IteratorAnalysis.
+/// Information about each iterator op constructed by IteratorAnalysis.
 struct IteratorInfo {
   /// Takes the `LLVM::LLVMStructType` as a parameter, to ensure proper build
   /// order (all uses are visited before any def).
   IteratorInfo(IteratorOpInterface op, NameAssigner &nameAssigner,
                LLVM::LLVMStructType t);
+
+  // Rule of five: default constructors/assignment operators
+  IteratorInfo() = default;
+  IteratorInfo(const IteratorInfo &other) = default;
+  IteratorInfo(IteratorInfo &&other) = default;
+  IteratorInfo &operator=(const IteratorInfo &other) = default;
+  IteratorInfo &operator=(IteratorInfo &&other) = default;
 
   // Pre-assigned symbols that should be used for the Open/Next/Close
   // functions of this iterator.
@@ -42,7 +49,8 @@ struct IteratorInfo {
 /// The state type of each iterator usually consists of a private part, which
 /// the iterator accesses in its Open/Next/Close logic, as well as the state of
 /// all of its transitive upstream iterators, i.e., the iterators that produce
-/// the operand streams.
+/// the operand streams. Ignores non-iterator ops, i.e., those that do not
+/// implement IteratorOpInterface.
 class IteratorAnalysis {
   using OperationMap = llvm::DenseMap<Operation *, IteratorInfo>;
 

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -1048,7 +1048,14 @@ static Value buildOpenBody(Operation *op, RewriterBase &rewriter,
                            Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   return llvm::TypeSwitch<Operation *, Value>(op)
-      .Case<ConstantStreamOp, FilterOp, MapOp, ReduceOp>([&](auto op) {
+      .Case<
+          // clang-format off
+          ConstantStreamOp,
+          FilterOp,
+          MapOp,
+          ReduceOp
+          // clang-format on
+          >([&](auto op) {
         return buildOpenBody(op, rewriter, initialState, upstreamInfos);
       });
 }
@@ -1058,7 +1065,14 @@ static llvm::SmallVector<Value, 4>
 buildNextBody(Operation *op, RewriterBase &rewriter, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
   return llvm::TypeSwitch<Operation *, llvm::SmallVector<Value, 4>>(op)
-      .Case<ConstantStreamOp, FilterOp, MapOp, ReduceOp>([&](auto op) {
+      .Case<
+          // clang-format off
+          ConstantStreamOp,
+          FilterOp,
+          MapOp,
+          ReduceOp
+          // clang-format on
+          >([&](auto op) {
         return buildNextBody(op, rewriter, initialState, upstreamInfos,
                              elementType);
       });
@@ -1069,7 +1083,14 @@ static Value buildCloseBody(Operation *op, RewriterBase &rewriter,
                             Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   return llvm::TypeSwitch<Operation *, Value>(op)
-      .Case<ConstantStreamOp, FilterOp, MapOp, ReduceOp>([&](auto op) {
+      .Case<
+          // clang-format off
+          ConstantStreamOp,
+          FilterOp,
+          MapOp,
+          ReduceOp
+          // clang-format on
+          >([&](auto op) {
         return buildCloseBody(op, rewriter, initialState, upstreamInfos);
       });
 }
@@ -1079,7 +1100,14 @@ static Value buildStateCreation(IteratorOpInterface op, RewriterBase &rewriter,
                                 LLVM::LLVMStructType stateType,
                                 ValueRange upstreamStates) {
   return llvm::TypeSwitch<Operation *, Value>(op)
-      .Case<ConstantStreamOp, FilterOp, MapOp, ReduceOp>([&](auto op) {
+      .Case<
+          // clang-format off
+          ConstantStreamOp,
+          FilterOp,
+          MapOp,
+          ReduceOp
+          // clang-format on
+          >([&](auto op) {
         return buildStateCreation(op, rewriter, stateType, upstreamStates);
       });
 }

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -50,9 +50,9 @@ public:
   }
 
 private:
-  /// Maps a TupleType to a corresponding LLVMStructType
+  /// Maps a TupleType to a corresponding LLVMStructType.
   static Optional<Type> convertTupleType(Type type) {
-    if (TupleType tupleType = type.dyn_cast<TupleType>()) {
+    if (auto tupleType = type.dyn_cast<TupleType>()) {
       return LLVMStructType::getNewIdentified(type.getContext(), "tuple",
                                               tupleType.getTypes());
     }


### PR DESCRIPTION
This PR is based on and therefore includes #539. It extends and cleans up the iterator analysis in preparation for #553. In that PR, we introduce an iterator op (a scan) than has a *non-iterator* operand -- something that doesn't occur with the ops we currently have. This PR makes the analysis correct for ops with non-iterator operands and cleans up a few other things.