### PR TITLE
SQL: add limit to the entire stack

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -764,6 +764,7 @@ class Ibis:
     self.ctx.register_op(Divide)
     self.ctx.register_op(UnboundTable)
     self.ctx.register_op(SortKey)
+    self.ctx.register_op(Limit)
     self.ctx.register_op(SchemaElement)
     self.ctx.register_op(Selection)
     self.ctx.register_op(CartesianProduct)

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -668,6 +668,33 @@ class UnboundTable(Operation):
 
 
 @irdl_op_definition
+class Limit(Operation):
+  """
+  Limits the number of tuples in `table` to `n` .
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/relations.py#L337
+
+  Example:
+
+  ```
+  ibis.limit() ["n" = 10 : !i64] {
+    ...
+  }
+  ```
+  """
+  name = "ibis.limit"
+
+  table = SingleBlockRegionDef()
+  n = AttributeDef(IntegerAttr)
+
+  @staticmethod
+  @builder
+  def get(table: Region, n: int) -> 'Limit':
+    return Limit.create(regions=[table],
+                        attributes={"n": IntegerAttr.from_int_and_width(n, 64)})
+
+
+@irdl_op_definition
 class SchemaElement(Operation):
   """
   Defines a schema element with name `elt_name` and type `elt_type`.

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -239,6 +239,31 @@ class Operator(Operation):
 
 
 @irdl_op_definition
+class Limit(Operator):
+  """
+  Limits the number of tuples in `table` to `n` .
+
+  Example:
+
+  ```
+  rel_alg.limit() ["n" = 10 : !i64] {
+    ...
+  }
+  ```
+  """
+  name = "rel_alg.limit"
+
+  table = SingleBlockRegionDef()
+  n = AttributeDef(IntegerAttr)
+
+  @staticmethod
+  @builder
+  def get(table: Region, n: int) -> 'Limit':
+    return Limit.create(regions=[table],
+                        attributes={"n": IntegerAttr.from_int_and_width(n, 64)})
+
+
+@irdl_op_definition
 class OrderBy(Operator):
   """
   Orders the given input by the columns in `by`.

--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -490,6 +490,7 @@ class RelationalAlg:
     self.ctx.register_attr(Order)
 
     self.ctx.register_op(Table)
+    self.ctx.register_op(Limit)
     self.ctx.register_op(SchemaElement)
     self.ctx.register_op(Select)
     self.ctx.register_op(Project)

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -669,6 +669,32 @@ class Aggregate(Operator):
         ])
 
 
+@irdl_op_definition
+class Limit(Operator):
+  """
+  Limits the number of tuples in `input` to `n` .
+
+  Example:
+
+  ```
+  %0 : ... = rel_impl.limit(...) ["n" = 10 : !i64]
+  ```
+  """
+  name = "rel_impl.limit"
+
+  input = OperandDef(Bag)
+  n = AttributeDef(IntegerAttr)
+
+  result = ResultDef(Bag)
+
+  @staticmethod
+  @builder
+  def get(table: Operation, n: int) -> 'Limit':
+    return Limit.create(operands=[table.result],
+                        attributes={"n": IntegerAttr.from_int_and_width(n, 64)},
+                        result_types=[table.result.typ])
+
+
 @dataclass
 class RelImpl:
   ctx: MLContext
@@ -688,6 +714,7 @@ class RelImpl:
     self.ctx.register_attr(Order)
 
     self.ctx.register_op(Select)
+    self.ctx.register_op(Limit)
     self.ctx.register_op(MergeSort)
     self.ctx.register_op(Project)
     self.ctx.register_op(CartesianProduct)

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -427,19 +427,17 @@ class Operator(Operation):
 @irdl_op_definition
 class Limit(Operator):
   """
-  Limits the number of tuples in `table` to `n` .
+  Limits the number of tuples in `input` to `n` .
 
   Example:
 
   ```
-  relssa.limit() ["n" = 10 : !i64] {
-    ...
-  }
+  %0 : ... = rel_ssa.limit(...) ["n" = 10 : !i64]
   ```
   """
   name = "rel_ssa.limit"
 
-  table = OperandDef(Bag)
+  input = OperandDef(Bag)
   n = AttributeDef(IntegerAttr)
 
   result = ResultDef(Bag)

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -425,6 +425,34 @@ class Operator(Operation):
 
 
 @irdl_op_definition
