### PR TITLE
Iterators: Lift restrictions on stream types

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -253,10 +253,10 @@ def Iterators_ReduceOp : Iterators_Op<"reduce",
     ```
   }];
   let arguments = (ins
-      Iterators_StreamOfLLVMStructOfNumerics:$input,
+      Iterators_Stream:$input,
       Iterators_ReduceFunctionSymbol:$reduceFuncRef
     );
-  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let results = (outs Iterators_Stream:$result);
   let extraClassDeclaration = [{
     func::FuncOp getReduceFunc() {
       return SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -195,10 +195,10 @@ def Iterators_MapOp : Iterators_Op<"map",
     ```
   }];
   let arguments = (ins
-      Iterators_StreamOfLLVMStructOfNumerics:$input,
+      Iterators_Stream:$input,
       Iterators_MapFunctionSymbol:$mapFuncRef
     );
-  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let results = (outs Iterators_Stream:$result);
   let extraClassDeclaration = [{
     func::FuncOp getMapFunc() {
       return SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -144,10 +144,10 @@ def Iterators_FilterOp : Iterators_Op<"filter",
     ```
   }];
   let arguments = (ins
-      Iterators_StreamOfLLVMStructOfNumerics:$input,
+      Iterators_Stream:$input,
       Iterators_PredicateFunctionSymbol:$predicateRef
     );
-  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let results = (outs Iterators_Stream:$result);
   let extraClassDeclaration = [{
     func::FuncOp getPredicate() {
       return SymbolTable::lookupNearestSymbolFrom<func::FuncOp>(

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
@@ -5,23 +5,62 @@
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \
 // RUN: | FileCheck %s
 
-!element_type = !llvm.struct<(i32)>
+!i32_struct = !llvm.struct<(i32)>
 
-func.func private @is_positive_struct(%struct : !element_type) -> i1 {
-  %i = llvm.extractvalue %struct[0 : index] : !element_type
+func.func private @is_positive_struct(%struct : !i32_struct) -> i1 {
+  %i = llvm.extractvalue %struct[0 : index] : !i32_struct
   %zero = arith.constant 0 : i32
   %cmp = arith.cmpi "sgt", %i, %zero : i32
   return %cmp : i1
 }
 
-func.func @main() {
+func.func @filter_is_positive_struct() {
   %input = "iterators.constantstream"()
     { value = [[0: i32], [1: i32], [-1: i32], [2: i32], [-2: i32]] }
-    : () -> (!iterators.stream<!element_type>)
-  %filter = "iterators.filter"(%input) {predicateRef = @is_positive_struct}
-    : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  "iterators.sink"(%filter) : (!iterators.stream<!element_type>) -> ()
+    : () -> (!iterators.stream<!i32_struct>)
+  %filtered = "iterators.filter"(%input) {predicateRef = @is_positive_struct}
+    : (!iterators.stream<!i32_struct>) -> (!iterators.stream<!i32_struct>)
+  "iterators.sink"(%filtered) : (!iterators.stream<!i32_struct>) -> ()
   // CHECK:      (1)
   // CHECK-NEXT: (2)
+  return
+}
+
+func.func private @is_positive_i32(%i : i32) -> i1 {
+  %zero = arith.constant 0 : i32
+  %cmp = arith.cmpi "sgt", %i, %zero : i32
+  return %cmp : i1
+}
+
+func.func private @unpack_i32(%input : !i32_struct) -> i32 {
+  %i = llvm.extractvalue %input[0 : index] : !i32_struct
+  return %i : i32
+}
+
+func.func private @pack_i32(%input : i32) -> !i32_struct {
+  %undef = llvm.mlir.undef : !i32_struct
+  %result =  llvm.insertvalue %input, %undef[0 : index] : !i32_struct
+  return %result : !i32_struct
+}
+
+func.func @filter_is_positive_i32() {
+  %input = "iterators.constantstream"()
+    { value = [[0: i32], [2: i32], [-2: i32], [4: i32], [-4: i32]] }
+    : () -> (!iterators.stream<!i32_struct>)
+  %unpacked = "iterators.map"(%input) {mapFuncRef = @unpack_i32}
+    : (!iterators.stream<!i32_struct>) -> (!iterators.stream<i32>)
+  %filtered = "iterators.filter"(%unpacked) {predicateRef = @is_positive_i32}
+    : (!iterators.stream<i32>) -> (!iterators.stream<i32>)
+  %repacked = "iterators.map"(%filtered) {mapFuncRef = @pack_i32}
+    : (!iterators.stream<i32>) -> (!iterators.stream<!i32_struct>)
+  "iterators.sink"(%repacked) : (!iterators.stream<!i32_struct>) -> ()
+  // CHECK:      (2)
+  // CHECK-NEXT: (4)
+  return
+}
+
+func.func @main() {
+  call @filter_is_positive_struct() : () -> ()
+  call @filter_is_positive_i32() : () -> ()
   return
 }


### PR DESCRIPTION
This PR lifts the restriction on the element types of the streams consumed and produced by the `MapOp`, `FilterOp`, and `ReduceOp`. This did not require any change in the compiler; I really only loosened the constraints and added test cases.

This is in line with the discussion of the iterator concepts added in #570, which says that iterator ops should work on streams of arbitrary elements. There are, however, ops that continue to have a tighter constraint: both `ConstantStreamOp` and `SinkOp` require `LLVMStructOfNumerics` because their lowering only works for such types currently. Similarly, the upcoming "read from columnar buffers op" (#553) will continue to produce `LLVMStruct`s for the time being.