### PR TITLE
SQL: add GreaterThan to ibis and lowering to rel alg.

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -550,6 +550,36 @@ class GreaterEqual(Operation):
 
 
 @irdl_op_definition
+class GreaterThan(Operation):
+  """
+  Checks whether each entry of `left` is greater than `right`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/logical.py#L94
+
+  Example:
+
+  ```
+  ibis.greaterThan() {
+    // left
+    ibis.table_column() ...
+  } {
+    // right
+    ibis.literal() ...
+  }
+  ```
+  """
+  name = "ibis.greaterThan"
+
+  left = SingleBlockRegionDef()
+  right = SingleBlockRegionDef()
+
+  @builder
+  @staticmethod
+  def get(left: Region, right: Region) -> 'GreaterThan':
+    return GreaterThan.create(regions=[left, right])
+
+
+@irdl_op_definition
 class LessThan(Operation):
   """
   Checks whether each entry of `left` is less than `right`.
@@ -713,6 +743,7 @@ class Ibis:
     self.ctx.register_op(Multiply)
     self.ctx.register_op(Equals)
     self.ctx.register_op(GreaterEqual)
+    self.ctx.register_op(GreaterThan)
     self.ctx.register_op(LessEqual)
     self.ctx.register_op(LessThan)
     self.ctx.register_op(TableColumn)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -197,6 +197,12 @@ def visit(  #type: ignore
   return create_logical_op(op, id.GreaterEqual)
 
 
+@dispatch(ibis.expr.operations.logical.Greater)
+def visit(  #type: ignore
+    op: ibis.expr.operations.logical.Greater) -> Operation:
+  return create_logical_op(op, id.GreaterThan)
+
+
 @dispatch(ibis.expr.operations.logical.LessEqual)
 def visit(  #type: ignore
     op: ibis.expr.operations.logical.LessEqual) -> Operation:

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -101,6 +101,17 @@ class GreaterEqualRewriter(IbisRewriter):
 
 
 @dataclass
+class GreaterThanRewriter(IbisRewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.GreaterThan, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.Compare.get(
+            ">", rewriter.move_region_contents_to_new_regions(op.left),
+            rewriter.move_region_contents_to_new_regions(op.right)))
+
+
+@dataclass
 class LessThanRewriter(IbisRewriter):
 
   @op_type_rewrite_pattern
@@ -246,6 +257,7 @@ def ibis_to_alg(ctx: MLContext, query: ModuleOp):
       CartesianProductRewriter(),
       EqualsRewriter(),
       GreaterEqualRewriter(),
+      GreaterThanRewriter(),
       LessEqualRewriter(),
       LessThanRewriter(),
       TableColumnRewriter(),

--- a/experimental/sql/test/frontend/greaterThan.ibis
+++ b/experimental/sql/test/frontend/greaterThan.ibis
@@ -1,0 +1,6 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.filter(table['b'] > np.int64(0))
+
+#      CHECK:    ibis.greaterThan() {

--- a/experimental/sql/test/ibis_to_alg/greaterThan.xdsl
+++ b/experimental/sql/test/ibis_to_alg/greaterThan.xdsl
@@ -1,0 +1,21 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+  ibis.selection() ["names" = []] {
+     ibis.unbound_table() ["table_name" = "t"] {
+       ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+     }
+   } {
+     ibis.greaterThan() {
+       ibis.table_column() ["col_name" = "id"] {
+         ibis.unbound_table() ["table_name" = "t"] {
+           ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]
+         }
+       }
+     } {
+       ibis.literal() ["val" = 5, "type" = !ibis.int64]
+     }
+   } {} {}
+}
+
+//      CHECK:         rel_alg.compare() ["comparator" = ">"] {


### PR DESCRIPTION
This PR adds handling of the GreaterThan node in ibis and its lowering to rel_alg. 


With this and #583, we can represent 9 queries of tpc-h. There would then be 12 more operations to go.