+class Limit(Operator):
+  """
+  Limits the number of tuples in `table` to `n` .
+
+  Example:
+
+  ```
+  relssa.limit() ["n" = 10 : !i64] {
+    ...
+  }
+  ```
+  """
+  name = "rel_ssa.limit"
+
+  table = OperandDef(Bag)
+  n = AttributeDef(IntegerAttr)
+
+  result = ResultDef(Bag)
+
+  @staticmethod
+  @builder
+  def get(table: Operation, n: int) -> 'Limit':
+    return Limit.create(operands=[table.result],
+                        attributes={"n": IntegerAttr.from_int_and_width(n, 64)},
+                        result_types=[table.result.typ])
+
+
+@irdl_op_definition
 class OrderBy(Operator):
   """
   Orders the given input by the columns in `by`.
@@ -655,6 +683,7 @@ class RelSSA:
     self.ctx.register_op(Project)
     self.ctx.register_op(CartesianProduct)
     self.ctx.register_op(OrderBy)
+    self.ctx.register_op(Limit)
 
     self.ctx.register_op(Literal)
     self.ctx.register_op(Compare)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -139,6 +139,11 @@ def visit(op: ibis.expr.operations.relations.InnerJoin) -> Operation:
   return cart_prod
 
 
+@dispatch(ibis.expr.operations.relations.Limit)
+def visit(op: ibis.expr.operations.relations.Limit) -> Operation:
+  return id.Limit.get(Region.from_operation_list([visit(op.table)]), op.n)
+
+
 @dispatch(ibis.expr.operations.relations.Selection)
 def visit(  #type: ignore
     op: ibis.expr.operations.relations.Selection) -> Operation:

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -79,6 +79,17 @@ class LiteralRewriter(IbisRewriter):
 
 
 @dataclass
+class LimitRewriter(IbisRewriter):
+  # This is a simple 1-1 rewrite.
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: ibis.Limit, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(
+        RelAlg.Limit.get(rewriter.move_region_contents_to_new_regions(op.table),
+                         op.n.value.data))
+
+
+@dataclass
 class EqualsRewriter(IbisRewriter):
 
   @op_type_rewrite_pattern
@@ -266,6 +277,7 @@ def ibis_to_alg(ctx: MLContext, query: ModuleOp):
       SubtractRewriter(),
       DivideRewriter(),
       AddRewriter(),
+      LimitRewriter(),
       LiteralRewriter()
   ]),
                                 walk_regions_first=False,

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -216,6 +216,14 @@ class AggregateRewriter(RelSSARewriter):
             [o.data for o in op.by.data]))
 
 
+@dataclass
+class LimitRewriter(RelSSARewriter):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelSSA.Limit, rewriter: PatternRewriter):
+    rewriter.replace_matched_op(RelImpl.Limit.get(op.input.op, op.n.value.data))
+
+
 #===------------------------------------------------------------------------===#
 # Conversion setup
 #===------------------------------------------------------------------------===#
@@ -236,6 +244,7 @@ def ssa_to_impl(ctx: MLContext, query: ModuleOp):
       AndRewriter(),
       CartesianProductRewriter(),
       OrderByRewriter(),
+      LimitRewriter(),
       BinOpRewriter()
   ]),
                                 walk_regions_first=False,

--- a/experimental/sql/test/alg_to_ssa/limit.xdsl
+++ b/experimental/sql/test/alg_to_ssa/limit.xdsl
@@ -1,0 +1,13 @@
+// RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
+
+module() {
+  rel_alg.limit() ["n" = 10 : !i64] {
+    rel_alg.table() ["table_name" = "t"] {
+      rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.nullable<!rel_alg.string>]
+      rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.nullable<!rel_alg.int64>]
+      rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.nullable<!rel_alg.int64>]
+    }
+  }
+}
+
+// CHECK: rel_ssa.limit({{.*}} ["n" = 10 : !i64]

--- a/experimental/sql/test/frontend/limit.ibis
+++ b/experimental/sql/test/frontend/limit.ibis
@@ -1,0 +1,6 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.limit(10)
+
+# CHECK: ibis.limit() ["n" = 10 : !i64]

--- a/experimental/sql/test/ibis_to_alg/limit.xdsl
+++ b/experimental/sql/test/ibis_to_alg/limit.xdsl
@@ -1,0 +1,11 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+  ibis.limit() ["n" = 10 : !i64] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
+    }
+  }
+}

--- a/experimental/sql/test/ibis_to_alg/limit.xdsl
+++ b/experimental/sql/test/ibis_to_alg/limit.xdsl
@@ -9,3 +9,5 @@ module() {
     }
   }
 }
+
+// CHECK: rel_alg.limit() ["n" = 10 : !i64]

--- a/experimental/sql/test/ssa_to_impl/limit.xdsl
+++ b/experimental/sql/test/ssa_to_impl/limit.xdsl
@@ -1,0 +1,8 @@
+// RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
+
+module() {
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"b", !rel_ssa.nullable<!rel_ssa.int64>>, !rel_ssa.schema_element<"c", !rel_ssa.nullable<!rel_ssa.int64>>]> = rel_ssa.table() ["table_name" = "t"]
+  %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"b", !rel_ssa.nullable<!rel_ssa.int64>>, !rel_ssa.schema_element<"c", !rel_ssa.nullable<!rel_ssa.int64>>]> = rel_ssa.limit(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"b", !rel_ssa.nullable<!rel_ssa.int64>>, !rel_ssa.schema_element<"c", !rel_ssa.nullable<!rel_ssa.int64>>]>) ["n" = 10 : !i64]
+}
+
+// CHECK: rel_impl.limit({{.*}} ["n" = 10 : !i64]


### PR DESCRIPTION
This PR adds the limit node to the entire compilation stack. This is one of the more advanced operations that are still left, but it will give us another 3 queries, so I considered it worth it.

Notice that I do not model the `offset` part of the ibis expression as this is not needed for TPC-H at all.