### PR TITLE
SQL: add group and order by to rel ssa and rel impl

### DIFF
--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -465,6 +465,7 @@ class RelationalAlg:
     self.ctx.register_attr(Decimal)
     self.ctx.register_attr(Int64)
     self.ctx.register_attr(Nullable)
+    self.ctx.register_attr(Order)
 
     self.ctx.register_op(Table)
     self.ctx.register_op(SchemaElement)

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -242,33 +242,6 @@ class Operator(Operation):
 
 
 @irdl_op_definition
-class GroupBy(Operator):
-  """
-  Groups the given input by the columns in `by`.
-
-  Example:
-  '''
-  rel_alg.group_by() ["by" = ["a", "b"]] {
-    rel_alg.table() ...
-  }
-  '''
-  """
-  name = "rel_alg.group_by"
-
-  input = SingleBlockRegionDef()
-  by = AttributeDef(ArrayAttr)
-
-  @builder
-  @staticmethod
-  def get(input: Region, by: list[str]) -> 'GroupBy':
-    return GroupBy.build(
-        regions=[input],
-        attributes={
-            "by": ArrayAttr.from_list([StringAttr.from_str(s) for s in by])
-        })
-
-
-@irdl_op_definition
 class OrderBy(Operator):
   """
   Orders the given input by the columns in `by`.
@@ -287,8 +260,8 @@ class OrderBy(Operator):
 
   @builder
   @staticmethod
-  def get(input: Region, by: list[str], order: list[str]) -> 'GroupBy':
-    return GroupBy.build(
+  def get(input: Region, by: list[str], order: list[str]) -> 'OrderBy':
+    return OrderBy.build(
         regions=[input],
         attributes={
             "by":
@@ -503,3 +476,4 @@ class RelationalAlg:
     self.ctx.register_op(Column)
     self.ctx.register_op(Compare)
     self.ctx.register_op(Aggregate)
+    self.ctx.register_op(OrderBy)

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -626,7 +626,7 @@ class Aggregate(Operator):
   Example:
 
   '''
-  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = ["a"]]
+  %0 : !rel_impl.bag<...> = rel_impl.aggregate(%0 : !rel_impl.bag<...>) ["col_names" = ["id"], "functions" = ["sum"], "by" = ["a"]]
   '''
   """
   name = "rel_impl.aggregate"

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -589,7 +589,8 @@ class Aggregate(Operator):
   Example:
 
   '''
-  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = ["a", "b"]] '''
+  %0 : !rel_ssa.bag<...> = rel_ssa.aggregate(%0 : !rel_ssa.bag<...>) ["col_names" = ["id"], "functions" = ["sum"], "by" = ["a", "b"]]
+  '''
   """
   name = "rel_ssa.aggregate"
 

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -431,9 +431,7 @@ class OrderBy(Operator):
 
   Example:
   '''
