### PR TITLE
SQL: add Divide, Subtract, and Add

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -102,6 +102,22 @@ class Int64(DataType):
 
 
 @irdl_attr_definition
+class Float64(DataType):
+  """
+  Models the ibis float64 type.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/datatypes.py#L334
+
+  Example:
+
+  ```
+  !ibis.float64
+  ```
+  """
+  name = "ibis.float64"
+
+
+@irdl_attr_definition
 class String(DataType):
   """
   Models the ibis string type. The Parameter `nullable` defines whether the
@@ -142,6 +158,102 @@ class TableColumn(Operation):
   def get(table: Region, col_name: str) -> 'TableColumn':
     return TableColumn.create(
         attributes={"col_name": StringAttr.from_str(col_name)}, regions=[table])
+
+
+@irdl_op_definition
+class Subtract(Operation):
+  """
+  Models a subtraction of the columns `lhs` and `rhs` with result type `output_type`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/numeric.py#L39
+
+  Example:
+  ```
+  ibis.subtraction() ["output_type" = !ibis.int64] {
+    // lhs
+    ibis.table_column() ...
+  } {
+    // rhs
+    ibis.table_column() ...
+  }
+  ```
+
+  """
+  name = "ibis.subtract"
+
+  lhs = SingleBlockRegionDef()
+  rhs = SingleBlockRegionDef()
+  output_type = AttributeDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(lhs: Region, rhs: Region, output_type: DataType) -> 'Subtract':
+    return Subtract.create(regions=[lhs, rhs],
+                           attributes={"output_type": output_type})
+
+
+@irdl_op_definition
+class Add(Operation):
+  """
+  Models an addition of the columns `lhs` and `rhs` with result type `output_type`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/numeric.py#L20
+
+  Example:
+  ```
+  ibis.add() ["output_type" = !ibis.int64] {
+    // lhs
+    ibis.table_column() ...
+  } {
+    // rhs
+    ibis.table_column() ...
+  }
+  ```
+
+  """
+  name = "ibis.add"
+
+  lhs = SingleBlockRegionDef()
+  rhs = SingleBlockRegionDef()
+  output_type = AttributeDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(lhs: Region, rhs: Region, output_type: DataType) -> 'Add':
+    return Add.create(regions=[lhs, rhs],
+                      attributes={"output_type": output_type})
+
+
+@irdl_op_definition
+class Divide(Operation):
+  """
+  Models a division of the columns `lhs` and `rhs` with result type `output_type`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/numeric.py#L44
+
+  Example:
+  ```
+  ibis.divide() ["output_type" = !ibis.int64] {
+    // lhs
+    ibis.table_column() ...
+  } {
+    // rhs
+    ibis.table_column() ...
+  }
+  ```
+
+  """
+  name = "ibis.divide"
+
+  lhs = SingleBlockRegionDef()
+  rhs = SingleBlockRegionDef()
+  output_type = AttributeDef(DataType)
+
+  @staticmethod
+  @builder
+  def get(lhs: Region, rhs: Region, output_type: DataType) -> 'Divide':
+    return Divide.create(regions=[lhs, rhs],
+                         attributes={"output_type": output_type})
 
 
 @irdl_op_definition
@@ -589,6 +701,9 @@ class Ibis:
     self.ctx.register_attr(Timestamp)
     self.ctx.register_attr(Nullable)
 
+    self.ctx.register_op(Subtract)
+    self.ctx.register_op(Add)
+    self.ctx.register_op(Divide)
     self.ctx.register_op(UnboundTable)
     self.ctx.register_op(SortKey)
     self.ctx.register_op(SchemaElement)

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -697,6 +697,7 @@ class Ibis:
     self.ctx.register_attr(String)
     self.ctx.register_attr(Int32)
     self.ctx.register_attr(Int64)
+    self.ctx.register_attr(Float64)
     self.ctx.register_attr(Decimal)
     self.ctx.register_attr(Timestamp)
     self.ctx.register_attr(Nullable)

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -133,36 +133,33 @@ class Expression(Operation):
   ...
 
 
+@irdl_op_definition
 class BinOp(Expression):
   """
