### PR TITLE
Convert function signatures and calls in IteratorsToLLVM.

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_conversion_library(MLIRIteratorsToLLVM
   LINK_LIBS PUBLIC
   IteratorsUtils
   MLIRFuncDialect
+  MLIRFuncTransforms
   MLIRIterators
   MLIRLLVMDialect
   MLIRPass

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/print.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/print.mlir
@@ -2,9 +2,17 @@
 // RUN: mlir-cpu-runner -e main -entry-point-result=void \
 // RUN: | FileCheck %s
 
+func.func @print_empty_tuple(%tuple : tuple<>) -> () {
+  "iterators.printtuple"(%tuple) : (tuple<>) -> ()
+  return
+}
+
 func.func @main() {
   %empty_tuple = "iterators.constanttuple"() { values = [] } : () -> tuple<>
   "iterators.printtuple"(%empty_tuple) : (tuple<>) -> ()
+  // CHECK:      ()
+
+  func.call @print_empty_tuple(%empty_tuple) : (tuple<>) -> ()
   // CHECK:      ()
 
   %one_field_tuple = "iterators.constanttuple"() { values = [1 : i32] } : () -> tuple<i32>


### PR DESCRIPTION
This PR used to be one commit of #553 and should be non-controversial.

It enables type conversion on function signatures and function calls. Eventually, this is is required to pass in pandas DataFrames (in some to-be-defined type) into compiled code.