### PR TITLE
Iterators: Implement TabularViewToStreamOp.

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -267,11 +267,12 @@ def Iterators_ReduceOp : Iterators_Op<"reduce",
 }
 
 def Iterators_TabularViewToStreamOp : Iterators_Op<"tabular_view_to_stream",
-    [AllMatch<["$input.getType().cast<TabularViewType>().getColumnTypes()",
-               "$result.getType().cast<StreamType>().getElementType()"
-               "    .cast<LLVM::LLVMStructType>().getBody()"],
-              "the field types of the LLVM struct in the result stream must "
-              "match the column types of the tabular view given as input">]> {
+    [TypesMatchWith<"element type of input stream must match result type",
+                    "result", "input",
+                    "TabularViewType::get("
+                    "    $_self.getContext(),"
+                    "    $_self.cast<StreamType>().getElementType()"
+                    "          .cast<LLVM::LLVMStructType>().getBody())">]> {
   let summary = "Extracts the tuples from a tabular view as LLVM structs";
   let description = [{
     Produces a stream of LLVM structs from a given `tabular_view` (i.e., "scans"
@@ -280,13 +281,13 @@ def Iterators_TabularViewToStreamOp : Iterators_Op<"tabular_view_to_stream",
 
     Example:
     ```mlir
-    %stream = "iterators.tabular_view_to_stream"(%view)
-      : (!iterators.tabular_view<!t1, ..., !tn>)
-        -> !iterators.stream<!llvm.struct<(!t1, ..., !tn)>>
+    %stream = iterators.tabular_view_to_stream %view
+                  to !iterators.stream<!llvm.struct<(!t1, ..., !tn)>>
     ```
   }];
   let arguments = (ins Tabular_TabularView:$input);
   let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let assemblyFormat = "$input attr-dict `to` type($result)";
 }
 
 /// The sink op is a special op that only consumes a stream of values and

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -273,11 +273,16 @@ def Iterators_TabularViewToStreamOp : Iterators_Op<"tabular_view_to_stream",
                     "    $_self.getContext(),"
                     "    $_self.cast<StreamType>().getElementType()"
                     "          .cast<LLVM::LLVMStructType>().getBody())">]> {
+  // TODO(ingomueller): Get rid of the LLVM dependency after designing a row
+  //                    type or similar.
   let summary = "Extracts the tuples from a tabular view as LLVM structs";
   let description = [{
     Produces a stream of LLVM structs from a given `tabular_view` (i.e., "scans"
     the given `tabular_view`). Each LLVM struct represents one row, and the op
     produces all rows in ascending order.
+
+    The current dependency on LLVM is not elegant and only a temporary solution
+    before we get a more high-level `row` type or similar.
 
     Example:
     ```mlir

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -11,6 +11,7 @@
 
 include "iterators/Dialect/Iterators/IR/IteratorsDialect.td"
 include "iterators/Dialect/Iterators/IR/IteratorsTypes.td"
+include "iterators/Dialect/Tabular/IR/TabularTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 include "mlir/IR/OpBase.td"
 
@@ -263,6 +264,29 @@ def Iterators_ReduceOp : Iterators_Op<"reduce",
           *this, reduceFuncRefAttr());
     }
   }];
+}
+
+def Iterators_TabularViewToStreamOp : Iterators_Op<"tabular_view_to_stream",
+    [AllMatch<["$input.getType().cast<TabularViewType>().getColumnTypes()",
+               "$result.getType().cast<StreamType>().getElementType()"
+               "    .cast<LLVM::LLVMStructType>().getBody()"],
+              "the field types of the LLVM struct in the result stream must "
+              "match the column types of the tabular view given as input">]> {
+  let summary = "Extracts the tuples from a tabular view as LLVM structs";
+  let description = [{
+    Produces a stream of LLVM structs from a given `tabular_view` (i.e., "scans"
+    the given `tabular_view`). Each LLVM struct represents one row, and the op
+    produces all rows in ascending order.
+
+    Example:
+    ```mlir
+    %stream = "iterators.tabular_view_to_stream"(%view)
+      : (!iterators.tabular_view<!t1, ..., !tn>)
+        -> !iterators.stream<!llvm.struct<(!t1, ..., !tn)>>
+    ```
+  }];
+  let arguments = (ins Tabular_TabularView:$input);
+  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
 }
 
 /// The sink op is a special op that only consumes a stream of values and

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
@@ -13,5 +13,6 @@ add_mlir_conversion_library(MLIRIteratorsToLLVM
   MLIRLLVMDialect
   MLIRPass
   MLIRSCFDialect
+  MLIRTabularToLLVM
   MLIRTransforms
 )

--- a/experimental/iterators/lib/Conversion/TabularToLLVM/TabularToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/TabularToLLVM/TabularToLLVM.cpp
@@ -165,7 +165,7 @@ void ConvertTabularToLLVMPass::runOnOperation() {
   typeConverter.addSourceMaterialization(addUnrealizedCast);
   typeConverter.addTargetMaterialization(addUnrealizedCast);
 
-  if (failed(applyFullConversion(module, target, std::move(patterns))))
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
     signalPassFailure();
 }
 

--- a/experimental/iterators/lib/Dialects/Iterators/IR/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialects/Iterators/IR/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_library(MLIRIterators
   MLIRInferTypeOpInterface
   MLIRIR
   MLIRLLVMDialect
+  MLIRTabular
 
   DEPENDS
   MLIRIteratorsInterfacesIncGen

--- a/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
+++ b/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Dialect/Tabular/IR/Tabular.h"
 
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/DialectImplementation.h"

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
@@ -36,8 +36,8 @@
 
 func.func @main(%input : !tabular.tabular_view<i32>) {
   // CHECK-LABEL: func.func @main(%{{arg.*}}: !llvm.struct<(i64, ptr<i32>)>) {
-  %stream = "iterators.tabular_view_to_stream"(%input)
-    : (!tabular.tabular_view<i32>) -> !iterators.stream<!llvm.struct<(i32)>>
+  %stream = iterators.tabular_view_to_stream %input
+                to !iterators.stream<!llvm.struct<(i32)>>
   // CHECK-NEXT:    %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
   // CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[arg:.*]], %[[V1]][1 : index] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
   return

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
@@ -1,0 +1,46 @@
+// RUN: mlir-proto-opt %s \
+// RUN:   -convert-iterators-to-llvm -reconcile-unrealized-casts \
+// RUN: | FileCheck --enable-var-scope %s
+
+// CHECK-LABEL: func private @iterators.tabular_view_to_stream.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})> {
+// CHECK-NEXT:    return %[[arg0:.*]] : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: func private @iterators.tabular_view_to_stream.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>) -> (!llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:    %[[V1:.*]] = llvm.extractvalue %[[arg0]][1 : index] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:    %[[V2:.*]] = llvm.extractvalue %[[V1]][0 : index] : !llvm.struct<(i64, ptr<i32>)>
+// CHECK-NEXT:    %[[V3:.*]] = arith.cmpi slt, %[[V0]], %[[V2]] : i64
+// CHECK-NEXT:    %[[V4:.*]]:2 = scf.if %[[V3]] -> (!llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, !llvm.struct<(i32)>) {
+// CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
+// CHECK-NEXT:      %[[V5:.*]] = arith.addi %[[V0]], %[[C1]] : i64
+// CHECK-NEXT:      %[[V6:.*]] = llvm.insertvalue %[[V5]], %[[arg0]][0 : index] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:      %[[V7:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+// CHECK-NEXT:      %[[V8:.*]] = llvm.extractvalue %[[V1]][1 : index] : !llvm.struct<(i64, ptr<i32>)>
+// CHECK-NEXT:      %[[V9:.*]] = llvm.getelementptr %[[V8]][%[[V0]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+// CHECK-NEXT:      %[[Va:.*]] = llvm.load %[[V9]] : !llvm.ptr<i32>
+// CHECK-NEXT:      %[[Vb:.*]] = llvm.insertvalue %[[Va]], %[[V7]][0 : index] : !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[V6]], %[[Vb]] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, !llvm.struct<(i32)>
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      %[[V5:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[arg0]], %[[V5]] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, !llvm.struct<(i32)>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[V4]]#0, %[[V3]], %[[V4]]#1 : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:  }
+
+// CHECK-LABEL: func private @iterators.tabular_view_to_stream.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>
+// CHECK-NEXT:    %[[V0:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:    %[[V1:.*]] = llvm.insertvalue %[[V0]], %[[arg0:.*]][0 : index] : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:    return %[[V1]] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:  }
+
+func.func @main(%input : !tabular.tabular_view<i32>) {
+  // CHECK-LABEL: func.func @main(%{{arg.*}}: !llvm.struct<(i64, ptr<i32>)>) {
+  %stream = "iterators.tabular_view_to_stream"(%input)
+    : (!tabular.tabular_view<i32>) -> !iterators.stream<!llvm.struct<(i32)>>
+  // CHECK-NEXT:    %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
+  // CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[arg:.*]], %[[V1]][1 : index] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+  return
+  // CHECK-NEXT:   return
+}
+// CHECK-NEXT:   }

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
@@ -1,0 +1,52 @@
+// RUN: mlir-proto-opt %s \
+// RUN:   -convert-tabular-to-llvm -convert-iterators-to-llvm \
+// RUN:   -arith-bufferize -cse -convert-memref-to-llvm -reconcile-unrealized-casts \
+// RUN:   -convert-func-to-llvm \
+// RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
+// RUN: | mlir-cpu-runner -e main -entry-point-result=void \
+// RUN: | FileCheck %s
+
+!struct_type = !llvm.struct<(i32,i64)>
+
+func.func @single_block() {
+  %t1 = arith.constant dense<[0, 1, 2]> : tensor<3xi32>
+  %t2 = arith.constant dense<[3, 4, 5]> : tensor<3xi64>
+  %m1 = bufferization.to_memref %t1 : memref<3xi32>
+  %m2 = bufferization.to_memref %t2 : memref<3xi64>
+  %view = "tabular.view_as_tabular"(%m1, %m2)
+    : (memref<3xi32>, memref<3xi64>) -> !tabular.tabular_view<i32,i64>
+  %stream = "iterators.tabular_view_to_stream"(%view)
+    : (!tabular.tabular_view<i32,i64>) -> !iterators.stream<!struct_type>
+  "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
+  // CHECK:      (0, 3)
+  // CHECK-NEXT: (1, 4)
+  // CHECK-NEXT: (2, 5)
+  return
+}
+
+func.func @query(%view : !tabular.tabular_view<i32,i64>) {
+  %stream = "iterators.tabular_view_to_stream"(%view)
+    : (!tabular.tabular_view<i32,i64>) -> !iterators.stream<!struct_type>
+  "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
+  return
+}
+
+func.func @function_arg() {
+  %t1 = arith.constant dense<[9, 8, 7]> : tensor<3xi32>
+  %t2 = arith.constant dense<[6, 5, 4]> : tensor<3xi64>
+  %m1 = bufferization.to_memref %t1 : memref<3xi32>
+  %m2 = bufferization.to_memref %t2 : memref<3xi64>
+  %view = "tabular.view_as_tabular"(%m1, %m2)
+    : (memref<3xi32>, memref<3xi64>) -> !tabular.tabular_view<i32,i64>
+  func.call @query(%view) : (!tabular.tabular_view<i32,i64>) -> ()
+  // CHECK-NEXT: (9, 6)
+  // CHECK-NEXT: (8, 5)
+  // CHECK-NEXT: (7, 4)
+  return
+}
+
+func.func @main() {
+  func.call @single_block() : () -> ()
+  func.call @function_arg() : () -> ()
+  return
+}

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
@@ -15,8 +15,8 @@ func.func @single_block() {
   %m2 = bufferization.to_memref %t2 : memref<3xi64>
   %view = "tabular.view_as_tabular"(%m1, %m2)
     : (memref<3xi32>, memref<3xi64>) -> !tabular.tabular_view<i32,i64>
-  %stream = "iterators.tabular_view_to_stream"(%view)
-    : (!tabular.tabular_view<i32,i64>) -> !iterators.stream<!struct_type>
+  %stream = iterators.tabular_view_to_stream %view
+    to !iterators.stream<!struct_type>
   "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
   // CHECK:      (0, 3)
   // CHECK-NEXT: (1, 4)
@@ -25,8 +25,8 @@ func.func @single_block() {
 }
 
 func.func @query(%view : !tabular.tabular_view<i32,i64>) {
-  %stream = "iterators.tabular_view_to_stream"(%view)
-    : (!tabular.tabular_view<i32,i64>) -> !iterators.stream<!struct_type>
+  %stream = iterators.tabular_view_to_stream %view
+    to !iterators.stream<!struct_type>
   "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
   return
 }


### PR DESCRIPTION
This PR depends on and therefor currently includes #600. The PR implements an iterator op that allows iterating over the "tabular view" introduced in the previous PR, which now lives in its own `Tabular` dialect.

The lowering of this op currently has a dependency on the lowering of the tabular view: the iterator needs the LLVM representation of the view in order to be able to store it in its state, so the view needs to be lowered at the same time as the iterator op. I have thought of overcoming this eventually by breaking up the lowering of iterators into a lowering into built-in `tuple`s (which can store any type, including `TabularViewType`) such that the tabular dialect can be lowered in a separate pass (and the `tuple`s would be lowered to LLVM structs again later). However, this would be a complete overhaul of the current pipeline, which I am not sure I should do right away.