### PR TITLE
SQL: add iterators scan op

### DIFF
--- a/experimental/sql/dialects/iterators.py
+++ b/experimental/sql/dialects/iterators.py
@@ -36,6 +36,21 @@ class Stream(ParametrizedAttribute):
     return Stream([elem_type])  #type: ignore
 
 
+@irdl_attr_definition
+class ColumnarBatch(ParametrizedAttribute):
+  """
+  Batch of tuples in columnar form
+  """
+  name = "iterators.columnar_batch"
+
+  elementType: ParameterDef[TupleType]
+
+  @builder
+  @staticmethod
+  def get(elem_type: TupleType) -> 'ColumnarBatch':
+    return ColumnarBatch([elem_type])
+
+
 #===------------------------------------------------------------------------===#
 # Operations
 #===------------------------------------------------------------------------===#
@@ -54,6 +69,22 @@ class SampleInputOp(Operation):
   @staticmethod
   def get(type: Attribute) -> 'SampleInputOp':
     return SampleInputOp.create(result_types=[type])
+
+
+@irdl_op_definition
+class ScanColumnarBatch(Operation):
+  """
+  Extracts the tuples from a columnar batch.
+  """
+  name = "iterators.scan_columnar_batch"
+
+  input = OperandDef(ColumnarBatch)
+  result = ResultDef(Stream)
+
+  @builder
+  @staticmethod
+  def get(input: Operation, result_type: Stream) -> 'ScanColumnarBatch':
+    return ScanColumnarBatch.build(operands=[input], result_types=[result_type])
 
 
 @irdl_op_definition
@@ -198,6 +229,7 @@ class Iterators:
 
   def __post_init__(self: 'Iterators'):
     self.ctx.register_attr(Stream)
+    self.ctx.register_attr(ColumnarBatch)
 
     self.ctx.register_op(SampleInputOp)
     self.ctx.register_op(ReduceOp)
@@ -205,3 +237,4 @@ class Iterators:
     self.ctx.register_op(MapOp)
     self.ctx.register_op(SinkOp)
     self.ctx.register_op(ConstantStreamOp)
+    self.ctx.register_op(ScanColumnarBatch)

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -41,6 +41,8 @@ def convert_datatype(type_: RelImpl.DataType) -> Attribute:
         StringAttr.from_str(""),
         ArrayAttr.from_list([IntegerType.from_width(8)] * 8)
     ])
+  if isinstance(type_, RelImpl.Nullable):
+    return convert_datatype(type_.type)
   raise Exception(f"type conversion not yet implemented for {type(type_)}")
 
 

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -11,4 +11,4 @@ module() {
   }
 }
 
-// CHECK:     %3 : !i32 = arith.constant() ["value" = 5 : !i32]
+// CHECK:     %{{.*}} : !i32 = arith.constant() ["value" = 5 : !i32]

--- a/experimental/sql/test/impl_to_iterators/filter.xdsl
+++ b/experimental/sql/test/impl_to_iterators/filter.xdsl
@@ -11,14 +11,15 @@ module() {
   }
 }
 
-//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
-// CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private"] {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
 // CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.filter(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["predicateRef" = @s0]
 // CHECK-NEXT:   iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
 // CHECK-NEXT:   func.return()
 // CHECK-NEXT: }
 // CHECK-NEXT: func.func() ["sym_name" = "s0", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!i1]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:   ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.struct<"", [!i32]>):
 // CHECK-NEXT:     %{{.*}} : !i32 = arith.constant() ["value" = 0 : !i32]
 // CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
 // CHECK-NEXT:     %{{.*}} : !i1 = arith.cmpi(%{{.*}} : !i32, %{{.*}} : !i32) ["predicate" = 4 : !i64]

--- a/experimental/sql/test/impl_to_iterators/map.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map.xdsl
@@ -10,14 +10,15 @@ module() {
  }
 }
 
-//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = {{.*}}[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private"] {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
 // CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @m0]
 // CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
 // CHECK-NEXT:     func.return()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func() ["sym_name" = "m0", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
+// CHECK-NEXT:     ^{{.*}}(%{{.*}} : !llvm.struct<"", [!i32]>):
 // CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
 // CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
 // CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.mlir.undef()

--- a/experimental/sql/test/impl_to_iterators/sum.xdsl
+++ b/experimental/sql/test/impl_to_iterators/sum.xdsl
@@ -5,17 +5,18 @@ module() {
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
 }
 
