### PR TITLE
SQL: fuse projections and tables

### DIFF
--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -211,7 +211,6 @@ class SelectYieldCombiner(RewritePattern):
     for operation in op.predicates.ops:
       if isinstance(operation, RelSSA.YieldValue):
         yielded_ops.append(operation.op.op)
-        print(operation)
         op.predicates.blocks[0].erase_op(operation)
     new_region = rewriter.move_region_contents_to_new_regions(op.predicates)
     while (len(yielded_ops) > 1):

--- a/experimental/sql/src/fuse_proj_into_scan.py
+++ b/experimental/sql/src/fuse_proj_into_scan.py
@@ -1,0 +1,64 @@
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from dataclasses import dataclass
+from xdsl.ir import Operation, MLContext, Region, Block
+from typing import List, Type, Optional
+from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
+
+from xdsl.pattern_rewriter import (RewritePattern, GreedyRewritePatternApplier,
+                                   PatternRewriteWalker, PatternRewriter,
+                                   op_type_rewrite_pattern)
+
+import dialects.rel_impl as RelImpl
+
+# This file contains rewrites that aim at fusing a table directly following
+# projection, that projects on a subset of the columns in the table.
+
+
+@dataclass
+class ProjScanFuser(RewritePattern):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelImpl.Project, rewriter: PatternRewriter):
+    if not isinstance(op.input.op, RelImpl.FullTableScanOp):
+      return
+
+    # This rewrite expects that the projection only maps onto a subset of the
+    # columns of the input. Therefore, we first check that only IndexByName is
+    # present and then that there are equally as many cols that are yielded as
+    # there are in the result.
+    if not all([
+        isinstance(o.op, RelImpl.IndexByName) for o in op.projection.ops[-1].ops
+    ]):
+      return
+
+    assert isinstance(op.projection.ops[-1], RelImpl.YieldTuple)
+    yielded_ssa_values = op.projection.ops[-1].ops
+
+    col_names = [o.op.col_name.data for o in yielded_ssa_values]
+    res_names = [s.elt_name.data for s in op.input.typ.schema.data]
+    if len(col_names) == len(res_names):
+      return
+
+    col_types = [o.typ for o in yielded_ssa_values]
+
+    new_op = RelImpl.FullTableScanOp.get(op.input.op.table_name.data,
+                                         RelImpl.Bag.get(col_types, col_names),
+                                         col_names)
+    rewriter.replace_matched_op(new_op)
+
+    if len(op.input.uses) == 0:
+      # TODO: remove that safe_erase is False, when we have some kind of dead code
+      # elimination.
+      rewriter.erase_op(op.input.op, safe_erase=False)
+
+
+def fuse_proj_into_scan(ctx: MLContext, query: ModuleOp):
+  fuse_proj_table_walker = PatternRewriteWalker(GreedyRewritePatternApplier(
+      [ProjScanFuser()]),
+                                                walk_regions_first=False,
+                                                apply_recursively=False,
+                                                walk_reverse=False)
+  fuse_proj_table_walker.rewrite_module(query)

