### PR TITLE
SQL: add min, mean, max, count, and count_distinct reductions

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -490,6 +490,134 @@ class Sum(Operation):
 
 
 @irdl_op_definition
+class Min(Operation):
+  """
+  Takes the minimum of all the elements of the column given in arg based on the encompassing
+  aggregation operator.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/reductions.py#L204
+
+  Example:
+
+  '''
+  ibis.min() {
+    ibis.table_column() ...
+  }
+  '''
+  """
+  name = "ibis.min"
+
+  arg = SingleBlockRegionDef()
+
+  @staticmethod
+  @builder
+  def get(arg: Region) -> 'Min':
+    return Min.create(regions=[arg])
+
+
+@irdl_op_definition
+class Max(Operation):
+  """
+  Takes the maximum of all the elements of the column given in arg based on the encompassing
+  aggregation operator.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/reductions.py#L197
+
+  Example:
+
+  '''
+  ibis.max() {
+    ibis.table_column() ...
+  }
+  '''
+  """
+  name = "ibis.max"
+
+  arg = SingleBlockRegionDef()
+
+  @staticmethod
+  @builder
+  def get(arg: Region) -> 'Max':
+    return Max.create(regions=[arg])
+
+
+@irdl_op_definition
+class Mean(Operation):
+  """
+  Takes the mean of all the elements of the column given in arg based on the encompassing
+  aggregation operator.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/reductions.py#L108
+
+  Example:
+
+  '''
+  ibis.mean() {
+    ibis.table_column() ...
+  }
+  '''
+  """
+  name = "ibis.mean"
+
+  arg = SingleBlockRegionDef()
+
+  @staticmethod
+  @builder
+  def get(arg: Region) -> 'Mean':
+    return Mean.create(regions=[arg])
+
+
+@irdl_op_definition
+class Count(Operation):
+  """
+  Counts the elements in arg based on the encompassing aggregation operator.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/reductions.py#L18
+
+  Example:
+
+  '''
+  ibis.count() {
+    ibis.unbound_table() ...
+  }
+  '''
+  """
+  name = "ibis.count"
+
+  arg = SingleBlockRegionDef()
+
+  @staticmethod
+  @builder
+  def get(arg: Region) -> 'Count':
+    return Count.create(regions=[arg])
+
+
+@irdl_op_definition
+class CountDistinct(Operation):
+  """
+  Counts the distinct elements of the column in arg based on the encompassing aggregation operator.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/reductions.py#L265
+
+  Example:
+
+  '''
+  ibis.count_distinct() {
+    ibis.table_column() ...
+  }
+  '''
+  """
+  name = "ibis.count_distinct"
+
+  arg = SingleBlockRegionDef()
+
+  @staticmethod
+  @builder
+  def get(arg: Region) -> 'CountDistinct':
+    return CountDistinct.create(regions=[arg])
+
+
+@irdl_op_definition
 class Equals(Operation):
   """
   Checks whether each entry of `left` is equal to `right`.
@@ -777,4 +905,8 @@ class Ibis:
     self.ctx.register_op(TableColumn)
     self.ctx.register_op(Literal)
     self.ctx.register_op(Sum)
+    self.ctx.register_op(Mean)
+    self.ctx.register_op(Min)
+    self.ctx.register_op(Max)
+    self.ctx.register_op(Count)
     self.ctx.register_op(Aggregation)

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -909,4 +909,5 @@ class Ibis:
     self.ctx.register_op(Min)
     self.ctx.register_op(Max)
     self.ctx.register_op(Count)
+    self.ctx.register_op(CountDistinct)
     self.ctx.register_op(Aggregation)

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -319,7 +319,7 @@ class Aggregate(Operator):
 
   def verify_(self) -> None:
     for f in self.functions.data:
-      if not f.data in ["sum"]:
+      if not f.data in ["sum", "min", "max", "avg", "count", "count_distinct"]:
         raise Exception(f"function {f.data} is not a supported function")
 
   @staticmethod

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -663,9 +663,11 @@ class Aggregate(Operator):
                 ArrayAttr.from_list([StringAttr.from_str(o) for o in by])
         },
         result_types=[
-            Bag.get(
-                [input.result.typ.lookup_type_in_schema(n) for n in col_names],
-                res_names)
+            Bag.get([
+                Int64()
+                if n == "" else input.result.typ.lookup_type_in_schema(n)
+                for n in col_names
+            ], res_names)
         ])
 
 

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -643,7 +643,7 @@ class Aggregate(Operator):
           f"Number of functions and column names should match: {len(self.functions.data)} vs {len(self.col_names.data)}"
       )
     for f in self.functions.data:
-      if not f.data in ["sum"]:
+      if not f.data in ["sum", "min", "max", "avg", "count", "count_distinct"]:
         raise Exception(f"function {f.data} is not a supported function")
 
   @builder

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -664,9 +664,9 @@ class Aggregate(Operator):
         },
         result_types=[
             Bag.get([
-                Int64()
-                if n == "" else input.result.typ.lookup_type_in_schema(n)
-                for n in col_names
+                Int64() if f in ["count", "count_distinct"] else
+                input.result.typ.lookup_type_in_schema(n)
+                for n, f in zip(col_names, functions)
             ], res_names)
         ])
 

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -632,7 +632,7 @@ class Aggregate(Operator):
           f"Number of functions and column names should match: {len(self.functions.data)} vs {len(self.col_names.data)}"
       )
     for f in self.functions.data:
-      if not f.data in ["sum"]:
+      if not f.data in ["sum", "min", "max", "avg", "count", "count_distinct"]:
         raise Exception(f"function {f.data} is not a supported function")
 
   @builder

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -653,9 +653,9 @@ class Aggregate(Operator):
         },
         result_types=[
             Bag.get(res_names, [
-                Int64()
-                if n == "" else input.result.typ.lookup_type_in_schema(n)
-                for n in col_names
+                Int64() if f in ["count", "count_distinct"] else
+                input.result.typ.lookup_type_in_schema(n)
+                for n, f in zip(col_names, functions)
             ])
         ])
 

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -652,9 +652,11 @@ class Aggregate(Operator):
                 ArrayAttr.from_list([StringAttr.from_str(s) for s in by])
         },
         result_types=[
-            Bag.get(
-                res_names,
-                [input.result.typ.lookup_type_in_schema(n) for n in col_names])
+            Bag.get(res_names, [
+                Int64()
+                if n == "" else input.result.typ.lookup_type_in_schema(n)
+                for n in col_names
+            ])
         ])
 
 

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -233,5 +233,40 @@ def visit(  #type: ignore
   return id.Sum.get(arg)
 
 
+@dispatch(ibis.expr.operations.reductions.Mean)
+def visit(  #type: ignore
+    op: ibis.expr.operations.reductions.Mean) -> Operation:
+  arg = Region.from_operation_list([visit(op.arg)])
+  return id.Mean.get(arg)
+
+
+@dispatch(ibis.expr.operations.reductions.Max)
+def visit(  #type: ignore
+    op: ibis.expr.operations.reductions.Max) -> Operation:
+  arg = Region.from_operation_list([visit(op.arg)])
+  return id.Max.get(arg)
+
+
+@dispatch(ibis.expr.operations.reductions.Min)
+def visit(  #type: ignore
+    op: ibis.expr.operations.reductions.Min) -> Operation:
+  arg = Region.from_operation_list([visit(op.arg)])
+  return id.Min.get(arg)
+
+
+@dispatch(ibis.expr.operations.reductions.Count)
+def visit(  #type: ignore
+    op: ibis.expr.operations.reductions.Count) -> Operation:
+  arg = Region.from_operation_list([visit(op.arg)])
+  return id.Count.get(arg)
+
+
+@dispatch(ibis.expr.operations.reductions.CountDistinct)
+def visit(  #type: ignore
+    op: ibis.expr.operations.reductions.CountDistinct) -> Operation:
+  arg = Region.from_operation_list([visit(op.arg)])
+  return id.CountDistinct.get(arg)
+
+
 def ibis_to_xdsl(ctx: MLContext, query: ibis.expr.types.Expr) -> ModuleOp:
   return ModuleOp.build(regions=[Region.from_operation_list([visit(query)])])

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -198,6 +198,19 @@ class AggregationRewriter(IbisRewriter):
   def get_col_name_and_function(self, metric_op: Operation) -> Tuple[str, str]:
     if isinstance(metric_op, ibis.Sum):
       return "sum", metric_op.arg.op.attributes["col_name"].data
+    if isinstance(metric_op, ibis.Min):
+      return "min", metric_op.arg.op.attributes["col_name"].data
+    if isinstance(metric_op, ibis.Max):
+      return "max", metric_op.arg.op.attributes["col_name"].data
+    if isinstance(metric_op, ibis.Mean):
+      return "avg", metric_op.arg.op.attributes["col_name"].data
+    if isinstance(metric_op, ibis.CountDistinct):
+      return "count_distinct", metric_op.arg.op.attributes["col_name"].data
+    if isinstance(metric_op, ibis.Count):
+      if isinstance(metric_op.arg.op, ibis.TableColumn):
+        return "count", metric_op.arg.op.attributes["col_name"].data
+      if isinstance(metric_op.arg.op, ibis.UnboundTable):
+        return "count", ""
     raise Exception(
         f"aggregation function not yet implemented {type(metric_op)}")
 

--- a/experimental/sql/test/alg_to_ssa/count.xdsl
+++ b/experimental/sql/test/alg_to_ssa/count.xdsl
@@ -1,0 +1,12 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+    rel_alg.aggregate() ["col_names" = [""], "functions" = ["count"], "res_names" = ["c"], "by" = []] {
+        rel_alg.table() ["table_name" = "t"] {
+            rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
+        }
+    }
+}
+
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = [""], "functions" = ["count"], "by" = []]

--- a/experimental/sql/test/alg_to_ssa/count_column.xdsl
+++ b/experimental/sql/test/alg_to_ssa/count_column.xdsl
@@ -1,0 +1,12 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+    rel_alg.aggregate() ["col_names" = ["b"], "functions" = ["count"], "res_names" = ["c"], "by" = []] {
+        rel_alg.table() ["table_name" = "t"] {
+            rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
+        }
+    }
+}
+
+//      CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
+// CHECK-NEXT:  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["b"], "functions" = ["count"], "by" = []]

--- a/experimental/sql/test/frontend/count.ibis
+++ b/experimental/sql/test/frontend/count.ibis
@@ -1,0 +1,7 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.aggregate(table.count().name('b'))
+
+
+# CHECK:     ibis.count()

--- a/experimental/sql/test/frontend/count_column.ibis
+++ b/experimental/sql/test/frontend/count_column.ibis
@@ -1,8 +1,8 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
 table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
-table.aggregate(table.count().name('b'))
+table.aggregate(table.b.count().name('b'))
 
 
 #      CHECK:     ibis.count() {
-# CHECK-NEXT:       ibis.unbound_table() ["table_name" = "t"] {
+# CHECK-NEXT:       ibis.table_column() ["col_name" = "b"] {

--- a/experimental/sql/test/frontend/count_distinct.ibis
+++ b/experimental/sql/test/frontend/count_distinct.ibis
@@ -1,0 +1,7 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.aggregate(table.b.nunique().name('b'))
+
+
+# CHECK:     ibis.count_distinct() {

--- a/experimental/sql/test/frontend/max.ibis
+++ b/experimental/sql/test/frontend/max.ibis
@@ -1,0 +1,6 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.aggregate(table.b.max().name('b'))
+
+# CHECK:     ibis.max()

--- a/experimental/sql/test/frontend/mean.ibis
+++ b/experimental/sql/test/frontend/mean.ibis
@@ -1,0 +1,7 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.aggregate(table.b.mean().name('b'))
+
+
+# CHECK:     ibis.mean()

--- a/experimental/sql/test/frontend/min.ibis
+++ b/experimental/sql/test/frontend/min.ibis
@@ -1,0 +1,6 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.aggregate(table.b.min().name('b'))
+
+# CHECK:     ibis.min()

--- a/experimental/sql/test/ibis_to_alg/count.xdsl
+++ b/experimental/sql/test/ibis_to_alg/count.xdsl
@@ -1,0 +1,21 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.aggregation() ["names" = ["b"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+    }
+  } {
+    ibis.count() {
+      ibis.unbound_table() ["table_name" = "t"] {
+        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+        ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+        ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+      }
+    }
+  } {}
+}
+
+//      CHECK: rel_alg.aggregate() ["col_names" = [""], "functions" = ["count"]

--- a/experimental/sql/test/ibis_to_alg/count_column.xdsl
+++ b/experimental/sql/test/ibis_to_alg/count_column.xdsl
@@ -1,0 +1,23 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.aggregation() ["names" = ["b"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+    }
+  } {
+    ibis.count() {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+        }
+      }
+    }
+  } {}
+}
+
+//      CHECK: rel_alg.aggregate() ["col_names" = ["b"], "functions" = ["count"]

--- a/experimental/sql/test/ibis_to_alg/count_distinct.xdsl
+++ b/experimental/sql/test/ibis_to_alg/count_distinct.xdsl
@@ -1,0 +1,23 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.aggregation() ["names" = ["b"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+    }
+  } {
+    ibis.count_distinct() {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+        }
+      }
+    }
+  } {}
+}
+
+//      CHECK: rel_alg.aggregate() {{.*}} "functions" = ["count_distinct"]

--- a/experimental/sql/test/ibis_to_alg/max.xdsl
+++ b/experimental/sql/test/ibis_to_alg/max.xdsl
@@ -1,0 +1,23 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.aggregation() ["names" = ["b"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+    }
+  } {
+    ibis.max() {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+        }
+      }
+    }
+  } {}
+}
+
+//      CHECK: rel_alg.aggregate() {{.*}} "functions" = ["max"]

--- a/experimental/sql/test/ibis_to_alg/mean.xdsl
+++ b/experimental/sql/test/ibis_to_alg/mean.xdsl
@@ -1,0 +1,23 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.aggregation() ["names" = ["b"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+    }
+  } {
+    ibis.mean() {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+        }
+      }
+    }
+  } {}
+}
+
+//      CHECK: rel_alg.aggregate() {{.*}} "functions" = ["avg"]

--- a/experimental/sql/test/ibis_to_alg/min.xdsl
+++ b/experimental/sql/test/ibis_to_alg/min.xdsl
@@ -1,0 +1,23 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ibis.aggregation() ["names" = ["b"]] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+    }
+  } {
+    ibis.min() {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.int32]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.int32]
+        }
+      }
+    }
+  } {}
+}
+
+//      CHECK: rel_alg.aggregate() {{.*}} "functions" = ["min"]

--- a/experimental/sql/test/ssa_to_impl/count.xdsl
+++ b/experimental/sql/test/ssa_to_impl/count.xdsl
@@ -1,0 +1,9 @@
+// RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
+
+module() {
+    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
+    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = [""], "functions" = ["count"], "by" = []]
+}
+
+//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = [""], "functions" = ["count"], "by" = []]

--- a/experimental/sql/test/ssa_to_impl/count_column.xdsl
+++ b/experimental/sql/test/ssa_to_impl/count_column.xdsl
@@ -1,0 +1,9 @@
+// RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
+
+module() {
+    %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
+    %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["b"], "functions" = ["count"], "by" = []]
+}
+
+//      CHECK:  %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+// CHECK-NEXT:  %1 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["b"], "functions" = ["count"], "by" = []]


### PR DESCRIPTION
This PR adds the min, mean, max, count, and count_distinct reductions. For the count, I decided to have an empty string as the col_name since we can take any column of the input operator to count, as all have the same number of rows. I also decided to rename `mean` to `avg` in rel_alg, as this corresponds to SQLs keyword (AFAIK).


This PR is the second in a row of PR's trying to make 9 tpc-h queries run with our prototype. This will let us represent 8 queries with one easy operation to go to handle the 9 simple queries. And with 13 operations to go in order to represent all of tpc-h.