-  rel_ssa.order_by() ["by" = [!rel_ssa.order<"a", "asc>, !rel_ssa.order<"b", "desc">]] {
-    rel_ssa.table() ...
-  }
+  %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>]> = rel_ssa.order_by(%{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>]>) ["by" = [!rel_ssa.order<"a", "desc">]]
   '''
   """
   name = "rel_ssa.order_by"
@@ -648,6 +646,7 @@ class RelSSA:
     self.ctx.register_attr(String)
     self.ctx.register_attr(Boolean)
     self.ctx.register_attr(SchemaElement)
+    self.ctx.register_attr(Order)
 
     self.ctx.register_op(Select)
     self.ctx.register_op(Table)

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -256,7 +256,8 @@ class AggregateRewriter(RelAlgRewriter):
         RelSSA.Aggregate.get(rewriter.added_operations_before[-1],
                              [c.data for c in op.col_names.data],
                              [f.data for f in op.functions.data],
-                             [r.data for r in op.res_names.data])
+                             [r.data for r in op.res_names.data],
+                             [b.data for b in op.by.data])
     ])
     rewriter.erase_matched_op()
 

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -158,6 +158,20 @@ class CartesianProductRewriter(RelAlgRewriter):
 
 
 @dataclass
+class OrderByRewriter(RelAlgRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelAlg.OrderBy, rewriter: PatternRewriter):
+    rewriter.inline_block_before_matched_op(op.input.blocks[0])
+    input = rewriter.added_operations_before[-1]
+
+    rewriter.insert_op_before_matched_op(
+        RelSSA.OrderBy.get(input, [o.col.data for o in op.by.data],
+                           [o.order.data for o in op.by.data]))
+    rewriter.erase_matched_op()
+
+
+@dataclass
 class ProjectRewriter(RelAlgRewriter):
 
   # TODO: This could be implemented in a more natural way using Analysis Passes in MLIR.
@@ -277,6 +291,7 @@ def alg_to_ssa(ctx: MLContext, query: ModuleOp):
       SelectRewriter(),
       AggregateRewriter(),
       ProjectRewriter(),
+      OrderByRewriter(),
       CartesianProductRewriter()
   ]),
                                          walk_regions_first=True,

--- a/experimental/sql/test/alg_to_ssa/group_by.xdsl
+++ b/experimental/sql/test/alg_to_ssa/group_by.xdsl
@@ -1,0 +1,15 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+ rel_alg.aggregate() ["col_names" = ["c"], "functions" = ["sum"], "res_names" = ["c_sum"], "by" = ["a", "b"]] {
+     rel_alg.table() ["table_name" = "t"] {
+       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
+       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
+       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
+     }
+   }
+}
+
+
+//      CHECK:  %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"c_sum", !rel_ssa.int64>]> = rel_ssa.aggregate(%{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["c"], "functions" = ["sum"], "by" = ["a", "b"]]

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -18,4 +18,4 @@ module() {
 // CHECK-NEXT:    %2 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]
 // CHECK-NEXT:    rel_ssa.yield_tuple(%2 : !rel_ssa.int32)
 // CHECK-NEXT:  }
-// CHECK-NEXT:  %3 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]>) ["col_names" = ["im"], "functions" = ["sum"]]
+// CHECK-NEXT:  %3 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%1 : !rel_ssa.bag<[!rel_ssa.schema_element<"im", !rel_ssa.int32>]>) ["col_names" = ["im"], "functions" = ["sum"], "by" = []]

--- a/experimental/sql/test/alg_to_ssa/order_by.xdsl
+++ b/experimental/sql/test/alg_to_ssa/order_by.xdsl
@@ -1,0 +1,14 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+  rel_alg.order_by() ["by" = [!rel_alg.order<"a", "asc">, !rel_alg.order<"b", "asc">]] {
+    rel_alg.table() ["table_name" = "t"] {
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]
+      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int64]
+      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
+    }
+  }
+}
+
+//      CHECK: %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT: %{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.order_by(%{{.*}} : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["by" = [!rel_ssa.order<"a", "asc">, !rel_ssa.order<"b", "asc">]]

--- a/experimental/sql/test/alg_to_ssa/sum.xdsl
+++ b/experimental/sql/test/alg_to_ssa/sum.xdsl
@@ -9,4 +9,4 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]

--- a/experimental/sql/test/fuse_proj_into_scan_tests/extended_case.xdsl
+++ b/experimental/sql/test/fuse_proj_into_scan_tests/extended_case.xdsl
@@ -27,7 +27,7 @@ module() {
     %19 : !rel_impl.int64 = rel_impl.bin_op(%17 : !rel_impl.int64, %18 : !rel_impl.int64) ["operator" = "*"]
     rel_impl.yield_tuple(%19 : !rel_impl.int64)
   }
-  %20 : !rel_impl.bag<[!rel_impl.schema_element<"revenue", !rel_impl.int64>]> = rel_impl.aggregate(%15 : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]>) ["col_names" = ["im"], "functions" = ["sum"]]
+  %20 : !rel_impl.bag<[!rel_impl.schema_element<"revenue", !rel_impl.int64>]> = rel_impl.aggregate(%15 : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]>) ["col_names" = ["im"], "functions" = ["sum"], "by" = []]
 }
 
 //      CHECK:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "lineitem", "cols" = ["a", "b", "c"]]
@@ -49,4 +49,4 @@ module() {
 // CHECK-NEXT:    %{{.*}} : !rel_impl.int64 = rel_impl.bin_op(%{{.*}} : !rel_impl.int64, %{{.*}} : !rel_impl.int64) ["operator" = "*"]
 // CHECK-NEXT:    rel_impl.yield_tuple(%{{.*}} : !rel_impl.int64)
 // CHECK-NEXT:  }
-// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"revenue", !rel_impl.int64>]> = rel_impl.aggregate(%10 : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]>) ["col_names" = ["im"], "functions" = ["sum"]]
+// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"revenue", !rel_impl.int64>]> = rel_impl.aggregate(%10 : !rel_impl.bag<[!rel_impl.schema_element<"im", !rel_impl.int64>]>) ["col_names" = ["im"], "functions" = ["sum"], "by" = []]

--- a/experimental/sql/test/ibis_to_alg/order_by.xdsl
+++ b/experimental/sql/test/ibis_to_alg/order_by.xdsl
@@ -30,7 +30,7 @@ module() {
 }
 
 
-//      CHECK: rel_alg.group_by() ["by" = [!rel_alg.order<"a", "asc">, !rel_alg.order<"b", "asc">]] {
+//      CHECK: rel_alg.order_by() ["by" = [!rel_alg.order<"a", "asc">, !rel_alg.order<"b", "asc">]] {
 // CHECK-NEXT:    rel_alg.table() ["table_name" = "t"] {
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.nullable<!rel_alg.string>]
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.nullable<!rel_alg.int64>]

--- a/experimental/sql/test/impl_to_iterators/sum.xdsl
+++ b/experimental/sql/test/impl_to_iterators/sum.xdsl
@@ -2,7 +2,7 @@
 
 module() {
     %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
-    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {

--- a/experimental/sql/test/relational_implementation_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/sum.xdsl
@@ -2,8 +2,8 @@
 
 module() {
     %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
-    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+    %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }
 
 //      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
-// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]

--- a/experimental/sql/test/relational_ssa_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/sum.xdsl
@@ -2,8 +2,8 @@
 
 module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
-    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }
 
 //      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
-// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]

--- a/experimental/sql/test/ssa_to_impl/group_by.xdsl
+++ b/experimental/sql/test/ssa_to_impl/group_by.xdsl
@@ -1,0 +1,9 @@
+// RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
+
+module() {
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c_sum", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["c"], "functions" = ["sum"], "by" = ["a", "b"]]
+}
+
+//      CHECK:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"c_sum", !rel_impl.int64>]> = rel_impl.aggregate(%{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["col_names" = ["c"], "functions" = ["sum"], "by" = ["a", "b"]]

--- a/experimental/sql/test/ssa_to_impl/order_by.xdsl
+++ b/experimental/sql/test/ssa_to_impl/order_by.xdsl
@@ -1,0 +1,9 @@
+// RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
+
+module() {
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.order_by(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["by" = [!rel_ssa.order<"a", "asc">, !rel_ssa.order<"b", "asc">]]
+}
+
+//      CHECK:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.merge_sort(%{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) ["by" = [!rel_impl.order<"a", "asc">, !rel_impl.order<"b", "asc">]]

--- a/experimental/sql/test/ssa_to_impl/sum.xdsl
+++ b/experimental/sql/test/ssa_to_impl/sum.xdsl
@@ -2,7 +2,7 @@
 
 module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
-    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }
 
 //      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/ssa_to_impl/sum.xdsl
+++ b/experimental/sql/test/ssa_to_impl/sum.xdsl
@@ -6,4 +6,4 @@ module() {
 }
 
 //      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
-// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"idsum", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"]]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"idsum", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]


### PR DESCRIPTION
This PR adds the lowerings for group and order by to rel ssa and rel impl. Currently, this just lowers to a bag in the case of order by, even though this could be a sequence. However, I feel that if we want a sequence type, we should model the kind of sequence, i.e., the column it is ordered by. I would suggest to add this in a later PR, such that we can understand the meaning of this change without the other noise in this PR and then focus the discussion on this particular type refinement.