--- a/experimental/sql/test/fuse_proj_into_scan_tests/extended_case.xdsl
+++ b/experimental/sql/test/fuse_proj_into_scan_tests/extended_case.xdsl
@@ -1,0 +1,52 @@
+// RUN: rel_opt.py -p fuse-proj-into-scan  %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "lineitem"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]>) {
+  ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]>):
+    %3 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]>) ["col_name" = "a"]
+    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]>) ["col_name" = "b"]
+    %5 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]>) ["col_name" = "c"]
+    rel_impl.yield_tuple(%3 : !rel_impl.int64, %4 : !rel_impl.int64, %5 : !rel_impl.int64)
+  }
+  %6 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.select(%1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+  ^1(%7 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+    %8 : !rel_impl.int64 = rel_impl.index_by_name(%7 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
+    %9 : !rel_impl.int64 = rel_impl.literal() ["value" = 7 : !i64]
+    %10 : !rel_impl.bool = rel_impl.compare(%8 : !rel_impl.int64, %9 : !rel_impl.int64) ["comparator" = "<="]
+    %11 : !rel_impl.int64 = rel_impl.index_by_name(%7 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+    %12 : !rel_impl.int64 = rel_impl.literal() ["value" = 24 : !i64]
+    %13 : !rel_impl.bool = rel_impl.compare(%11 : !rel_impl.int64, %12 : !rel_impl.int64) ["comparator" = "<"]
+    %14 : !rel_impl.bool = rel_impl.and(%13 : !rel_impl.bool, %10 : !rel_impl.bool)
+    rel_impl.yield_value(%14 : !rel_impl.bool)
+  }
+  %15 : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]> = rel_impl.project(%6 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+  ^2(%16 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+    %17 : !rel_impl.int64 = rel_impl.index_by_name(%16 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+    %18 : !rel_impl.int64 = rel_impl.index_by_name(%16 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "c"]
+    %19 : !rel_impl.int64 = rel_impl.bin_op(%17 : !rel_impl.int64, %18 : !rel_impl.int64) ["operator" = "*"]
+    rel_impl.yield_tuple(%19 : !rel_impl.int64)
+  }
+  %20 : !rel_impl.bag<[!rel_impl.schema_element<"revenue", !rel_impl.int64>]> = rel_impl.aggregate(%15 : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]>) ["col_names" = ["im"], "functions" = ["sum"]]
+}
+
+//      CHECK:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "lineitem", "cols" = ["a", "b", "c"]]
+// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.select(%{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+// CHECK-NEXT:  ^0(%{{.*}} : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+// CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.index_by_name(%{{.*}} : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.literal() ["value" = 7 : !i64]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.bool = rel_impl.compare(%{{.*}} : !rel_impl.int64, %{{.*}} : !rel_impl.int64) ["comparator" = "<="]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.index_by_name(%{{.*}} : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.literal() ["value" = 24 : !i64]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.bool = rel_impl.compare(%{{.*}} : !rel_impl.int64, %{{.*}} : !rel_impl.int64) ["comparator" = "<"]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.bool = rel_impl.and(%{{.*}} : !rel_impl.bool, %{{.*}} : !rel_impl.bool)
+// CHECK-NEXT:    rel_impl.yield_value(%{{.*}} : !rel_impl.bool)
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]> = rel_impl.project(%{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+// CHECK-NEXT:  ^1(%{{.*}} : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+// CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.index_by_name(%{{.*}} : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.index_by_name(%{{.*}} : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "c"]
+// CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.bin_op(%{{.*}} : !rel_impl.int64, %{{.*}} : !rel_impl.int64) ["operator" = "*"]
+// CHECK-NEXT:    rel_impl.yield_tuple(%{{.*}} : !rel_impl.int64)
+// CHECK-NEXT:  }
+// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"revenue", !rel_impl.int64>]> = rel_impl.aggregate(%10 : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]>) ["col_names" = ["im"], "functions" = ["sum"]]

--- a/experimental/sql/test/fuse_proj_into_scan_tests/simple_case.xdsl
+++ b/experimental/sql/test/fuse_proj_into_scan_tests/simple_case.xdsl
@@ -1,0 +1,13 @@
+// RUN: rel_opt.py -p fuse-proj-into-scan %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
+    ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):
+    %3 : !rel_impl.string = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "a"]
+    %4 : !rel_impl.int64 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_name" = "b"]
+    rel_impl.yield_tuple(%3 : !rel_impl.string, %4 : !rel_impl.int64)
+ }
+}
+
+// CHECK:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t", "cols" = ["a", "b"]]

--- a/experimental/sql/test/impl_to_iterators/partial_scan.xdsl
+++ b/experimental/sql/test/impl_to_iterators/partial_scan.xdsl
@@ -1,0 +1,12 @@
+// RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t", "cols" = ["a", "b"]]
+}
+
+//      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i64, !i64]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
+// CHECK-NEXT:   ^0(%0 : !iterators.columnar_batch<!tuple<[!i64, !i64]>>):
+// CHECK-NEXT:     %1 : !iterators.stream<!llvm.struct<"", [!i64, !i64]>> = iterators.scan_columnar_batch(%0 : !iterators.columnar_batch<!tuple<[!i64, !i64]>>)
+// CHECK-NEXT:     iterators.sink(%1 : !iterators.stream<!llvm.struct<"", [!i64, !i64]>>)
+// CHECK-NEXT:     func.return()
+// CHECK-NEXT:   }

--- a/experimental/sql/tools/rel_opt.py
+++ b/experimental/sql/tools/rel_opt.py
@@ -19,6 +19,7 @@ from src.alg_to_ssa import alg_to_ssa
 from src.ssa_to_impl import ssa_to_impl
 from src.impl_to_iterators import impl_to_iterators
 from src.projection_pushdown import projection_pushdown
+from src.fuse_proj_into_scan import fuse_proj_into_scan
 from dialects.ibis_dialect import Ibis
 from dialects.rel_alg import RelationalAlg
 from dialects.rel_ssa import RelSSA
@@ -34,6 +35,7 @@ class RelOptMain(xDSLOptMain):
     self.available_passes['ssa-to-impl'] = ssa_to_impl
     self.available_passes['impl-to-iterators'] = impl_to_iterators
     self.available_passes['projection-pushdown'] = projection_pushdown
+    self.available_passes['fuse-proj-into-scan'] = fuse_proj_into_scan
 
   def register_all_frontends(self):
     super().register_all_frontends()


### PR DESCRIPTION
This PR adds the fusion of tables with subsequent (simple) projections. In order t do that, it introduces the `partial_table_scan` operation, an operation similar to the `full_table_scan`, but with col_names to define which columns should be loaded.