### PR TITLE
Iterators: Add Python runtime/execution engine stub

### DIFF
--- a/experimental/iterators/python/CMakeLists.txt
+++ b/experimental/iterators/python/CMakeLists.txt
@@ -47,6 +47,13 @@ declare_mlir_python_extension(IteratorsPythonSources.PassesExtension
   IteratorsCAPI
 )
 
+declare_mlir_python_sources(IteratorsPythonSources.ExecutionEngine
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_iterators"
+  ADD_TO_PARENT IteratorsPythonSources
+  SOURCES_GLOB
+    runtime/*.py
+)
+
 # ###############################################################################
 # Common CAPI
 # ###############################################################################

--- a/experimental/iterators/python/mlir_iterators/runtime/pandas_to_iterators.py
+++ b/experimental/iterators/python/mlir_iterators/runtime/pandas_to_iterators.py
@@ -1,0 +1,37 @@
+import ctypes
+
+import numpy as np
+import pandas as pd
+
+
+def make_tabular_view_descriptor(column_types: list[object]):
+  '''
+  Creates an empty instance a ctype.Structure corresponding to the
+  LLVMSTructType that the tabular view type with the given column types lowers
+  to. The column types must be provided as ctypes.
+  '''
+
+  class TabularViewDescriptor(ctypes.Structure):
+    '''A descriptor of a tabular view with columns of a particular type.'''
+
+    _fields_ = [('num_elements', ctypes.c_longlong)] \
+      + [('column' + str(i), ctypes.POINTER(dtype))
+         for i, dtype in enumerate(column_types)]
+
+  return TabularViewDescriptor()
+
+
+def to_tabular_view_descriptor(df: pd.DataFrame):
+  '''
+  Converts the given DataFrame to an instance of ctype.Structure equivalent to
+  what an instance of a corresponding tabular.TabularViewType would get lowered
+  to by TabularToLLVM.
+  '''
+
+  dtypes = [np.ctypeslib.as_ctypes_type(t) for t in df.dtypes]
+  descriptor = make_tabular_view_descriptor(dtypes)
+  descriptor.num_elements = ctypes.c_longlong(len(df.index))
+  for i, (dtype, col) in enumerate(zip(dtypes, df.columns)):
+    setattr(descriptor, 'column' + str(i),
+            df[col].values.ctypes.data_as(ctypes.POINTER(dtype)))
+  return descriptor

--- a/experimental/iterators/python/mlir_iterators/runtime/pandas_to_iterators.py
+++ b/experimental/iterators/python/mlir_iterators/runtime/pandas_to_iterators.py
@@ -25,7 +25,8 @@ def to_tabular_view_descriptor(df: pd.DataFrame):
   '''
   Converts the given DataFrame to an instance of ctype.Structure equivalent to
   what an instance of a corresponding tabular.TabularViewType would get lowered
-  to by TabularToLLVM.
+  to by TabularToLLVM. This is zero-copy: the conversion constis of extracting
+  the pointers from the pandas data structure and wrapping those.
   '''
 
   dtypes = [np.ctypeslib.as_ctypes_type(t) for t in df.dtypes]

--- a/experimental/iterators/test/lit.cfg.py
+++ b/experimental/iterators/test/lit.cfg.py
@@ -46,3 +46,8 @@ config.environment["PYTHONPATH"] = ":".join(sys.path)
 config.environment["PATH"] = ":".join(sys.path)
 config.environment["RUNTIMELIB"] = os.path.join(lib_dir, 'libruntime_utils.so')
 project_root = os.path.dirname(os.path.dirname(__file__))
+
+# Deactivate Python's output buffering. Otherwise, output on stdout from Python
+# gets delayed with respect to output from native libraries (such as the MLIR
+# Python bindings) such that order is not preserved and FileCheck checks fail.
+config.environment['PYTHONUNBUFFERED'] = '1'

--- a/experimental/iterators/test/python/dialects/iterators/dialect.py
+++ b/experimental/iterators/test/python/dialects/iterators/dialect.py
@@ -112,9 +112,8 @@ def testEndToEndWithInput():
       !struct_type = !llvm.struct<(i32,i64)>
       func.func @main(%input: !tabular.tabular_view<i32,i64>)
           attributes { llvm.emit_c_interface } {
-        %stream = "iterators.tabular_view_to_stream"(%input)
-          : (!tabular.tabular_view<i32,i64>)
-            -> !iterators.stream<!struct_type>
+        %stream = iterators.tabular_view_to_stream %input
+          to !iterators.stream<!struct_type>
         "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
         return
       }

--- a/experimental/iterators/test/python/dialects/iterators/dialect.py
+++ b/experimental/iterators/test/python/dialects/iterators/dialect.py
@@ -1,7 +1,12 @@
 # RUN: %PYTHON %s | FileCheck %s
 
+import ctypes
 import os
 
+import pandas as pd
+import numpy as np
+
+from mlir_iterators.runtime.pandas_to_iterators import to_tabular_view_descriptor
 from mlir_iterators.dialects import iterators as it
 from mlir_iterators.dialects import tabular as tab
 from mlir_iterators.passmanager import PassManager
@@ -71,8 +76,8 @@ def testConvertIteratorsToLlvm():
 
 
 @run
-# CHECK-LABEL: TEST: testEndToEnd
-def testEndToEnd():
+# CHECK-LABEL: TEST: testEndToEndStandalone
+def testEndToEndStandalone():
   mod = Module.parse('''
       !element_type = !llvm.struct<(i32)>
       func.func private @sum_struct(%lhs : !element_type, %rhs : !element_type) -> !element_type {
@@ -98,3 +103,33 @@ def testEndToEnd():
   engine = ExecutionEngine(mod)
   # CHECK: (6)
   engine.invoke('main')
+
+
+@run
+# CHECK-LABEL: TEST: testEndToEndWithInput
+def testEndToEndWithInput():
+  mod = Module.parse('''
+      !struct_type = !llvm.struct<(i32,i64)>
+      func.func @main(%input: !tabular.tabular_view<i32,i64>)
+          attributes { llvm.emit_c_interface } {
+        %stream = "iterators.tabular_view_to_stream"(%input)
+          : (!tabular.tabular_view<i32,i64>)
+            -> !iterators.stream<!struct_type>
+        "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
+        return
+      }
+      ''')
+  pm = PassManager.parse(
+      'convert-iterators-to-llvm,convert-memref-to-llvm,convert-func-to-llvm,'
+      'reconcile-unrealized-casts,convert-scf-to-cf,convert-cf-to-llvm')
+  pm.run(mod)
+
+  data = np.array([(0, 3), (1, 4), (2, 5)], dtype=[('a', 'i4'), ('b', 'i8')])
+  df = pd.DataFrame.from_records(data)
+  arg = ctypes.pointer(to_tabular_view_descriptor(df))
+
+  # CHECK:      (0, 3)
+  # CHECK-NEXT: (1, 4)
+  # CHECK-NEXT: (2, 5)
+  engine = ExecutionEngine(mod)
+  engine.invoke('main', arg)


### PR DESCRIPTION
This PR adds utility functions that allow passing pandas DataFrames into jitted code. It depends on and currently includes #600 and #579.