### PR TITLE
SQL: small fixes for several parts of the pipeline

### DIFF
--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,7 +1,7 @@
 filecheck==0.0.18
 lit==14.0.0
 pytest==6.2.5
-xdsl==0.5.2
+xdsl==0.5.3
 yapf==0.32.0
 pyright==0.0.13
 frozenlist==1.2.*

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -16,7 +16,6 @@ import dialects.rel_impl as RelImpl
 import dialects.iterators as it
 from decimal import Decimal
 from datetime import datetime
-from numpy import datetime64
 from time import mktime
 
 # This file contains the rewrite infrastructure to translate the relational
@@ -134,15 +133,12 @@ class LiteralRewriter(RelImplRewriter):
           Constant.from_int_constant(int(Decimal(op.value.data) * Decimal(100)),
                                      64))
     elif isinstance(type, RelImpl.Timestamp):
-      d = datetime64(op.value.data)
       rewriter.replace_matched_op(
           Constant.from_int_constant(
               int(
                   mktime(
-                      datetime(
-                          d.astype(object).year,
-                          d.astype(object).month,
-                          d.astype(object).day).timetuple())), 64))
+                      datetime.strptime(op.value.data,
+                                        "%Y-%m-%d").timetuple())), 64))
     else:
       raise Exception(
           f"lowering of literals with type {type(type)} not yet implemented")

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -15,7 +15,7 @@ from xdsl.pattern_rewriter import RewritePattern, GreedyRewritePatternApplier, P
 import dialects.rel_impl as RelImpl
 import dialects.iterators as it
 from decimal import Decimal
-from datetime import datetime
+from datetime import datetime, timezone
 from time import mktime
 
 # This file contains the rewrite infrastructure to translate the relational
@@ -137,8 +137,8 @@ class LiteralRewriter(RelImplRewriter):
           Constant.from_int_constant(
               int(
                   mktime(
-                      datetime.strptime(op.value.data,
-                                        "%Y-%m-%d").timetuple())), 64))
+                      datetime.strptime(op.value.data, "%Y-%m-%d").replace(
+                          tzinfo=timezone.utc).timetuple())), 64))
     else:
       raise Exception(
           f"lowering of literals with type {type(type)} not yet implemented")

--- a/experimental/sql/src/impl_to_iterators.py
+++ b/experimental/sql/src/impl_to_iterators.py
@@ -133,12 +133,11 @@ class LiteralRewriter(RelImplRewriter):
           Constant.from_int_constant(int(Decimal(op.value.data) * Decimal(100)),
                                      64))
     elif isinstance(type, RelImpl.Timestamp):
+      epoch = datetime.utcfromtimestamp(0)
       rewriter.replace_matched_op(
           Constant.from_int_constant(
-              int(
-                  mktime(
-                      datetime.strptime(op.value.data, "%Y-%m-%d").replace(
-                          tzinfo=timezone.utc).timetuple())), 64))
+              int((datetime.strptime(op.value.data, "%Y-%m-%d") -
+                   epoch).total_seconds()), 64))
     else:
       raise Exception(
           f"lowering of literals with type {type(type)} not yet implemented")

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -11,4 +11,4 @@ module() {
   }
 }
 
-// CHECK:     %{{.*}} : !i32 = arith.constant() ["value" = 5 : !i32]
+// CHECK:     %{{.*}} : !i64 = arith.constant() ["value" = 5 : !i64]

--- a/experimental/sql/test/impl_to_iterators/filter.xdsl
+++ b/experimental/sql/test/impl_to_iterators/filter.xdsl
@@ -11,7 +11,7 @@ module() {
   }
 }
 
-//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private"] {
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
 // CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
 // CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.filter(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["predicateRef" = @s0]

--- a/experimental/sql/test/impl_to_iterators/map.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map.xdsl
@@ -10,7 +10,7 @@ module() {
  }
 }
 
-//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private"] {
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
 // CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
 // CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @m0]

--- a/experimental/sql/test/impl_to_iterators/sum.xdsl
+++ b/experimental/sql/test/impl_to_iterators/sum.xdsl
@@ -5,7 +5,7 @@ module() {
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
 }
 
-//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private"] {
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
 // CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
 // CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.reduce(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["reduceFuncRef" = @sum_struct]

--- a/experimental/sql/test/impl_to_iterators/timestamp.xdsl
+++ b/experimental/sql/test/impl_to_iterators/timestamp.xdsl
@@ -11,4 +11,4 @@ module() {
   }
 }
 
-// CHECK:     %{{.*}} : !i64 = arith.constant() ["value" = 781743600 : !i64]
+// CHECK:     %{{.*}} : !i64 = arith.constant() ["value" = 781747200 : !i64]

--- a/experimental/sql/test/impl_to_iterators/timestamp.xdsl
+++ b/experimental/sql/test/impl_to_iterators/timestamp.xdsl
@@ -11,4 +11,4 @@ module() {
   }
 }
 
-// CHECK:     %{{.*}} : !i32 = arith.constant() ["value" = 9048 : !i32]
+// CHECK:     %{{.*}} : !i64 = arith.constant() ["value" = 781743600 : !i64]


### PR DESCRIPTION
This PR upstreams several small fixes of issues I found on friday while making Q6 work (nearly) end-to-end. Notice that the handling for datetimes was adjusted to fit @ingomueller-net's way of generating the integers for the TPC-H benchmark.

Note that this PR depends on a `UnitAttr`, which I am currently upstreaming to xdsl. Therefore, it will currently break on the CI.