-  Binary operation on two values.
-  """
-
-  lhs = SingleBlockRegionDef()
-  rhs = SingleBlockRegionDef()
-
-
-@irdl_op_definition
-class Multiply(BinOp):
-  """
-  Multiplies two values.
+  Computes the binary operation `operator` of `lhs` and `rhs`.
 
   Example:
 
   '''
-  rel_alg.multiply() {
+  rel_alg.bin_op() ["operator" = "*"] {
     rel_alg.column() ...
   } {
     rel_alg.column() ...
   }
   '''
   """
-  name = "rel_alg.multiply"
+
+  name = "rel_alg.bin_op"
+
+  lhs = SingleBlockRegionDef()
+  rhs = SingleBlockRegionDef()
+  operator = AttributeDef(StringAttr)
 
   @builder
   @staticmethod
-  def get(lhs: Region, rhs: Region) -> 'Multiply':
-    return Multiply.create(regions=[lhs, rhs])
+  def get(lhs: Region, rhs: Region, operator: str) -> 'BinOp':
+    return BinOp.create(regions=[lhs, rhs],
+                        attributes={"operator": StringAttr.from_str(operator)})
 
 
 @irdl_op_definition
@@ -472,7 +469,7 @@ class RelationalAlg:
     self.ctx.register_op(Select)
     self.ctx.register_op(Project)
     self.ctx.register_op(CartesianProduct)
-    self.ctx.register_op(Multiply)
+    self.ctx.register_op(BinOp)
     self.ctx.register_op(Literal)
     self.ctx.register_op(Column)
     self.ctx.register_op(Compare)

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -115,11 +115,6 @@ class CompareRewriter(RelAlgRewriter):
 @dataclass
 class BinOpRewriter(RelAlgRewriter):
 
-  def convert_bin_op_to_str(self, op: RelAlg.BinOp) -> str:
-    if isinstance(op, RelAlg.Multiply):
-      return "*"
-    raise Exception(f"bin op conversion not yet implemented for {type(op)}")
-
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelAlg.BinOp, rewriter: PatternRewriter):
     # Remove the yield and inline the rest of the block.
@@ -132,7 +127,7 @@ class BinOpRewriter(RelAlgRewriter):
     right = rewriter.added_operations_before[-1]
 
     # TODO: Make Decimals change their prec and scale on certain operations.
-    new_op = RelSSA.BinOp.get(left, right, self.convert_bin_op_to_str(op))
+    new_op = RelSSA.BinOp.get(left, right, op.operator.data)
     rewriter.replace_matched_op([new_op, RelSSA.YieldTuple.get([new_op])])
 
 

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -31,6 +31,8 @@ def convert_datatype(type_: ibis.expr.datatypes) -> id.DataType:
     ret_type = id.Int32()
   elif isinstance(type_, ibis.expr.datatypes.Int64):
     ret_type = id.Int64()
+  elif isinstance(type_, ibis.expr.datatypes.Float64):
+    ret_type = id.Float64()
   elif isinstance(type_, ibis.expr.datatypes.Timestamp):
     ret_type = id.Timestamp()
   elif isinstance(type_, ibis.expr.datatypes.Decimal):
@@ -82,6 +84,27 @@ def visit(  # type: ignore
   return id.Multiply.get(Region.from_operation_list([visit(op.left)]),
                          Region.from_operation_list([visit(op.right)]),
                          convert_datatype(op.output_dtype()))
+
+
+@dispatch(ibis.expr.operations.numeric.Subtract)
+def visit(op: ibis.expr.operations.numeric.Subtract):
+  return id.Subtract.get(Region.from_operation_list([visit(op.left)]),
+                         Region.from_operation_list([visit(op.right)]),
+                         convert_datatype(op.output_dtype()))
+
+
+@dispatch(ibis.expr.operations.numeric.Add)
+def visit(op: ibis.expr.operations.numeric.Add):
+  return id.Add.get(Region.from_operation_list([visit(op.left)]),
+                    Region.from_operation_list([visit(op.right)]),
+                    convert_datatype(op.output_dtype()))
+
+
+@dispatch(ibis.expr.operations.numeric.Divide)
+def visit(op: ibis.expr.operations.numeric.Divide):
+  return id.Divide.get(Region.from_operation_list([visit(op.left)]),
+                       Region.from_operation_list([visit(op.right)]),
+                       convert_datatype(op.output_dtype()))
 
 
 @dispatch(ibis.expr.operations.core.Alias)

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -200,9 +200,9 @@ class MultiplyRewriter(IbisRewriter):
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: ibis.Multiply, rewriter: PatternRewriter):
     rewriter.replace_matched_op(
-        RelAlg.Multiply.get(
-            rewriter.move_region_contents_to_new_regions(op.lhs),
-            rewriter.move_region_contents_to_new_regions(op.rhs)))
+        RelAlg.BinOp.get(rewriter.move_region_contents_to_new_regions(op.lhs),
+                         rewriter.move_region_contents_to_new_regions(op.rhs),
+                         "*"))
 
 
 def ibis_to_alg(ctx: MLContext, query: ModuleOp):

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -205,6 +205,39 @@ class MultiplyRewriter(IbisRewriter):
                          "*"))
 
 
+@dataclass
+class DivideRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.Divide, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.BinOp.get(rewriter.move_region_contents_to_new_regions(op.lhs),
+                         rewriter.move_region_contents_to_new_regions(op.rhs),
+                         "/"))
+
+
+@dataclass
+class SubtractRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.Subtract, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.BinOp.get(rewriter.move_region_contents_to_new_regions(op.lhs),
+                         rewriter.move_region_contents_to_new_regions(op.rhs),
+                         "-"))
+
+
+@dataclass
+class AddRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.Add, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.BinOp.get(rewriter.move_region_contents_to_new_regions(op.lhs),
+                         rewriter.move_region_contents_to_new_regions(op.rhs),
+                         "+"))
+
+
 def ibis_to_alg(ctx: MLContext, query: ModuleOp):
   walker = PatternRewriteWalker(GreedyRewritePatternApplier([
       UnboundTableRewriter(),
@@ -218,6 +251,9 @@ def ibis_to_alg(ctx: MLContext, query: ModuleOp):
       TableColumnRewriter(),
       AggregationRewriter(),
       MultiplyRewriter(),
+      SubtractRewriter(),
+      DivideRewriter(),
+      AddRewriter(),
       LiteralRewriter()
   ]),
                                 walk_regions_first=False,

--- a/experimental/sql/test/alg_to_ssa/multiply.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multiply.xdsl
@@ -8,7 +8,7 @@ module() {
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
     }
   } {
-    rel_alg.multiply() {
+    rel_alg.bin_op() ["operator" = "*"] {
       rel_alg.column() ["col_name" = "b"]
     } {
       rel_alg.column() ["col_name" = "c"]

--- a/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
+++ b/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
@@ -8,7 +8,7 @@ module() {
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]
     }
   } {
-    rel_alg.multiply() {
+    rel_alg.bin_op() ["operator" = "*"] {
       rel_alg.column() ["col_name" = "b"]
     } {
       rel_alg.column() ["col_name" = "c"]

--- a/experimental/sql/test/frontend/add.ibis
+++ b/experimental/sql/test/frontend/add.ibis
@@ -1,0 +1,7 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table[(table['b'] + table['c']).name('d')]
+
+
+# CHECK:     ibis.add() ["output_type" = !ibis.nullable<!ibis.int64>] {

--- a/experimental/sql/test/frontend/divide.ibis
+++ b/experimental/sql/test/frontend/divide.ibis
@@ -1,0 +1,7 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table[(table['b'] / table['c']).name('d')]
+
+
+# CHECK:     ibis.divide() ["output_type" = !ibis.nullable<!ibis.float64>] {

--- a/experimental/sql/test/frontend/subtract.ibis
+++ b/experimental/sql/test/frontend/subtract.ibis
@@ -1,0 +1,7 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table[(table['b'] - table['c']).name('d')]
+
+
+# CHECK:     ibis.subtract() ["output_type" = !ibis.nullable<!ibis.int64>] {

--- a/experimental/sql/test/ibis_to_alg/add.xdsl
+++ b/experimental/sql/test/ibis_to_alg/add.xdsl
@@ -1,0 +1,32 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.selection() ["names" = ["bc"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+    }
+  } {} {
+    ibis.add() ["output_type" = !ibis.int64] {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        }
+      }
+    }  {
+      ibis.table_column() ["col_name" = "c"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        }
+      }
+    }
+  } {}
+}
+
+
+// CHECK:   rel_alg.bin_op() ["operator" = "+"] {

--- a/experimental/sql/test/ibis_to_alg/divide.xdsl
+++ b/experimental/sql/test/ibis_to_alg/divide.xdsl
@@ -1,0 +1,32 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.selection() ["names" = ["bc"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+    }
+  } {} {
+    ibis.divide() ["output_type" = !ibis.int64] {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        }
+      }
+    }  {
+      ibis.table_column() ["col_name" = "c"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        }
+      }
+    }
+  } {}
+}
+
+
+// CHECK:   rel_alg.bin_op() ["operator" = "/"] {

--- a/experimental/sql/test/ibis_to_alg/multiply.xdsl
+++ b/experimental/sql/test/ibis_to_alg/multiply.xdsl
@@ -35,7 +35,7 @@ ibis.selection() ["names" = ["bc"]] {
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  } {
-// CHECK-NEXT:   rel_alg.multiply() {
+// CHECK-NEXT:   rel_alg.bin_op() ["operator" = "*"] {
 // CHECK-NEXT:      rel_alg.column() ["col_name" = "b"]
 // CHECK-NEXT:    } {
 // CHECK-NEXT:      rel_alg.column() ["col_name" = "c"]

--- a/experimental/sql/test/ibis_to_alg/subtract.xdsl
+++ b/experimental/sql/test/ibis_to_alg/subtract.xdsl
@@ -1,0 +1,32 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.selection() ["names" = ["bc"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+    }
+  } {} {
+    ibis.subtract() ["output_type" = !ibis.int64] {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        }
+      }
+    }  {
+      ibis.table_column() ["col_name" = "c"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int64]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int64]
+        }
+      }
+    }
+  } {}
+}
+
+
+// CHECK:   rel_alg.bin_op() ["operator" = "-"] {

--- a/experimental/sql/test/projection_pushdown_tests/extended_case.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/extended_case.xdsl
@@ -23,7 +23,7 @@ module() {
         }
       }
     } {
-      rel_alg.multiply() {
+      rel_alg.bin_op() ["operator" = "*"] {
         rel_alg.column() ["col_name" = "b"]
       } {
         rel_alg.column() ["col_name" = "c"]
@@ -61,7 +61,7 @@ module() {
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:    } {
-// CHECK-NEXT:      rel_alg.multiply() {
+// CHECK-NEXT:      rel_alg.bin_op() ["operator" = "*"] {
 // CHECK-NEXT:        rel_alg.column() ["col_name" = "b"]
 // CHECK-NEXT:      } {
 // CHECK-NEXT:        rel_alg.column() ["col_name" = "c"]

--- a/experimental/sql/test/projection_pushdown_tests/multiply.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/multiply.xdsl
@@ -16,7 +16,7 @@ module() {
         }
     }
   } {
-    rel_alg.multiply() {
+    rel_alg.bin_op() ["operator" = "*"] {
       rel_alg.column() ["col_name" = "b"]
     } {
       rel_alg.column() ["col_name" = "c"]
@@ -44,7 +44,7 @@ module() {
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  } {
-// CHECK-NEXT:    rel_alg.multiply() {
+// CHECK-NEXT:    rel_alg.bin_op() ["operator" = "*"] {
 // CHECK-NEXT:      rel_alg.column() ["col_name" = "b"]
 // CHECK-NEXT:    } {
 // CHECK-NEXT:      rel_alg.column() ["col_name" = "c"]

--- a/experimental/sql/test/relational_algebra_dialect_tests/multiply.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/multiply.xdsl
@@ -8,7 +8,7 @@ module() {
       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
     }
   } {
-    rel_alg.multiply() {
+    rel_alg.bin_op() ["operator" = "*"] {
       rel_alg.column() ["col_name" = "b"]
     } {
       rel_alg.column() ["col_name" = "c"]
@@ -23,7 +23,7 @@ module() {
 // CHECK-NEXT:      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int64]
 // CHECK-NEXT:    }
 // CHECK-NEXT:  } {
-// CHECK-NEXT:   rel_alg.multiply() {
+// CHECK-NEXT:   rel_alg.bin_op() ["operator" = "*"] {
 // CHECK-NEXT:      rel_alg.column() ["col_name" = "b"]
 // CHECK-NEXT:    } {
 // CHECK-NEXT:      rel_alg.column() ["col_name" = "c"]


### PR DESCRIPTION
This PR adds the modelings for Add, Subtract, and Divide to the ibis dialect. Additionally, it lowers to the new `bin_op` operation in rel_alg.

This is a series of PRs to get 9 tpc-h queries running with our prototype. This PR should give us 4 more queries.