### PR TITLE
[NFC] Iterators: Use ImplicitLocOpBuilder where possible

### DIFF
--- a/experimental/iterators/include/iterators/Utils/MLIRSupport.h
+++ b/experimental/iterators/include/iterators/Utils/MLIRSupport.h
@@ -15,6 +15,7 @@
 namespace mlir {
 class NamedAttribute;
 class OpBuilder;
+class ImplicitLocOpBuilder;
 } // namespace mlir
 
 namespace mlir {
@@ -24,6 +25,14 @@ class WhileOp;
 WhileOp createWhileOp(
     OpBuilder &builder, Location loc, TypeRange resultTypes,
     ValueRange operands,
+    llvm::function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
+        beforeBuilder,
+    llvm::function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
+        afterBuilder,
+    llvm::ArrayRef<NamedAttribute> attributes = {});
+
+WhileOp createWhileOp(
+    ImplicitLocOpBuilder &builder, TypeRange resultTypes, ValueRange operands,
     llvm::function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
         beforeBuilder,
     llvm::function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
@@ -40,7 +49,15 @@ InsertValueOp createInsertValueOp(OpBuilder &builder, Location loc,
                                   Value container, Value value,
                                   ArrayRef<int64_t> position);
 
+InsertValueOp createInsertValueOp(ImplicitLocOpBuilder &builder,
+                                  Value container, Value value,
+                                  ArrayRef<int64_t> position);
+
 ExtractValueOp createExtractValueOp(OpBuilder &builder, Location loc, Type res,
+                                    Value container,
+                                    ArrayRef<int64_t> position);
+
+ExtractValueOp createExtractValueOp(ImplicitLocOpBuilder &builder, Type res,
                                     Value container,
                                     ArrayRef<int64_t> position);
 

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -260,7 +260,7 @@ struct PrintOpLowering : public OpConversionPattern<PrintOp> {
 /// %0 = llvm.mlir.constant(0 : i32) : i32
 /// %1 = llvm.insertvalue %0, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.constant_stream_state", (i32)>
-static Value buildOpenBody(ConstantStreamOp op, RewriterBase &rewriter,
+static Value buildOpenBody(ConstantStreamOp op, OpBuilder &rewriter,
                            Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -372,7 +372,7 @@ static GlobalOp buildGlobalData(ConstantStreamOp op, OpBuilder &rewriter,
 ///       !llvm.struct<"iterators.constant_stream_state", (i32)>, !element_type
 /// }
 static llvm::SmallVector<Value, 4>
-buildNextBody(ConstantStreamOp op, RewriterBase &rewriter, Value initialState,
+buildNextBody(ConstantStreamOp op, OpBuilder &rewriter, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
   Location loc = op->getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -428,7 +428,7 @@ buildNextBody(ConstantStreamOp op, RewriterBase &rewriter, Value initialState,
 
 /// Forwards the initial state. The ConstantStreamOp doesn't do anything on
 /// Close.
-static Value buildCloseBody(ConstantStreamOp op, RewriterBase &rewriter,
+static Value buildCloseBody(ConstantStreamOp op, OpBuilder &rewriter,
                             Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   return initialState;
@@ -443,9 +443,9 @@ static Value buildCloseBody(ConstantStreamOp op, RewriterBase &rewriter,
 /// return %1 : !llvm.struct<"iterators.constant_stream_state", (i32)>
 static Value buildStateCreation(ConstantStreamOp op,
                                 ConstantStreamOp::Adaptor /*adaptor*/,
-                                RewriterBase &rewriter,
+                                OpBuilder &builder,
                                 LLVM::LLVMStructType stateType) {
-  return rewriter.create<UndefOp>(op.getLoc(), stateType);
+  return builder.create<UndefOp>(op.getLoc(), stateType);
 }
 
 //===----------------------------------------------------------------------===//
@@ -460,8 +460,7 @@ static Value buildStateCreation(ConstantStreamOp op,
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.filter_state", (!nested_state)>
-static Value buildOpenBody(FilterOp op, RewriterBase &rewriter,
-                           Value initialState,
+static Value buildOpenBody(FilterOp op, OpBuilder &rewriter, Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -518,7 +517,7 @@ static Value buildOpenBody(FilterOp op, RewriterBase &rewriter,
 /// %2 = llvm.insertvalue %1#0, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.filter_state", (!nested_state)>
 static llvm::SmallVector<Value, 4>
-buildNextBody(FilterOp op, RewriterBase &rewriter, Value initialState,
+buildNextBody(FilterOp op, OpBuilder &rewriter, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -600,7 +599,7 @@ buildNextBody(FilterOp op, RewriterBase &rewriter, Value initialState,
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.filter_state", (!nested_state)>
-static Value buildCloseBody(FilterOp op, RewriterBase &rewriter,
+static Value buildCloseBody(FilterOp op, OpBuilder &rewriter,
                             Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -632,7 +631,7 @@ static Value buildCloseBody(FilterOp op, RewriterBase &rewriter,
 /// %2 = llvm.insertvalue %0, %1[0 : index] :
 ///          !llvm.struct<"iterators.filter_state", (!nested_state)>
 static Value buildStateCreation(FilterOp op, FilterOp::Adaptor adaptor,
-                                RewriterBase &rewriter,
+                                OpBuilder &rewriter,
                                 LLVM::LLVMStructType stateType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -653,7 +652,7 @@ static Value buildStateCreation(FilterOp op, FilterOp::Adaptor adaptor,
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.map_state", (!nested_state)>
-static Value buildOpenBody(MapOp op, RewriterBase &rewriter, Value initialState,
+static Value buildOpenBody(MapOp op, OpBuilder &rewriter, Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -710,7 +709,7 @@ static Value buildOpenBody(MapOp op, RewriterBase &rewriter, Value initialState,
 /// %2 = llvm.insertvalue %1#0, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.map_state", (!nested_state)>
 static llvm::SmallVector<Value, 4>
-buildNextBody(MapOp op, RewriterBase &rewriter, Value initialState,
+buildNextBody(MapOp op, OpBuilder &rewriter, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -771,8 +770,7 @@ buildNextBody(MapOp op, RewriterBase &rewriter, Value initialState,
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.map_state", (!nested_state)>
-static Value buildCloseBody(MapOp op, RewriterBase &rewriter,
-                            Value initialState,
+static Value buildCloseBody(MapOp op, OpBuilder &rewriter, Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -802,7 +800,7 @@ static Value buildCloseBody(MapOp op, RewriterBase &rewriter,
 /// %2 = llvm.insertvalue %0, %1[0 : index] :
 ///          !llvm.struct<"iterators.filter_state", (!nested_state)>
 static Value buildStateCreation(MapOp op, MapOp::Adaptor adaptor,
-                                RewriterBase &rewriter,
+                                OpBuilder &rewriter,
                                 LLVM::LLVMStructType stateType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -823,8 +821,7 @@ static Value buildStateCreation(MapOp op, MapOp::Adaptor adaptor,
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
-static Value buildOpenBody(ReduceOp op, RewriterBase &rewriter,
-                           Value initialState,
+static Value buildOpenBody(ReduceOp op, OpBuilder &rewriter, Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -885,7 +882,7 @@ static Value buildOpenBody(ReduceOp op, RewriterBase &rewriter,
 /// %3 = llvm.insertvalue %2#0, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
 static llvm::SmallVector<Value, 4>
-buildNextBody(ReduceOp op, RewriterBase &rewriter, Value initialState,
+buildNextBody(ReduceOp op, OpBuilder &rewriter, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -992,7 +989,7 @@ buildNextBody(ReduceOp op, RewriterBase &rewriter, Value initialState,
 ///          (!nested_state) -> !nested_state
 /// %2 = llvm.insertvalue %1, %arg0[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
-static Value buildCloseBody(ReduceOp op, RewriterBase &rewriter,
+static Value buildCloseBody(ReduceOp op, OpBuilder &rewriter,
                             Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -1024,7 +1021,7 @@ static Value buildCloseBody(ReduceOp op, RewriterBase &rewriter,
 /// %2 = llvm.insertvalue %0, %1[0 : index] :
 ///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
 static Value buildStateCreation(ReduceOp op, ReduceOp::Adaptor adaptor,
-                                RewriterBase &rewriter,
+                                OpBuilder &rewriter,
                                 LLVM::LLVMStructType stateType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -1038,7 +1035,7 @@ static Value buildStateCreation(ReduceOp op, ReduceOp::Adaptor adaptor,
 //===----------------------------------------------------------------------===//
 
 using OpenNextCloseBodyBuilder =
-    llvm::function_ref<llvm::SmallVector<Value, 4>(RewriterBase &, Value)>;
+    llvm::function_ref<llvm::SmallVector<Value, 4>(OpBuilder &, Value)>;
 
 /// Creates a new Open/Next/Close function at the parent module of originalOp
 /// with the given types and name, initializes the function body with a first
@@ -1046,7 +1043,7 @@ using OpenNextCloseBodyBuilder =
 /// are only used by the iterators in this module, they are created with private
 /// visibility.
 static FuncOp
-buildOpenNextCloseInParentModule(Operation *originalOp, RewriterBase &rewriter,
+buildOpenNextCloseInParentModule(Operation *originalOp, OpBuilder &rewriter,
                                  Type inputType, TypeRange returnTypes,
                                  SymbolRefAttr funcNameAttr,
                                  OpenNextCloseBodyBuilder bodyBuilder) {
@@ -1070,22 +1067,18 @@ buildOpenNextCloseInParentModule(Operation *originalOp, RewriterBase &rewriter,
   // Create initial block.
   Block *block =
       builder.createBlock(&funcOp.getBody(), funcOp.begin(), inputType, loc);
-  // XXX(ingomueller): Change to use builder in the whole function once the
-  //                   signature of OpenNextCloseBodyBuilder has changed.
-  OpBuilder::InsertionGuard guardXxxRemoveMe(rewriter);
-  rewriter.setInsertionPointToStart(block);
+  builder.setInsertionPointToStart(block);
 
   // Build body.
   Value initialState = block->getArgument(0);
-  llvm::SmallVector<Value, 4> returnValues =
-      bodyBuilder(rewriter, initialState);
-  rewriter.create<func::ReturnOp>(loc, returnValues);
+  llvm::SmallVector<Value, 4> returnValues = bodyBuilder(builder, initialState);
+  builder.create<func::ReturnOp>(loc, returnValues);
 
   return funcOp;
 }
 
 /// Type-switching proxy for builders of the body of Open functions.
-static Value buildOpenBody(Operation *op, RewriterBase &rewriter,
+static Value buildOpenBody(Operation *op, OpBuilder &builder,
                            Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   return llvm::TypeSwitch<Operation *, Value>(op)
@@ -1097,13 +1090,13 @@ static Value buildOpenBody(Operation *op, RewriterBase &rewriter,
           ReduceOp
           // clang-format on
           >([&](auto op) {
-        return buildOpenBody(op, rewriter, initialState, upstreamInfos);
+        return buildOpenBody(op, builder, initialState, upstreamInfos);
       });
 }
 
 /// Type-switching proxy for builders of the body of Next functions.
 static llvm::SmallVector<Value, 4>
-buildNextBody(Operation *op, RewriterBase &rewriter, Value initialState,
+buildNextBody(Operation *op, OpBuilder &builder, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
   return llvm::TypeSwitch<Operation *, llvm::SmallVector<Value, 4>>(op)
       .Case<
@@ -1114,13 +1107,13 @@ buildNextBody(Operation *op, RewriterBase &rewriter, Value initialState,
           ReduceOp
           // clang-format on
           >([&](auto op) {
-        return buildNextBody(op, rewriter, initialState, upstreamInfos,
+        return buildNextBody(op, builder, initialState, upstreamInfos,
                              elementType);
       });
 }
 
 /// Type-switching proxy for builders of the body of Close functions.
-static Value buildCloseBody(Operation *op, RewriterBase &rewriter,
+static Value buildCloseBody(Operation *op, OpBuilder &builder,
                             Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   return llvm::TypeSwitch<Operation *, Value>(op)
@@ -1132,12 +1125,12 @@ static Value buildCloseBody(Operation *op, RewriterBase &rewriter,
           ReduceOp
           // clang-format on
           >([&](auto op) {
-        return buildCloseBody(op, rewriter, initialState, upstreamInfos);
+        return buildCloseBody(op, builder, initialState, upstreamInfos);
       });
 }
 
 /// Type-switching proxy for builders of iterator state creation.
-static Value buildStateCreation(IteratorOpInterface op, RewriterBase &rewriter,
+static Value buildStateCreation(IteratorOpInterface op, OpBuilder &builder,
                                 LLVM::LLVMStructType stateType,
                                 ValueRange operands) {
   return llvm::TypeSwitch<Operation *, Value>(op)
@@ -1151,7 +1144,7 @@ static Value buildStateCreation(IteratorOpInterface op, RewriterBase &rewriter,
           >([&](auto op) {
         using OpAdaptor = typename decltype(op)::Adaptor;
         OpAdaptor adaptor(operands, op->getAttrDictionary());
-        return buildStateCreation(op, adaptor, rewriter, stateType);
+        return buildStateCreation(op, adaptor, builder, stateType);
       });
 }
 
@@ -1159,7 +1152,7 @@ static Value buildStateCreation(IteratorOpInterface op, RewriterBase &rewriter,
 /// function only does plumbing; the actual work is done by
 /// `buildOpenNextCloseInParentModule` and `buildOpenBody`.
 static FuncOp
-buildOpenFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
+buildOpenFuncInParentModule(Operation *originalOp, OpBuilder &builder,
                             const IteratorInfo &opInfo,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   Type inputType = opInfo.stateType;
@@ -1167,11 +1160,11 @@ buildOpenFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
   SymbolRefAttr funcName = opInfo.openFunc;
 
   return buildOpenNextCloseInParentModule(
-      originalOp, rewriter, inputType, returnType, funcName,
-      [&](RewriterBase &rewriter,
+      originalOp, builder, inputType, returnType, funcName,
+      [&](OpBuilder &builder,
           Value initialState) -> llvm::SmallVector<Value, 4> {
         return {
-            buildOpenBody(originalOp, rewriter, initialState, upstreamInfos)};
+            buildOpenBody(originalOp, builder, initialState, upstreamInfos)};
       });
 }
 
@@ -1179,7 +1172,7 @@ buildOpenFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
 /// function only does plumbing; the actual work is done by
 /// `buildOpenNextCloseInParentModule` and `buildNextBody`.
 static FuncOp
-buildNextFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
+buildNextFuncInParentModule(Operation *originalOp, OpBuilder &builder,
                             const IteratorInfo &opInfo,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   // Compute element type.
@@ -1190,14 +1183,14 @@ buildNextFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
   Type elementType = streamType.getElementType();
 
   // Build function.
-  Type i1 = rewriter.getI1Type();
+  Type i1 = builder.getI1Type();
   Type inputType = opInfo.stateType;
   SymbolRefAttr funcName = opInfo.nextFunc;
 
   return buildOpenNextCloseInParentModule(
-      originalOp, rewriter, inputType, {opInfo.stateType, i1, elementType},
-      funcName, [&](RewriterBase &rewriter, Value initialState) {
-        return buildNextBody(originalOp, rewriter, initialState, upstreamInfos,
+      originalOp, builder, inputType, {opInfo.stateType, i1, elementType},
+      funcName, [&](OpBuilder &builder, Value initialState) {
+        return buildNextBody(originalOp, builder, initialState, upstreamInfos,
                              elementType);
       });
 }
@@ -1206,7 +1199,7 @@ buildNextFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
 /// function only does plumbing; the actual work is done by
 /// `buildOpenNextCloseInParentModule` and `buildCloseBody`.
 static FuncOp
-buildCloseFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
+buildCloseFuncInParentModule(Operation *originalOp, OpBuilder &builder,
                              const IteratorInfo &opInfo,
                              ArrayRef<IteratorInfo> upstreamInfos) {
   Type inputType = opInfo.stateType;
@@ -1214,11 +1207,11 @@ buildCloseFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
   SymbolRefAttr funcName = opInfo.closeFunc;
 
   return buildOpenNextCloseInParentModule(
-      originalOp, rewriter, inputType, returnType, funcName,
-      [&](RewriterBase &rewriter,
+      originalOp, builder, inputType, returnType, funcName,
+      [&](OpBuilder &builder,
           Value initialState) -> llvm::SmallVector<Value, 4> {
         return {
-            buildCloseBody(originalOp, rewriter, initialState, upstreamInfos)};
+            buildCloseBody(originalOp, builder, initialState, upstreamInfos)};
       });
 }
 
@@ -1231,7 +1224,7 @@ buildCloseFuncInParentModule(Operation *originalOp, RewriterBase &rewriter,
 /// state based on the initial states of the upstream iterators and (2) building
 /// the op-specific Open/Next/Close functions.
 static Value convert(IteratorOpInterface op, ValueRange operands,
-                     RewriterBase &rewriter,
+                     OpBuilder &builder,
                      const IteratorAnalysis &iteratorAnalysis) {
   // IteratorInfo for this op.
   IteratorInfo opInfo = iteratorAnalysis.getExpectedIteratorInfo(op);
@@ -1252,13 +1245,13 @@ static Value convert(IteratorOpInterface op, ValueRange operands,
   }
 
   // Build Open/Next/Close functions.
-  buildOpenFuncInParentModule(op, rewriter, opInfo, upstreamInfos);
-  buildNextFuncInParentModule(op, rewriter, opInfo, upstreamInfos);
-  buildCloseFuncInParentModule(op, rewriter, opInfo, upstreamInfos);
+  buildOpenFuncInParentModule(op, builder, opInfo, upstreamInfos);
+  buildNextFuncInParentModule(op, builder, opInfo, upstreamInfos);
+  buildCloseFuncInParentModule(op, builder, opInfo, upstreamInfos);
 
   // Create initial state.
   LLVMStructType stateType = opInfo.stateType;
-  return buildStateCreation(op, rewriter, stateType, operands);
+  return buildStateCreation(op, builder, stateType, operands);
 }
 
 /// Converts the given sink to LLVM using the converted operands from the root
@@ -1287,7 +1280,7 @@ static Value convert(IteratorOpInterface op, ValueRange operands,
 /// }
 /// %5 = call @iterators.reduce.close.1(%4#0) :
 ///          (!root_state_type) -> !root_state_type
-static Value convert(SinkOp op, ValueRange operands, RewriterBase &rewriter,
+static Value convert(SinkOp op, ValueRange operands, OpBuilder &rewriter,
                      const IteratorAnalysis &iteratorAnalysis) {
   Location loc = op->getLoc();
   ImplicitLocOpBuilder builder(loc, rewriter);
@@ -1360,14 +1353,14 @@ static Value convert(SinkOp op, ValueRange operands, RewriterBase &rewriter,
 /// iterator. This function is essentially a switch between conversion functions
 /// for sink and non-sink iterator ops.
 static Value convertIteratorOp(Operation *op, ValueRange operands,
-                               RewriterBase &rewriter,
+                               OpBuilder &builder,
                                const IteratorAnalysis &iteratorAnalysis) {
   return TypeSwitch<Operation *, Value>(op)
       .Case<IteratorOpInterface>([&](auto op) {
-        return convert(op, operands, rewriter, iteratorAnalysis);
+        return convert(op, operands, builder, iteratorAnalysis);
       })
       .Case<SinkOp>([&](auto op) {
-        return convert(op, operands, rewriter, iteratorAnalysis);
+        return convert(op, operands, builder, iteratorAnalysis);
       });
 }
 

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -271,7 +271,7 @@ static Value buildOpenBody(ConstantStreamOp op, RewriterBase &rewriter,
   Attribute zeroAttr = builder.getI32IntegerAttr(0);
   Value zeroValue = builder.create<LLVM::ConstantOp>(i32, zeroAttr);
   Value updatedState =
-      createInsertValueOp(builder, loc, initialState, zeroValue, {0});
+      createInsertValueOp(builder, initialState, zeroValue, {0});
 
   return updatedState;
 }
@@ -319,11 +319,11 @@ static GlobalOp buildGlobalData(ConstantStreamOp op, OpBuilder &rewriter,
       auto value = builder.create<LLVM::ConstantOp>(fieldAttr.value().getType(),
                                                     fieldAttr.value());
       structValue =
-          createInsertValueOp(builder, loc, structValue, value,
+          createInsertValueOp(builder, structValue, value,
                               {static_cast<int64_t>(fieldAttr.index())});
     }
     initValue =
-        createInsertValueOp(builder, loc, initValue, structValue,
+        createInsertValueOp(builder, initValue, structValue,
                             {static_cast<int64_t>(elementAttr.index())});
   }
 
@@ -379,8 +379,7 @@ buildNextBody(ConstantStreamOp op, RewriterBase &rewriter, Value initialState,
   Type i32 = builder.getI32Type();
 
   // Extract current index.
-  Value currentIndex =
-      createExtractValueOp(builder, loc, i32, initialState, {0});
+  Value currentIndex = createExtractValueOp(builder, i32, initialState, {0});
 
   // Test if we have reached the end of the range.
   int64_t numElements = op.value().size();
@@ -400,7 +399,7 @@ buildNextBody(ConstantStreamOp op, RewriterBase &rewriter, Value initialState,
         ArithBuilder ab(b, b.getLoc());
         Value updatedCurrentIndex = ab.add(currentIndex, one);
         Value updatedState =
-            createInsertValueOp(b, loc, initialState, updatedCurrentIndex, {0});
+            createInsertValueOp(b, initialState, updatedCurrentIndex, {0});
 
         // Load element from global data at current index.
         GlobalOp globalArray = buildGlobalData(op, b, elementType);
@@ -471,7 +470,7 @@ static Value buildOpenBody(FilterOp op, RewriterBase &rewriter,
 
   // Extract upstream state.
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Call Open on upstream.
   SymbolRefAttr openFunc = upstreamInfos[0].openFunc;
@@ -480,8 +479,8 @@ static Value buildOpenBody(FilterOp op, RewriterBase &rewriter,
 
   // Update upstream state.
   Value updatedUpstreamState = openCallOp->getResult(0);
-  Value updatedState = createInsertValueOp(builder, loc, initialState,
-                                           updatedUpstreamState, {0});
+  Value updatedState =
+      createInsertValueOp(builder, initialState, updatedUpstreamState, {0});
 
   return updatedState;
 }
@@ -527,13 +526,13 @@ buildNextBody(FilterOp op, RewriterBase &rewriter, Value initialState,
   // Extract upstream state.
   Type upstreamStateType = upstreamInfos[0].stateType;
   Value initialUpstreamState =
-      createExtractValueOp(rewriter, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Main while loop.
   Type i1 = builder.getI1Type();
   SmallVector<Type> nextResultTypes = {upstreamStateType, i1, elementType};
   scf::WhileOp whileOp = scf::createWhileOp(
-      builder, loc, nextResultTypes, initialUpstreamState,
+      builder, nextResultTypes, initialUpstreamState,
       /*beforeBuilder=*/
       [&](OpBuilder &builder, Location loc, Block::BlockArgListType args) {
         ImplicitLocOpBuilder b(loc, builder);
@@ -586,7 +585,7 @@ buildNextBody(FilterOp op, RewriterBase &rewriter, Value initialState,
   // Update state.
   Value finalUpstreamState = whileOp->getResult(0);
   Value finalState =
-      createInsertValueOp(builder, loc, initialState, finalUpstreamState, {0});
+      createInsertValueOp(builder, initialState, finalUpstreamState, {0});
   Value hasNext = whileOp->getResult(1);
   Value nextElement = whileOp->getResult(2);
 
@@ -611,7 +610,7 @@ static Value buildCloseBody(FilterOp op, RewriterBase &rewriter,
 
   // Extract upstream state.
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Call Close on upstream.
   SymbolRefAttr closeFunc = upstreamInfos[0].closeFunc;
@@ -620,8 +619,7 @@ static Value buildCloseBody(FilterOp op, RewriterBase &rewriter,
 
   // Update upstream state.
   Value updatedUpstreamState = closeCallOp->getResult(0);
-  return createInsertValueOp(builder, loc, initialState, updatedUpstreamState,
-                             {0})
+  return createInsertValueOp(builder, initialState, updatedUpstreamState, {0})
       .getResult();
 }
 
@@ -640,7 +638,7 @@ static Value buildStateCreation(FilterOp op, FilterOp::Adaptor adaptor,
   ImplicitLocOpBuilder builder(loc, rewriter);
   Value undefState = builder.create<UndefOp>(stateType);
   Value upstreamState = adaptor.input();
-  return createInsertValueOp(builder, loc, undefState, upstreamState, {0});
+  return createInsertValueOp(builder, undefState, upstreamState, {0});
 }
 
 //===----------------------------------------------------------------------===//
@@ -664,7 +662,7 @@ static Value buildOpenBody(MapOp op, RewriterBase &rewriter, Value initialState,
 
   // Extract upstream state.
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Call Open on upstream.
   SymbolRefAttr openFunc = upstreamInfos[0].openFunc;
@@ -673,8 +671,8 @@ static Value buildOpenBody(MapOp op, RewriterBase &rewriter, Value initialState,
 
   // Update upstream state.
   Value updatedUpstreamState = openCallOp->getResult(0);
-  Value updatedState = createInsertValueOp(builder, loc, initialState,
-                                           updatedUpstreamState, {0});
+  Value updatedState =
+      createInsertValueOp(builder, initialState, updatedUpstreamState, {0});
 
   return updatedState;
 }
@@ -720,7 +718,7 @@ buildNextBody(MapOp op, RewriterBase &rewriter, Value initialState,
   // Extract upstream state.
   Type upstreamStateType = upstreamInfos[0].stateType;
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Extract input element type.
   StreamType inputStreamType = op.input().getType().dyn_cast<StreamType>();
@@ -760,7 +758,7 @@ buildNextBody(MapOp op, RewriterBase &rewriter, Value initialState,
   // Update state.
   Value finalUpstreamState = nextCall.getResult(0);
   Value finalState =
-      createInsertValueOp(builder, loc, initialState, finalUpstreamState, {0});
+      createInsertValueOp(builder, initialState, finalUpstreamState, {0});
 
   return {finalState, hasNext, mappedElement};
 }
@@ -783,7 +781,7 @@ static Value buildCloseBody(MapOp op, RewriterBase &rewriter,
 
   // Extract upstream state.
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Call Close on upstream.
   SymbolRefAttr closeFunc = upstreamInfos[0].closeFunc;
@@ -792,8 +790,7 @@ static Value buildCloseBody(MapOp op, RewriterBase &rewriter,
 
   // Update upstream state.
   Value updatedUpstreamState = closeCallOp->getResult(0);
-  return createInsertValueOp(builder, loc, initialState, updatedUpstreamState,
-                             {0})
+  return createInsertValueOp(builder, initialState, updatedUpstreamState, {0})
       .getResult();
 }
 
@@ -811,7 +808,7 @@ static Value buildStateCreation(MapOp op, MapOp::Adaptor adaptor,
   ImplicitLocOpBuilder builder(loc, rewriter);
   Value undefState = builder.create<UndefOp>(stateType);
   Value upstreamState = adaptor.input();
-  return createInsertValueOp(builder, loc, undefState, upstreamState, {0});
+  return createInsertValueOp(builder, undefState, upstreamState, {0});
 }
 
 //===----------------------------------------------------------------------===//
@@ -836,7 +833,7 @@ static Value buildOpenBody(ReduceOp op, RewriterBase &rewriter,
 
   // Extract upstream state.
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Call Open on upstream.
   SymbolRefAttr openFunc = upstreamInfos[0].openFunc;
@@ -845,8 +842,8 @@ static Value buildOpenBody(ReduceOp op, RewriterBase &rewriter,
 
   // Update upstream state.
   Value updatedUpstreamState = openCallOp->getResult(0);
-  Value updatedState = createInsertValueOp(builder, loc, initialState,
-                                           updatedUpstreamState, {0});
+  Value updatedState =
+      createInsertValueOp(builder, initialState, updatedUpstreamState, {0});
 
   return updatedState;
 }
@@ -896,7 +893,7 @@ buildNextBody(ReduceOp op, RewriterBase &rewriter, Value initialState,
   // Extract upstream state.
   Type upstreamStateType = upstreamInfos[0].stateType;
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Get first result from upstream.
   Type i1 = builder.getI1Type();
@@ -924,7 +921,7 @@ buildNextBody(ReduceOp op, RewriterBase &rewriter, Value initialState,
             elementType        // Element from last next call.
         };
         scf::WhileOp whileOp = scf::createWhileOp(
-            b, loc, whileResultTypes, whileInputs,
+            b, whileResultTypes, whileInputs,
             /*beforeBuilder=*/
             [&](OpBuilder &builder, Location loc,
                 Block::BlockArgListType args) {
@@ -980,7 +977,7 @@ buildNextBody(ReduceOp op, RewriterBase &rewriter, Value initialState,
   // Update state.
   Value finalUpstreamState = ifOp->getResult(0);
   Value finalState =
-      createInsertValueOp(builder, loc, initialState, finalUpstreamState, {0});
+      createInsertValueOp(builder, initialState, finalUpstreamState, {0});
   Value hasNext = ifOp->getResult(1);
   Value nextElement = ifOp->getResult(2);
 
@@ -1005,7 +1002,7 @@ static Value buildCloseBody(ReduceOp op, RewriterBase &rewriter,
 
   // Extract upstream state.
   Value initialUpstreamState =
-      createExtractValueOp(builder, loc, upstreamStateType, initialState, {0});
+      createExtractValueOp(builder, upstreamStateType, initialState, {0});
 
   // Call Close on upstream.
   SymbolRefAttr closeFunc = upstreamInfos[0].closeFunc;
@@ -1014,8 +1011,7 @@ static Value buildCloseBody(ReduceOp op, RewriterBase &rewriter,
 
   // Update upstream state.
   Value updatedUpstreamState = closeCallOp->getResult(0);
-  return createInsertValueOp(builder, loc, initialState, updatedUpstreamState,
-                             {0})
+  return createInsertValueOp(builder, initialState, updatedUpstreamState, {0})
       .getResult();
 }
 
@@ -1034,7 +1030,7 @@ static Value buildStateCreation(ReduceOp op, ReduceOp::Adaptor adaptor,
   ImplicitLocOpBuilder builder(loc, rewriter);
   Value undefState = builder.create<UndefOp>(loc, stateType);
   Value upstreamState = adaptor.input();
-  return createInsertValueOp(builder, loc, undefState, upstreamState, {0});
+  return createInsertValueOp(builder, undefState, upstreamState, {0});
 }
 
 //===----------------------------------------------------------------------===//
@@ -1323,7 +1319,7 @@ static Value convert(SinkOp op, ValueRange operands, RewriterBase &rewriter,
   SmallVector<Location> whileResultLocs = {loc, loc};
 
   scf::WhileOp whileOp = scf::createWhileOp(
-      builder, loc, whileResultTypes, openedUpstreamState,
+      builder, whileResultTypes, openedUpstreamState,
       /*beforeBuilder=*/
       [&](OpBuilder &builder, Location loc, Block::BlockArgListType args) {
         ImplicitLocOpBuilder b(loc, builder);

--- a/experimental/iterators/lib/Utils/MLIRSupport.cpp
+++ b/experimental/iterators/lib/Utils/MLIRSupport.cpp
@@ -10,6 +10,7 @@
 
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/SCF.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 
 using namespace mlir;
 
@@ -41,6 +42,17 @@ scf::WhileOp mlir::scf::createWhileOp(
   return op;
 }
 
+scf::WhileOp mlir::scf::createWhileOp(
+    ImplicitLocOpBuilder &builder, TypeRange resultTypes, ValueRange operands,
+    function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
+        beforeBuilder,
+    function_ref<void(OpBuilder &, Location, Block::BlockArgListType)>
+        afterBuilder,
+    ArrayRef<NamedAttribute> attributes) {
+  return createWhileOp(builder, builder.getLoc(), resultTypes, operands,
+                       beforeBuilder, afterBuilder, attributes);
+}
+
 LLVM::InsertValueOp
 mlir::LLVM::createInsertValueOp(OpBuilder &builder, Location loc,
                                 Value container, Value value,
@@ -53,6 +65,13 @@ mlir::LLVM::createInsertValueOp(OpBuilder &builder, Location loc,
                                              indicesAttr);
 }
 
+LLVM::InsertValueOp
+mlir::LLVM::createInsertValueOp(ImplicitLocOpBuilder &builder, Value container,
+                                Value value, ArrayRef<int64_t> position) {
+  return createInsertValueOp(builder, builder.getLoc(), container, value,
+                             position);
+}
+
 LLVM::ExtractValueOp
 mlir::LLVM::createExtractValueOp(OpBuilder &builder, Location loc, Type res,
                                  Value container, ArrayRef<int64_t> position) {
@@ -61,4 +80,11 @@ mlir::LLVM::createExtractValueOp(OpBuilder &builder, Location loc, Type res,
 
   // Extract from struct.
   return builder.create<LLVM::ExtractValueOp>(loc, res, container, indicesAttr);
+}
+
+LLVM::ExtractValueOp
+mlir::LLVM::createExtractValueOp(ImplicitLocOpBuilder &builder, Type res,
+                                 Value container, ArrayRef<int64_t> position) {
+  return createExtractValueOp(builder, builder.getLoc(), res, container,
+                              position);
 }


### PR DESCRIPTION
This PR implements the suggestion by @nicolasvasilache made [here](https://github.com/iree-org/iree-llvm-sandbox/pull/539#discussion_r944278535) and [here](https://github.com/iree-org/iree-llvm-sandbox/pull/539#issuecomment-1213140850) to use `ImplicitLocOpBuilder` to reduce code verbosity. It also changes the type from `RewriterBase` to `OpBuilder` in the various `build*` functions, since those really just *build* new IR. (The existing IR is modified by generic code outside of those functions.)

While I have no objection against this change, I have to say that I find the gain in readability relatively limited. We need additional lines for every scope with a builder (which are sometimes nested due to the lambda arguments that build the regions of `scf` ops) and then get two builder variables (the one provided by the call site and the one with the implicit location). All of that just to save a few usages of `loc` (whose usage is enforced by the compiler anyways)... But, of course, if this is the convention, I'll happily accept it.

~~This PR depends on (and currently includes) #553.~~