-//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
-// CHECK-NEXT:     %0 : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
-// CHECK-NEXT:     %1 : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.reduce(%0 : !iterators.stream<!llvm.struct<"", [!i32]>>) ["reduceFuncRef" = @sum_struct]
-// CHECK-NEXT:     iterators.sink(%1 : !iterators.stream<!llvm.struct<"", [!i32]>>)
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private"] {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.reduce(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["reduceFuncRef" = @sum_struct]
+// CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
 // CHECK-NEXT:     func.return()
 // CHECK-NEXT:   }
 // CHECK-NEXT:   func.func() ["sym_name" = "sum_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>, !llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:   ^0(%2 : !llvm.struct<"", [!i32]>, %3 : !llvm.struct<"", [!i32]>):
-// CHECK-NEXT:     %4 : !i32 = llvm.extractvalue(%2 : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
-// CHECK-NEXT:     %5 : !i32 = llvm.extractvalue(%3 : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
-// CHECK-NEXT:     %6 : !i32 = arith.addi(%4 : !i32, %5 : !i32)
-// CHECK-NEXT:     %7 : !llvm.struct<"", [!i32]> = llvm.insertvalue(%2 : !llvm.struct<"", [!i32]>, %6 : !i32) ["position" = [0 : !index]]
-// CHECK-NEXT:     func.return(%7 : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !llvm.struct<"", [!i32]>):
+// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:     %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
+// CHECK-NEXT:     %{{.*}} : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:     func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
 // CHECK-NEXT:   }

--- a/experimental/sql/test/impl_to_iterators/timestamp.xdsl
+++ b/experimental/sql/test/impl_to_iterators/timestamp.xdsl
@@ -11,4 +11,4 @@ module() {
   }
 }
 
-// CHECK:     %3 : !i32 = arith.constant() ["value" = 9048 : !i32]
+// CHECK:     %{{.*}} : !i32 = arith.constant() ["value" = 9048 : !i32]

--- a/experimental/sql/test_mlir/conversion_tests/scan_columnar_batch.xdsl
+++ b/experimental/sql/test_mlir/conversion_tests/scan_columnar_batch.xdsl
@@ -1,0 +1,19 @@
+// RUN: rel_opt.py -t mlir %s | filecheck %s
+
+module() {
+  func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32, !i64, !i64]>>], []>, "sym_visibility" = "public"] {
+    ^0(%input : !iterators.columnar_batch<!tuple<[!i32, !i64, !i64]>>):
+      %stream : !iterators.stream<!llvm.struct<"", [!i32, !i64, !i64]>> = iterators.scan_columnar_batch(%input : !iterators.columnar_batch<!tuple<[!i32, !i64, !i64]>>)
+      iterators.sink(%stream : !iterators.stream<!llvm.struct<"", [!i32, !i64, !i64]>>)
+      func.return()
+  }
+}
+
+
+// CHECK-NEXT: func.func @main(%input: !iterators.columnar_batch<tuple<i32, i64, i64>>) {
+// CHECK-NEXT:   %stream = "iterators.scan_columnar_batch"(%input)
+// CHECK-NEXT:   : (!iterators.columnar_batch<tuple<i32, i64, i64>>)
+// CHECK-NEXT:       -> !iterators.stream<!llvm.struct<(i32, i64, i64)>>
+// CHECK-NEXT:   "iterators.sink"(%stream) : (!iterators.stream<!llvm.struct<(i32, i64, i64)>>) -> ()
+// CHECK-NEXT:   return
+// CHECK-NEXT: }

--- a/experimental/sql/tools/IteratorsMLIRConverter.py
+++ b/experimental/sql/tools/IteratorsMLIRConverter.py
@@ -2,7 +2,7 @@ import mlir_iterators.ir as ir
 from mlir_iterators.dialects import iterators as it
 from xdsl.mlir_converter import MLIRConverter
 from xdsl.ir import Attribute
-from dialects.iterators import Stream
+from dialects.iterators import Stream, ColumnarBatch
 
 # This MLIRConverter enriches the standard xdsl MLIRConverter
 # (https://github.com/xdslproject/xdsl/blob/main/src/xdsl/mlir_converter.py) by
@@ -19,4 +19,6 @@ class IteratorsMLIRConverter(MLIRConverter):
   def convert_type(self, typ: Attribute) -> ir.Type:
     if isinstance(typ, Stream):
       return it.StreamType.get(self.convert_type(typ.types))
+    if isinstance(typ, ColumnarBatch):
+      return it.ColumnarBatchType.get(self.convert_type(typ.elementType))
     return super().convert_type(typ)


### PR DESCRIPTION
This PR adds the iterators scan op, the way to actually lower `FullTableScan`s to the iterators dialect. The PR relies on the version of the python bindings from #553. With this version, we can now go all the way through in terms of building the IR. Executing the code is still WIP.