### PR TITLE
[doc] Iterators: Create new top-level README with motivation and background.

### DIFF
--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -148,9 +148,9 @@ A few related but distinct concepts deserve a short discussion:
   (which seems to be the more common usage of simply `generator`) or
   [`generator iterator`](https://docs.python.org/3/glossary.html#term-generator-iterator).
   In short, the former is a function that returns the latter.
-  In more detail, an `iterator function` is a function with a `yield` statement,
-  which, therefor, returns an object of the built-in type `generator` -- a class
-  that implements the `iterator` interface. Similarly, a
+  In more detail, a `generator function` is a function with a `yield` statement,
+  which, therefore, returns an object of the built-in type `generator` -- a
+  class that implements the `iterator` interface. Similarly, a
   [`generator expression`](https://docs.python.org/3/glossary.html#term-generator-expression)
   (such as `i*i for i in range(10)`) is a language construct that, like
   `generator function`s, returns an object of the built-in type `generator`
@@ -169,7 +169,7 @@ consumes the streams from its zero or more "upstream" iterators to do so --
 without knowing anything about its upstream and downstream iterators. This helps
 isolating the control flow of each iterator, which may be complex, as well as
 its state. Like in Python, the iterator interface also allows for interleaved
-execution of many different computation steps py passing data *and* control:
+execution of many different computation steps by passing data *and* control:
 when one iterator asks its upstream iterator for the next element, it passes
 control to that iterator, which returns the control together with the next
 element. By limiting the number of in-flight elements to essentially one, this
@@ -181,7 +181,7 @@ this model, see [Graefe'90](https://doi.org/10.1145/93605.98720)). Conceptually,
 the model is the same as those of Python's iterators; however, the communication
 protocol between iterators is slightly different. Concretely, it defines that
 each iterator class should have the functions `open`, `next`, and `close` (and
-is therefor sometimes called "open/next/close" interface). Computations are
+is therefore sometimes called "open/next/close" interface). Computations are
 expressed as a tree of such iterators. The computation is initialized by calling
 `open` on the root iterator, which typically calls `open` on its child
 iterators, such that the whole tree is initialized recursively. The computation
@@ -231,7 +231,7 @@ Relational database systems manage *relations*. A relation is a bag (i.e.,
 multiset) of *tuples* (or *records*). (Textbooks often define relations as
 *sets* but practical systems use bag-based relational algebra, or even
 sequence-based or mixed algebras in order to support order-sensitive operations
-such as window functions.) A record is collection of named and typed
+such as window functions.) A record is a collection of named and typed
 *attributes* (or *fields* or, depending on the context, *columns*). Attributes
 may be *nullable* (read: optional), i.e., they may contain a value of a
 particular type or the special value *null* indicating the absence of a value.

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -1,0 +1,146 @@
+# Iterators dialect for MLIR
+
+This folder contains an MLIR dialect based on the concepts of database-style
+itertors, which allow to express computations on streams of data.
+
+## Motivation
+
+Database systems (both relational and non-relational) often implement
+domain-specific compilers for high-level optimizations of their user programs
+(or "queries") and, increasingly so, use JIT-compilers to reduce runtime
+overheads. While this seems to make MLIR a good framework for implementing the
+compilers of these systems, computations of their domains have some properties
+that MLIR is currently unprepared for. This dialect is a first step to bridge
+that gap: its goal is to implement database-style "iterators," which database
+systems typically use in their execution layer.
+
+## Background
+
+### Analogy to Iterators in Python
+
+Python's concept of [iterators](https://docs.python.org/3/glossary.html#term-iterator)
+is very similar to that of the database-style iterators that this project is
+targeting. The subsequent explains Python iterators in order to establish
+fundamental concepts and terminology in a context that is familiar to many
+readers.
+
+Python's iterators allow to work with sequences of values without materializing
+these sequences. This allows to (1) save memory for storing the entire sequence,
+which may allow to do computations that would otherwise exceed the main memory,
+(2) avoid computing values in the sequence that are never used, (3) as a
+concequence, work with inifite sequences, and (4) improve cache efficiency
+because the consumer of the values of a sequence is interleaved with the
+producer of that sequence.
+
+Consider the following example:
+
+```python3
+from itertools import *
+for x in islice(count(10, 2), 3):
+  print(x)
+# Output:
+# 10
+# 12
+# 14
+```
+
+Note that
+[`count`](https://docs.python.org/3/library/itertools.html#itertools.count)
+produces an infinite sequence -- it starts counting at the number given by first
+argument (and the increment given as the second) -- but
+[`islice`](https://docs.python.org/3/library/itertools.html#itertools.islice)
+only consumes the first 3 values of it (as instructed to by its second
+argument).
+
+Formally, an [iterator](https://docs.python.org/3/glossary.html#term-iterator)
+in Python is simply an object with a `__next__()` function, which, when called
+repeatedly, return the values of the sequence defined by the iterator (and an
+`__iter__()` function, which allows to use the iterator wherever an
+[`iterable`](https://docs.python.org/3/glossary.html#term-iterable) is needed).
+Consider the following class, which fulfills this requirement:
+
+```python3
+class CountToThree:
+  def __init__(self):
+    self.i = 0
+  def __next__(self):
+    if self.i == 3:
+      raise StopIteration
+    self.i += 1
+    return self.i
+  def __iter__(self):
+    return self
+
+for i in CountToThree():
+  print(i)
+
+# Output:
+# 1
+# 2
+# 3
+```
+
+What is happening behind the scenes is that the `for` loop takes an instances of
+the class `CountToThree`, calls `__iter__()` on that instance (which is required
+to be an `iterable`) in order to obtain an `iterator`, and then calls
+`__next__()` on that `iterator` until a `StopIteration` exceptions indicates the
+end of the sequence, binding each resulting value to the loop variable. This
+roughly corresponds to:
+
+```python3
+iterable = CountToThree()
+iterator = iterable.__iter__()
+print(iterator.__next__()) # Outputs: 1
+print(iterator.__next__()) # Outputs: 2
+print(iterator.__next__()) # Outputs: 3
+print(iterator.__next__()) # Raises: StopIteration
+```
+
+One property that makes iterators in Python so powerful is that they are
+composable. Many
+[built-in functions](https://docs.python.org/3/library/functions.html) (such as
+`enumerate`, `filter`, `map`, etc.) and standard library functions (most notably
+those defined in
+[`itertools`](https://docs.python.org/3/library/itertools.html)) accept
+arguments of type `iterable` and produce again results that are `iterable`.
+I/O is also often done with `iterable` objects (for example, via
+[`IOBase`](https://docs.python.org/3/library/io.html#io.IOBase)).
+
+Consider the following example, which computes the maximum length of a line with
+an even number of characters of all lines in a given text file:
+
+```python3
+max(
+  filter(lambda x: x % 2 == 0,
+         map(lambda x: len(x),
+             open('file.txt'))))
+```
+
+Each of the functions `max`, `filter`, `map`, and `open` either accepts or
+produces an `iterator` object (or both). The result of the three inner-most
+function is an `iterator` object that has two more `iterator` objects
+recursively nested insise of them. That object is given to `max`, which drives
+the computation by calling `__next__()` repeatably on that object, which, in
+turn, causes a cascade of calls to `__next__()` of the nested `iterator`
+objects. Since the state in each `iterator` object and the number of values
+passed between them is constant, the above example essentially works on
+arbitrarily large files.
+
+### Iterators in Database Systems
+
+Database systems (both relational and non-relational) typically express their
+computations as transformations of streams of data in order to reduce data
+movement between slow and fast memory (e.g., between DRAM and CPU cache).
+Transformations are typically made composable through an "iterator" interface:
+Each iterator produces a stream of data that can be consumed "downstream" one
+element at a time, and, in turn, consumes the streams from its zero or more
+"upstream" iterators to do so -- without knowing anything about its upstream and
+downstream iterators. Each iterator may have complex control flow logic, often
+depending on the data that it consumes, and can manage its own state. The
+iterator interface, thus, passes data *and* control: when one iterator asks its
+upstream iterator for the next element, it passes control to that iterator,
+which returns the control together with the next element. By limiting the number
+of in-flight elements to essentially one, this minimizes the overall state and
+thus data movement.
+
+TODO(ingomueller): explain Volcano iterator interface

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -159,17 +159,19 @@ A few related but distinct concepts deserve a short discussion:
 
 Database systems (both relational and non-relational) typically express their
 computations as transformations of streams of data in order to reduce data
-movement between slow and fast memory (e.g., between DRAM and CPU cache).
-Transformations are typically made composable through an "iterator" interface:
-Each iterator produces a stream of data that can be consumed "downstream" one
-element at a time, and, in turn, consumes the streams from its zero or more
-"upstream" iterators to do so -- without knowing anything about its upstream and
-downstream iterators. Each iterator may have complex control flow logic, often
-depending on the data that it consumes, and can manage its own state. The
-iterator interface, thus, passes data *and* control: when one iterator asks its
-upstream iterator for the next element, it passes control to that iterator,
-which returns the control together with the next element. By limiting the number
-of in-flight elements to essentially one, this minimizes the overall state and
-thus data movement.
+movement between slow and fast memory (e.g., between DRAM and CPU cache). They
+typically do so with "iterators" that are quite similar to those in Python, and
+pretty much for the same reason. First, having all transformations implement
+some iterator interface makes them composable: Each iterator produces a stream
+of data that can be consumed "downstream" one element at a time, and, in turn,
+consumes the streams from its zero or more "upstream" iterators to do so --
+without knowing anything about its upstream and downstream iterators. This helps
+isolating the control flow of each iterator, which may be complex, as well as
+its state. Like in Python, the iterator interface also allows for interleaved
+execution of many different computations steps py passing data *and* control:
+when one iterator asks its upstream iterator for the next element, it passes
+control to that iterator, which returns the control together with the next
+element. By limiting the number of in-flight elements to essentially one, this
+minimizes the overall state and thus data movement.
 
 TODO(ingomueller): explain Volcano iterator interface

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -24,6 +24,8 @@ targeting. The subsequent explains Python iterators in order to establish
 fundamental concepts and terminology in a context that is familiar to many
 readers.
 
+#### Motivation
+
 Python's iterators allow to work with sequences of values without materializing
 these sequences. This allows to (1) save memory for storing the entire sequence,
 which may allow to do computations that would otherwise exceed the main memory,
@@ -51,6 +53,8 @@ argument (and the increment given as the second) -- but
 [`islice`](https://docs.python.org/3/library/itertools.html#itertools.islice)
 only consumes the first 3 values of it (as instructed to by its second
 argument).
+
+#### Definition of `iterator`
 
 Formally, an [iterator](https://docs.python.org/3/glossary.html#term-iterator)
 in Python is simply an object with a `__next__()` function, which, when called
@@ -96,6 +100,8 @@ print(iterator.__next__()) # Outputs: 3
 print(iterator.__next__()) # Raises: StopIteration
 ```
 
+#### Composability
+
 One property that makes iterators in Python so powerful is that they are
 composable. Many
 [built-in functions](https://docs.python.org/3/library/functions.html) (such as
@@ -125,6 +131,29 @@ turn, causes a cascade of calls to `__next__()` of the nested `iterator`
 objects. Since the state in each `iterator` object and the number of values
 passed between them is constant, the above example essentially works on
 arbitrarily large files.
+
+#### Distinction to Related Concepts
+
+A few related but distinct concepts deserve a short discussion:
+
+* `iterable`: As mentioned before, `iterable`s in Python are things than can be
+  iterated over (such as containers like `list`s, `tuple`s, etc) while
+  `iterator`s are objects that help with that iteration. `iterable`s provide
+  `iterator`s via their `__iter__()` function. The `for` loop uses that function
+  to get an `iterator`, and uses that in turn to iterate. Confusion may arise
+  because `iterator`s *are* also `iterable` (in order to make `iterator`s usable
+  in `for` loops).
+* `generator`: This term is actually ambiguous; it may refer to
+  [`generator function`](https://docs.python.org/3/glossary.html#term-generator)
+  (which seems to be the more common usage of simply `generator`) or
+  [`generator iterator`](https://docs.python.org/3/glossary.html#term-generator-iterator).
+  In short, the former is a function that returns the latter.
+  In more detail, an `iterator function` is a function with a `yield` statement,
+  which, therefor, returns an object of the builtin type `generator` -- a class
+  that implements the `iterator` interface. Similarly, a
+  [`generator expression`](https://docs.python.org/3/glossary.html#term-generator-expression)
+  (such as `i*i for i in range(10)`) is a language construct that, like
+  `generator function`s returns an object of the built-in type `generator`.
 
 ### Iterators in Database Systems
 

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -1,7 +1,7 @@
 # Iterators dialect for MLIR
 
 This folder contains an MLIR dialect based on the concepts of database-style
-itertors, which allow to express computations on streams of data.
+iterators, which allow to express computations on streams of data.
 
 ## Motivation
 
@@ -28,7 +28,7 @@ Python's iterators allow to work with sequences of values without materializing
 these sequences. This allows to (1) save memory for storing the entire sequence,
 which may allow to do computations that would otherwise exceed the main memory,
 (2) avoid computing values in the sequence that are never used, (3) as a
-concequence, work with inifite sequences, and (4) improve cache efficiency
+consequence, work with infinite sequences, and (4) improve cache efficiency
 because the consumer of the values of a sequence is interleaved with the
 producer of that sequence.
 

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -176,23 +176,23 @@ minimizes the overall state and thus data movement.
 
 Iterators in database systems are often implemented with some variant of the
 so-called "Volcano" iterator model (named after the system that first proposed
-this model, se [Graefe'90](https://dl.acm.org/doi/abs/10.1145/93605.98720)).
-Conceptually, the model is the same as those of Python's iterators; however, the
-communication protocol between iterators is slightly different. Concretely, it
-defines that each iterator class should have the functions `open`, `next`, and
-`close` (and is therefor sometimes called "open/next/close" iterface).
-Computations are expressed as a tree of such iterators. The computation is
-initialized by calling `open` on the root iterator, which typically calls `open`
-on its child iterators, such that the whole tree is initialized recursively. The
-computation is then driven by calling `next` repeatedly on the root, each call
-producing one element of the result until all of them have been produced. Each
-call to `next` on the root typically triggers a cascade of `next` calls in the
-tree (but how many calls are required in each of the iterators depends on those
-iterators, their current state, and the input they are consuming). After a call
-to `next` has signaled the end of the result stream, or when the system or user
-wants to abort the computation, the `close` function of the root iterator is
-called, which recursively calls `close` on its children, all of which clean up
-any state they may have.
+this model, se [Graefe'90](https://doi.org/10.1145/93605.98720)). Conceptually,
+the model is the same as those of Python's iterators; however, the communication
+protocol between iterators is slightly different. Concretely, it defines that
+each iterator class should have the functions `open`, `next`, and `close` (and
+is therefor sometimes called "open/next/close" iterface). Computations are
+expressed as a tree of such iterators. The computation is initialized by calling
+`open` on the root iterator, which typically calls `open` on its child
+iterators, such that the whole tree is initialized recursively. The computation
+is then driven by calling `next` repeatedly on the root, each call producing one
+element of the result until all of them have been produced. Each call to `next`
+on the root typically triggers a cascade of `next` calls in the tree (but how
+many calls are required in each of the iterators depends on those iterators,
+their current state, and the input they are consuming). After a call to `next`
+has signaled the end of the result stream, or when the system or user wants to
+abort the computation, the `close` function of the root iterator is called,
+which recursively calls `close` on its children, all of which clean up any state
+they may have.
 
 The [`examples/database-iterators-standalone`](examples/database-iterators-standalone)
 folder contains a standalone project that implements the open/next/close

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -132,7 +132,7 @@ objects. Since the state in each `iterator` object and the number of values
 passed between them is constant, the above example essentially works on
 arbitrarily large files.
 
-#### Distinction to Related Concepts
+#### Distinction to Related Concepts in Python
 
 A few related but distinct concepts deserve a short discussion:
 
@@ -153,7 +153,7 @@ A few related but distinct concepts deserve a short discussion:
   that implements the `iterator` interface. Similarly, a
   [`generator expression`](https://docs.python.org/3/glossary.html#term-generator-expression)
   (such as `i*i for i in range(10)`) is a language construct that, like
-  `generator function`s returns an object of the built-in type `generator`.
+  `generator function`s, returns an object of the built-in type `generator`.
 
 ### Iterators in Database Systems
 
@@ -168,7 +168,7 @@ consumes the streams from its zero or more "upstream" iterators to do so --
 without knowing anything about its upstream and downstream iterators. This helps
 isolating the control flow of each iterator, which may be complex, as well as
 its state. Like in Python, the iterator interface also allows for interleaved
-execution of many different computations steps py passing data *and* control:
+execution of many different computation steps py passing data *and* control:
 when one iterator asks its upstream iterator for the next element, it passes
 control to that iterator, which returns the control together with the next
 element. By limiting the number of in-flight elements to essentially one, this
@@ -176,22 +176,23 @@ minimizes the overall state and thus data movement.
 
 Iterators in database systems are often implemented with some variant of the
 so-called "Volcano" iterator model (named after the system that first proposed
-this model). Conceptually, the model is the same as those of Python's iterators;
-however, the communication protocol between iterators is slightly different.
-Concretely, it defines that each iterator class should have the functions
-`open`, `next`, and `close` (and is therefor sometimes called "open/next/close"
-iterface). Computations are expressed as a tree of such iterators. The
-computation is initialized by calling `open` on the root iterator, which
-typically calls `open` on its child iterators, such that the whole tree is
-initialized recursively. The computation is then driven by calling `next`
-repeatedly on the root, each call producing one element of the result until all
-of them have been produced. Each call to `next` on the root typically triggers
-a cascade of `next` calls in the tree (but how many calls are required in each
-of the iterators depends on those iterators, their current state, and the input
-they are consuming). After a call to `next` has signaled the end of the result
-stream, or when the system or user wants to abort the computation, the `close`
-function of the root iterator is called, which recursively calls `close` on its
-children, all of which clean up any state they may have.
+this model, se [Graefe'90](https://dl.acm.org/doi/abs/10.1145/93605.98720)).
+Conceptually, the model is the same as those of Python's iterators; however, the
+communication protocol between iterators is slightly different. Concretely, it
+defines that each iterator class should have the functions `open`, `next`, and
+`close` (and is therefor sometimes called "open/next/close" iterface).
+Computations are expressed as a tree of such iterators. The computation is
+initialized by calling `open` on the root iterator, which typically calls `open`
+on its child iterators, such that the whole tree is initialized recursively. The
+computation is then driven by calling `next` repeatedly on the root, each call
+producing one element of the result until all of them have been produced. Each
+call to `next` on the root typically triggers a cascade of `next` calls in the
+tree (but how many calls are required in each of the iterators depends on those
+iterators, their current state, and the input they are consuming). After a call
+to `next` has signaled the end of the result stream, or when the system or user
+wants to abort the computation, the `close` function of the root iterator is
+called, which recursively calls `close` on its children, all of which clean up
+any state they may have.
 
 The [`examples/database-iterators-standalone`](examples/database-iterators-standalone)
 folder contains a standalone project that implements the open/next/close

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -174,4 +174,25 @@ control to that iterator, which returns the control together with the next
 element. By limiting the number of in-flight elements to essentially one, this
 minimizes the overall state and thus data movement.
 
-TODO(ingomueller): explain Volcano iterator interface
+Iterators in database systems are often implemented with some variant of the
+so-called "Volcano" iterator model (named after the system that first proposed
+this model). Conceptually, the model is the same as those of Python's iterators;
+however, the communication protocol between iterators is slightly different.
+Concretely, it defines that each iterator class should have the functions
+`open`, `next`, and `close` (and is therefor sometimes called "open/next/close"
+iterface). Computations are expressed as a tree of such iterators. The
+computation is initialized by calling `open` on the root iterator, which
+typically calls `open` on its child iterators, such that the whole tree is
+initialized recursively. The computation is then driven by calling `next`
+repeatedly on the root, each call producing one element of the result until all
+of them have been produced. Each call to `next` on the root typically triggers
+a cascade of `next` calls in the tree (but how many calls are required in each
+of the iterators depends on those iterators, their current state, and the input
+they are consuming). After a call to `next` has signaled the end of the result
+stream, or when the system or user wants to abort the computation, the `close`
+function of the root iterator is called, which recursively calls `close` on its
+children, all of which clean up any state they may have.
+
+The [`examples/database-iterators-standalone`](examples/database-iterators-standalone)
+folder contains a standalone project that implements the open/next/close
+interface using C++ templates for illustration purposes.

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -244,8 +244,8 @@ The closest equivalent to a relation in Python is arguably a
 where `TupleType` is some type based on
 [`NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple),
 e.g., `NamedTuple('Employee', [('name', Optional[str]), ('id', int)])`. One
-inaccuracy in this analogy its the fact (bag-based) relations do not specify an
-order of their tuples while `List` does. Another inaccuracy is the fact that
+inaccuracy in this analogy is the fact that (bag-based) relations do not specify
+an order of their tuples while `List` does. Another inaccuracy is the fact that
 `NamedTuple` specifies a name for the tuple type whereas this isn't (always) the
 case in the relational model. Also, `NamedTuple` allows ordered access to the
 fields whereas the field order does not play any role in the relational model

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -218,3 +218,49 @@ degree, the [C++ template project](examples/database-iterators-standalone)
 mentioned above achieves this by relying on the C++ compiler to inline templated
 function calls; another widespread technique is to produce LLVM IR one way or
 the other.
+
+### The Relational Data Model
+
+We briefly review the data model of (relational) database systems. To a large
+degree, iterators seem orthogonal to the elements they iterate over but whether
+or not and how we should achieve this orthogonality may require some discussion,
+so reviewing the data model here may be useful.
+
+Relational database systems manage *relations*. A relation is a bag (i.e.,
+multiset) of *tuples* (or *records*). (Textbooks often define relations as
+*sets* but practical systems use on bag-based relational algebra, or even
+sequence-based or mixed algebras in order to support order-sensitive operations
+such as window functions.) A record is collection of named and typed
+*attributes* (or *fields* or, depending on the context, *columns*). Attributes
+may be *nullable* (read: optional), i.e., they may contain a value of a
+particular type or the special value *null* indicating the absence of a value.
+In the plain relational model, attributes are atomic values (numbers, strings,
+etc); in nested relational algebra, an attribute may be of a relation type or a
+tuple type.
+
+The closest equivalent to a relation in Python is arguably a
+[`List[TupleType]`](https://docs.python.org/3/library/typing.html#typing.List),
+where `TupleType` is some type based on
+[`NamedTuple`](https://docs.python.org/3/library/typing.html#typing.NamedTuple),
+e.g., `NamedTuple('Employee', [('name', Optional[str]), ('id', int)])`. One
+inaccuracy in this analogy its the fact (bag-based) relations do not specify an
+order of their tuples while `List` does. Another inaccuracy is the fact that
+`NamedTuple` specifies a name for the tuple type whereas this isn't (always) the
+case in the relational model. Also, `NamedTuple` allows ordered access to the
+fields whereas the field order does not play any role in the relational model
+(though it does play a role in SQL, most notably for `UNION` and similar).
+
+Another way to look at relations is to think of them as *tables*: each tuple
+represents one row of the table and the corresponding attribute values of
+different rows represent a column. The values in each column have the same type.
+Again, this analogy is inaccurate in that it implies an order of the rows and
+columns.
+
+Relations, thus, have a certain similarity to matrices: they are also
+two-dimensional and can be thought of in terms of rows and columns. However,
+(1) only columns have values of the same type, whereas the values of one row
+generally don't, (2) at least on the highest-level of abstraction (and modulo
+the sequence-based relational model), neither the order of the rows nor that of
+the columns matter, (3) the elements of relations may be strings or similar
+variable-length data types, and (4) nested relational algebra also allows for
+structured element types (which may have variable length).

--- a/experimental/iterators/README.md
+++ b/experimental/iterators/README.md
@@ -124,13 +124,13 @@ max(
 
 Each of the functions `max`, `filter`, `map`, and `open` either accepts or
 produces an `iterator` object (or both). The result of the three inner-most
-function is an `iterator` object that has two more `iterator` objects
-recursively nested insise of them. That object is given to `max`, which drives
-the computation by calling `__next__()` repeatably on that object, which, in
-turn, causes a cascade of calls to `__next__()` of the nested `iterator`
-objects. Since the state in each `iterator` object and the number of values
-passed between them is constant, the above example essentially works on
-arbitrarily large files.
+functions is an `iterator` object that has two more `iterator` objects
+recursively nested inside of it. That object is given to `max`, which drives the
+computation by calling `__next__()` repeatably on that object, which, in turn,
+causes a cascade of calls to `__next__()` of the nested `iterator` objects.
+Since the state in each `iterator` object and the number of values passed
+between them is constant, the above example essentially works on arbitrarily
+large files.
 
 #### Distinction to Related Concepts in Python
 
@@ -149,11 +149,12 @@ A few related but distinct concepts deserve a short discussion:
   [`generator iterator`](https://docs.python.org/3/glossary.html#term-generator-iterator).
   In short, the former is a function that returns the latter.
   In more detail, an `iterator function` is a function with a `yield` statement,
-  which, therefor, returns an object of the builtin type `generator` -- a class
+  which, therefor, returns an object of the built-in type `generator` -- a class
   that implements the `iterator` interface. Similarly, a
   [`generator expression`](https://docs.python.org/3/glossary.html#term-generator-expression)
   (such as `i*i for i in range(10)`) is a language construct that, like
-  `generator function`s, returns an object of the built-in type `generator`.
+  `generator function`s, returns an object of the built-in type `generator`
+  (which is an iterator).
 
 ### Iterators in Database Systems
 
@@ -161,7 +162,7 @@ Database systems (both relational and non-relational) typically express their
 computations as transformations of streams of data in order to reduce data
 movement between slow and fast memory (e.g., between DRAM and CPU cache). They
 typically do so with "iterators" that are quite similar to those in Python, and
-pretty much for the same reason. First, having all transformations implement
+pretty much for the same reasons. First, having all transformations implement
 some iterator interface makes them composable: Each iterator produces a stream
 of data that can be consumed "downstream" one element at a time, and, in turn,
 consumes the streams from its zero or more "upstream" iterators to do so --
@@ -176,11 +177,11 @@ minimizes the overall state and thus data movement.
 
 Iterators in database systems are often implemented with some variant of the
 so-called "Volcano" iterator model (named after the system that first proposed
-this model, se [Graefe'90](https://doi.org/10.1145/93605.98720)). Conceptually,
+this model, see [Graefe'90](https://doi.org/10.1145/93605.98720)). Conceptually,
 the model is the same as those of Python's iterators; however, the communication
 protocol between iterators is slightly different. Concretely, it defines that
 each iterator class should have the functions `open`, `next`, and `close` (and
-is therefor sometimes called "open/next/close" iterface). Computations are
+is therefor sometimes called "open/next/close" interface). Computations are
 expressed as a tree of such iterators. The computation is initialized by calling
 `open` on the root iterator, which typically calls `open` on its child
 iterators, such that the whole tree is initialized recursively. The computation
@@ -221,14 +222,14 @@ the other.
 
 ### The Relational Data Model
 
-We briefly review the data model of (relational) database systems. To a large
+We briefly review the data model of relational database systems. To a large
 degree, iterators seem orthogonal to the elements they iterate over but whether
 or not and how we should achieve this orthogonality may require some discussion,
 so reviewing the data model here may be useful.
 
 Relational database systems manage *relations*. A relation is a bag (i.e.,
 multiset) of *tuples* (or *records*). (Textbooks often define relations as
-*sets* but practical systems use on bag-based relational algebra, or even
+*sets* but practical systems use bag-based relational algebra, or even
 sequence-based or mixed algebras in order to support order-sensitive operations
 such as window functions.) A record is collection of named and typed
 *attributes* (or *fields* or, depending on the context, *columns*). Attributes


### PR DESCRIPTION
This PR creates a new top-level README file for the Iterators project. It currently provides a high-level motivation as well as some background on database-style iterators and an analogy of those to Python's iterators.

This is certainly not complete but maybe it is worth making a first reviewing pass to make sure it's going into the right direction.