### PR TITLE
Iterators: [NFC?] Pass TypeConverter through IteratorAnalysis.

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
@@ -15,6 +15,7 @@
 namespace mlir {
 class ModuleOp;
 class Operation;
+class TypeConverter;
 
 namespace iterators {
 
@@ -55,7 +56,7 @@ class IteratorAnalysis {
   using OperationMap = llvm::DenseMap<Operation *, IteratorInfo>;
 
 public:
-  explicit IteratorAnalysis(Operation *rootOp);
+  explicit IteratorAnalysis(Operation *rootOp, TypeConverter &typeConverter);
 
   /// Returns the operation this analysis was constructed from.
   Operation *getRootOperation() const { return rootOp; }

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -1401,7 +1401,7 @@ static Value convertIteratorOp(Operation *op, ValueRange operands,
 ///    (which it has walked before) to the conversion logic.
 static void convertIteratorOps(ModuleOp module, TypeConverter &typeConverter) {
   IRRewriter rewriter(module.getContext());
-  IteratorAnalysis analysis(module);
+  IteratorAnalysis analysis(module, typeConverter);
   BlockAndValueMapping mapping;
 
   // Collect all iterator ops in a worklist. Within each block, the iterator


### PR DESCRIPTION
This PR used to be part of #553 and should be non-controversial. It extends the `IteratorAnalysis` class and related functions with a `TypeConverter` member/argument such that that type converter can be used when computing the type of an iterator state (which is one of the main tasks of the analysis).