### PR TITLE
SQL: update xdsl to v0.7.4

### DIFF
--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,7 +1,7 @@
 filecheck==0.0.18
 lit==14.0.0
 pytest==6.2.5
-xdsl==0.5.3
+xdsl==0.7.0
 yapf==0.32.0
 pyright==0.0.13
 frozenlist==1.2.*

--- a/experimental/sql/requirements.txt
+++ b/experimental/sql/requirements.txt
@@ -1,7 +1,7 @@
 filecheck==0.0.18
 lit==14.0.0
 pytest==6.2.5
-xdsl==0.7.0
+xdsl==0.7.4
 yapf==0.32.0
 pyright==0.0.13
 frozenlist==1.2.*

--- a/experimental/sql/test/alg_to_ssa/cartesian.xdsl
+++ b/experimental/sql/test/alg_to_ssa/cartesian.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.cartesian_product() {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int64]

--- a/experimental/sql/test/alg_to_ssa/count.xdsl
+++ b/experimental/sql/test/alg_to_ssa/count.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.aggregate() ["col_names" = [""], "functions" = ["count"], "res_names" = ["c"], "by" = []] {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/alg_to_ssa/count_column.xdsl
+++ b/experimental/sql/test/alg_to_ssa/count_column.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.aggregate() ["col_names" = ["b"], "functions" = ["count"], "res_names" = ["c"], "by" = []] {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/alg_to_ssa/datatypes.xdsl
+++ b/experimental/sql/test/alg_to_ssa/datatypes.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.table() ["table_name" = "some_name"] {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
         rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]

--- a/experimental/sql/test/alg_to_ssa/group_by.xdsl
+++ b/experimental/sql/test/alg_to_ssa/group_by.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
  rel_alg.aggregate() ["col_names" = ["c"], "functions" = ["sum"], "res_names" = ["c_sum"], "by" = ["a", "b"]] {
      rel_alg.table() ["table_name" = "t"] {
        rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]

--- a/experimental/sql/test/alg_to_ssa/limit.xdsl
+++ b/experimental/sql/test/alg_to_ssa/limit.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.limit() ["n" = 10 : !i64] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.nullable<!rel_alg.string>]

--- a/experimental/sql/test/alg_to_ssa/multi_cond.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multi_cond.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
    rel_alg.select() {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/alg_to_ssa/multiply.xdsl
+++ b/experimental/sql/test/alg_to_ssa/multiply.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]

--- a/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
+++ b/experimental/sql/test/alg_to_ssa/nesting_error.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.aggregate() ["col_names" = ["im"], "functions" = ["sum"], "res_names" = ["idsum"], "by" = []] {
         rel_alg.project() ["names" = ["im"]] {
             rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/alg_to_ssa/order_by.xdsl
+++ b/experimental/sql/test/alg_to_ssa/order_by.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.order_by() ["by" = [!rel_alg.order<"a", "asc">, !rel_alg.order<"b", "asc">]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]

--- a/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
+++ b/experimental/sql/test/alg_to_ssa/project_type_fix.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]

--- a/experimental/sql/test/alg_to_ssa/projection.xdsl
+++ b/experimental/sql/test/alg_to_ssa/projection.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["a", "b"]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]

--- a/experimental/sql/test/alg_to_ssa/selection_op.xdsl
+++ b/experimental/sql/test/alg_to_ssa/selection_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
    rel_alg.select() {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/alg_to_ssa/sum.xdsl
+++ b/experimental/sql/test/alg_to_ssa/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["idsum"], "by" = []] {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/alg_to_ssa/table_op.xdsl
+++ b/experimental/sql/test/alg_to_ssa/table_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p alg-to-ssa %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.table() ["table_name" = "some_name"] {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
     }

--- a/experimental/sql/test/fuse_proj_into_scan_tests/complex_projection.xdsl
+++ b/experimental/sql/test/fuse_proj_into_scan_tests/complex_projection.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p fuse-proj-into-scan  %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"add", !rel_impl.int32>, !rel_impl.schema_element<"a", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]>) {
   ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]>):

--- a/experimental/sql/test/fuse_proj_into_scan_tests/extended_case.xdsl
+++ b/experimental/sql/test/fuse_proj_into_scan_tests/extended_case.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p fuse-proj-into-scan  %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "lineitem"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]>) {
   ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>, !rel_impl.schema_element<"d", !rel_impl.int64>]>):

--- a/experimental/sql/test/fuse_proj_into_scan_tests/simple_case.xdsl
+++ b/experimental/sql/test/fuse_proj_into_scan_tests/simple_case.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p fuse-proj-into-scan %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):

--- a/experimental/sql/test/ibis_dialect_tests/multiply.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/multiply.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = ["d"]] {
       ibis.unbound_table() ["table_name" = "t"] {
         ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]

--- a/experimental/sql/test/ibis_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/projection.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 // Query: table['a', 'b']
-module() {
+builtin.module() {
   ibis.selection() ["names" = ["a", "b"]] {
     // selection input
     ibis.unbound_table() ["table_name" = "t"] {

--- a/experimental/sql/test/ibis_dialect_tests/selection.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/selection.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py %s | filecheck %s
 
 // Query: table.filter(table['a'] == 'AS')
-module() {
+builtin.module() {
   ibis.selection() ["names" = []] {
     // selection input
     ibis.unbound_table() ["table_name" = "t"] {

--- a/experimental/sql/test/ibis_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/ibis_dialect_tests/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]

--- a/experimental/sql/test/ibis_to_alg/LessEqual.xdsl
+++ b/experimental/sql/test/ibis_to_alg/LessEqual.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = []] {
      ibis.unbound_table() ["table_name" = "t"] {
        ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_to_alg/add.xdsl
+++ b/experimental/sql/test/ibis_to_alg/add.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.selection() ["names" = ["bc"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/between.xdsl
+++ b/experimental/sql/test/ibis_to_alg/between.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
  ibis.selection() ["names" = []] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]

--- a/experimental/sql/test/ibis_to_alg/cartesian.xdsl
+++ b/experimental/sql/test/ibis_to_alg/cartesian.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
  ibis.cartesian_product() {
   ibis.unbound_table() ["table_name" = "t"] {
     ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.int64>]

--- a/experimental/sql/test/ibis_to_alg/count.xdsl
+++ b/experimental/sql/test/ibis_to_alg/count.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/count_column.xdsl
+++ b/experimental/sql/test/ibis_to_alg/count_column.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/count_distinct.xdsl
+++ b/experimental/sql/test/ibis_to_alg/count_distinct.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/datatypes.xdsl
+++ b/experimental/sql/test/ibis_to_alg/datatypes.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
     ibis.unbound_table() ["table_name" = "some_name"] {
         ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int32]
         ibis.schema_element() ["elt_name" = "price", "elt_type" = !ibis.decimal<4 : !i32, 2 : !i32>]

--- a/experimental/sql/test/ibis_to_alg/divide.xdsl
+++ b/experimental/sql/test/ibis_to_alg/divide.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.selection() ["names" = ["bc"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/equals.xdsl
+++ b/experimental/sql/test/ibis_to_alg/equals.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = []] {
      ibis.unbound_table() ["table_name" = "t"] {
        ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_to_alg/greaterEqual.xdsl
+++ b/experimental/sql/test/ibis_to_alg/greaterEqual.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = []] {
      ibis.unbound_table() ["table_name" = "t"] {
        ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_to_alg/greaterThan.xdsl
+++ b/experimental/sql/test/ibis_to_alg/greaterThan.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = []] {
      ibis.unbound_table() ["table_name" = "t"] {
        ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_to_alg/group_by.xdsl
+++ b/experimental/sql/test/ibis_to_alg/group_by.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.aggregation() ["names" = ["c_sum"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/lessThan.xdsl
+++ b/experimental/sql/test/ibis_to_alg/lessThan.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = []] {
      ibis.unbound_table() ["table_name" = "t"] {
        ibis.schema_element() ["elt_name" = "id", "elt_type" = !ibis.int64]

--- a/experimental/sql/test/ibis_to_alg/limit.xdsl
+++ b/experimental/sql/test/ibis_to_alg/limit.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.limit() ["n" = 10 : !i64] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]

--- a/experimental/sql/test/ibis_to_alg/max.xdsl
+++ b/experimental/sql/test/ibis_to_alg/max.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/mean.xdsl
+++ b/experimental/sql/test/ibis_to_alg/mean.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/min.xdsl
+++ b/experimental/sql/test/ibis_to_alg/min.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/multiply.xdsl
+++ b/experimental/sql/test/ibis_to_alg/multiply.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.selection() ["names" = ["bc"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/order_by.xdsl
+++ b/experimental/sql/test/ibis_to_alg/order_by.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
  ibis.selection() ["names" = []] {
      ibis.unbound_table() ["table_name" = "t"] {
        ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]

--- a/experimental/sql/test/ibis_to_alg/projection.xdsl
+++ b/experimental/sql/test/ibis_to_alg/projection.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = ["a", "b"]] {
     // selection input
     ibis.unbound_table() ["table_name" = "t"] {

--- a/experimental/sql/test/ibis_to_alg/selection_op.xdsl
+++ b/experimental/sql/test/ibis_to_alg/selection_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.selection() ["names" = []] {
     // selection input
     ibis.unbound_table() ["table_name" = "t"] {

--- a/experimental/sql/test/ibis_to_alg/subtract.xdsl
+++ b/experimental/sql/test/ibis_to_alg/subtract.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.selection() ["names" = ["bc"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/sum.xdsl
+++ b/experimental/sql/test/ibis_to_alg/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
 ibis.aggregation() ["names" = ["b"]] {
     ibis.unbound_table() ["table_name" = "t"] {
       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]

--- a/experimental/sql/test/ibis_to_alg/table_op.xdsl
+++ b/experimental/sql/test/ibis_to_alg/table_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   ibis.unbound_table() ["table_name" = "t"] {
     ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.string]
   }

--- a/experimental/sql/test/impl_to_iterators/decimal.xdsl
+++ b/experimental/sql/test/impl_to_iterators/decimal.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>]>):

--- a/experimental/sql/test/impl_to_iterators/filter.xdsl
+++ b/experimental/sql/test/impl_to_iterators/filter.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>):
@@ -13,15 +13,15 @@ module() {
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
-// CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.filter(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["predicateRef" = @s0]
-// CHECK-NEXT:   iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
+// CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.filter(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>) ["predicateRef" = @s0]
+// CHECK-NEXT:   iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>)
 // CHECK-NEXT:   func.return()
 // CHECK-NEXT: }
-// CHECK-NEXT: func.func() ["sym_name" = "s0", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!i1]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.struct<"", [!i32]>):
+// CHECK-NEXT: func.func() ["sym_name" = "s0", "function_type" = !fun<[!llvm.struct<(!i32)>], [!i1]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.struct<(!i32)>):
 // CHECK-NEXT:     %{{.*}} : !i32 = arith.constant() ["value" = 0 : !i32]
-// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
 // CHECK-NEXT:     %{{.*}} : !i1 = arith.cmpi(%{{.*}} : !i32, %{{.*}} : !i32) ["predicate" = 4 : !i64]
 // CHECK-NEXT:     func.return(%{{.*}} : !i1)
 // CHECK-NEXT: }

--- a/experimental/sql/test/impl_to_iterators/filter_and.xdsl
+++ b/experimental/sql/test/impl_to_iterators/filter_and.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>) {
   ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>):

--- a/experimental/sql/test/impl_to_iterators/map.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):
@@ -12,16 +12,16 @@ module() {
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @m0]
-// CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>) ["mapFuncRef" = @m0]
+// CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>)
 // CHECK-NEXT:     func.return()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   func.func() ["sym_name" = "m0", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:     ^{{.*}}(%{{.*}} : !llvm.struct<"", [!i32]>):
-// CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:   func.func() ["sym_name" = "m0", "function_type" = !fun<[!llvm.struct<(!i32)>], [!llvm.struct<(!i32)>]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:     ^{{.*}}(%{{.*}} : !llvm.struct<(!i32)>):
+// CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
 // CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
-// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.mlir.undef()
-// CHECK-NEXT:       %{{.*}}: !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
-// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:       %{{.*}} : !llvm.struct<(!i32)> = llvm.mlir.undef()
+// CHECK-NEXT:       %{{.*}}: !llvm.struct<(!i32)> = llvm.insertvalue(%{{.*}} : !llvm.struct<(!i32)>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<(!i32)>)
 // CHECK-NEXT:   }

--- a/experimental/sql/test/impl_to_iterators/map_mul.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map_mul.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):

--- a/experimental/sql/test/impl_to_iterators/map_sub.xdsl
+++ b/experimental/sql/test/impl_to_iterators/map_sub.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"c", !rel_impl.int32>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"c", !rel_impl.int32>]>):

--- a/experimental/sql/test/impl_to_iterators/partial_scan.xdsl
+++ b/experimental/sql/test/impl_to_iterators/partial_scan.xdsl
@@ -1,12 +1,12 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int64>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t", "cols" = ["a", "b"]]
 }
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i64, !i64]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
 // CHECK-NEXT:   ^0(%0 : !iterators.columnar_batch<!tuple<[!i64, !i64]>>):
-// CHECK-NEXT:     %1 : !iterators.stream<!llvm.struct<"", [!i64, !i64]>> = iterators.scan_columnar_batch(%0 : !iterators.columnar_batch<!tuple<[!i64, !i64]>>)
-// CHECK-NEXT:     iterators.sink(%1 : !iterators.stream<!llvm.struct<"", [!i64, !i64]>>)
+// CHECK-NEXT:     %1 : !iterators.stream<!llvm.struct<(!i64, !i64)>> = iterators.scan_columnar_batch(%0 : !iterators.columnar_batch<!tuple<[!i64, !i64]>>)
+// CHECK-NEXT:     iterators.sink(%1 : !iterators.stream<!llvm.struct<(!i64, !i64)>>)
 // CHECK-NEXT:     func.return()
 // CHECK-NEXT:   }

--- a/experimental/sql/test/impl_to_iterators/sum.xdsl
+++ b/experimental/sql/test/impl_to_iterators/sum.xdsl
@@ -1,22 +1,22 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[!iterators.columnar_batch<!tuple<[!i32]>>], []>, "sym_visibility" = "private", "llvm.emit_c_interface"] {
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>):
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.reduce(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["reduceFuncRef" = @sum_struct]
-// CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>)
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.scan_columnar_batch(%{{.*}} : !iterators.columnar_batch<!tuple<[!i32]>>)
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.reduce(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>) ["reduceFuncRef" = @sum_struct]
+// CHECK-NEXT:     iterators.sink(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>)
 // CHECK-NEXT:     func.return()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   func.func() ["sym_name" = "sum_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>, !llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !llvm.struct<"", [!i32]>):
-// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
-// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:   func.func() ["sym_name" = "sum_struct", "function_type" = !fun<[!llvm.struct<(!i32)>, !llvm.struct<(!i32)>], [!llvm.struct<(!i32)>]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.struct<(!i32)>, %{{.*}} : !llvm.struct<(!i32)>):
+// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
+// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
 // CHECK-NEXT:     %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
-// CHECK-NEXT:     %{{.*}} : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
-// CHECK-NEXT:     func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:     %{{.*}} : !llvm.struct<(!i32)> = llvm.insertvalue(%{{.*}} : !llvm.struct<(!i32)>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:     func.return(%{{.*}} : !llvm.struct<(!i32)>)
 // CHECK-NEXT:   }

--- a/experimental/sql/test/impl_to_iterators/timestamp.xdsl
+++ b/experimental/sql/test/impl_to_iterators/timestamp.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p impl-to-iterators %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"date", !rel_impl.timestamp>]>):

--- a/experimental/sql/test/iterators_dialect_tests/filter.xdsl
+++ b/experimental/sql/test/iterators_dialect_tests/filter.xdsl
@@ -1,14 +1,14 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
   func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
-    %input : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[42 : !i32]]]
-    %reduce : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.filter(%input : !iterators.stream<!llvm.struct<"", [!i32]>>) ["predicateRef" = @is_positive_struct]
+    %input : !iterators.stream<!llvm.struct<(!i32)>> = iterators.constantstream() ["value" = [[42 : !i32]]]
+    %reduce : !iterators.stream<!llvm.struct<(!i32)>> = iterators.filter(%input : !iterators.stream<!llvm.struct<(!i32)>>) ["predicateRef" = @is_positive_struct]
     func.return()
   }
-  func.func() ["sym_name" = "is_positive_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!i1]>, "sym_visibility" = "private"] {
-    ^0(%struct : !llvm.struct<"", [!i32]>):
-      %i : !i32 = llvm.extractvalue(%struct : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+  func.func() ["sym_name" = "is_positive_struct", "function_type" = !fun<[!llvm.struct<(!i32)>], [!i1]>, "sym_visibility" = "private"] {
+    ^0(%struct : !llvm.struct<(!i32)>):
+      %i : !i32 = llvm.extractvalue(%struct : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
       %zero  : !i32 = arith.constant() ["value" = 0 : !i32]
       %cmp : !i1= arith.cmpi(%i :!i32, %zero : !i32) ["predicate" = 4 : !i64]
       func.return(%cmp : !i1)
@@ -16,13 +16,13 @@ module() {
 }
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
-// CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[42 : !i32]]]
-// CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.filter(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["predicateRef" = @is_positive_struct]
+// CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.constantstream() ["value" = [[42 : !i32]]]
+// CHECK-NEXT:   %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.filter(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>) ["predicateRef" = @is_positive_struct]
 // CHECK-NEXT:   func.return()
 // CHECK-NEXT: }
-// CHECK-NEXT: func.func() ["sym_name" = "is_positive_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!i1]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:   ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
-// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT: func.func() ["sym_name" = "is_positive_struct", "function_type" = !fun<[!llvm.struct<(!i32)>], [!i1]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:   ^0(%{{.*}} : !llvm.struct<(!i32)>):
+// CHECK-NEXT:     %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
 // CHECK-NEXT:     %{{.*}} : !i32 = arith.constant() ["value" = 0 : !i32]
 // CHECK-NEXT:     %{{.*}} : !i1 = arith.cmpi(%{{.*}} : !i32, %{{.*}} : !i32) ["predicate" = 4 : !i64]
 // CHECK-NEXT:     func.return(%{{.*}} : !i1)

--- a/experimental/sql/test/iterators_dialect_tests/map.xdsl
+++ b/experimental/sql/test/iterators_dialect_tests/map.xdsl
@@ -1,29 +1,29 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
   func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
-    %input : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
-    %map : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%input : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @double_struct]
+    %input : !iterators.stream<!llvm.struct<(!i32)>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+    %map : !iterators.stream<!llvm.struct<(!i32)>> = iterators.map(%input : !iterators.stream<!llvm.struct<(!i32)>>) ["mapFuncRef" = @double_struct]
     func.return()
   }
-  func.func() ["sym_name" = "double_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-    ^0(%struct : !llvm.struct<"", [!i32]>):
-      %i : !i32 = llvm.extractvalue(%struct : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+  func.func() ["sym_name" = "double_struct", "function_type" = !fun<[!llvm.struct<(!i32)>], [!llvm.struct<(!i32)>]>, "sym_visibility" = "private"] {
+    ^0(%struct : !llvm.struct<(!i32)>):
+      %i : !i32 = llvm.extractvalue(%struct : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
       %doubled : !i32 = arith.addi(%i : !i32, %i : !i32)
-      %result : !llvm.struct<"", [!i32]> = llvm.insertvalue(%struct : !llvm.struct<"", [!i32]>, %i : !i32) ["position" = [0 : !index]]
-      func.return(%result : !llvm.struct<"", [!i32]>)
+      %result : !llvm.struct<(!i32)> = llvm.insertvalue(%struct : !llvm.struct<(!i32)>, %i : !i32) ["position" = [0 : !index]]
+      func.return(%result : !llvm.struct<(!i32)>)
   }
 }
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "public"] {
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
-// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<"", [!i32]>>) ["mapFuncRef" = @double_struct]
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+// CHECK-NEXT:     %{{.*}} : !iterators.stream<!llvm.struct<(!i32)>> = iterators.map(%{{.*}} : !iterators.stream<!llvm.struct<(!i32)>>) ["mapFuncRef" = @double_struct]
 // CHECK-NEXT:     func.return()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   func.func() ["sym_name" = "double_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<"", [!i32]>):
-// CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:   func.func() ["sym_name" = "double_struct", "function_type" = !fun<[!llvm.struct<(!i32)>], [!llvm.struct<(!i32)>]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:     ^0(%{{.*}} : !llvm.struct<(!i32)>):
+// CHECK-NEXT:       %{{.*}} : !i32 = llvm.extractvalue(%{{.*}} : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
 // CHECK-NEXT:       %{{.*}} : !i32 = arith.addi(%{{.*}} : !i32, %{{.*}} : !i32)
-// CHECK-NEXT:       %{{.*}} : !llvm.struct<"", [!i32]> = llvm.insertvalue(%{{.*}} : !llvm.struct<"", [!i32]>, %{{.*}} : !i32) ["position" = [0 : !index]]
-// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:       %{{.*}} : !llvm.struct<(!i32)> = llvm.insertvalue(%{{.*}} : !llvm.struct<(!i32)>, %{{.*}} : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:       func.return(%{{.*}} : !llvm.struct<(!i32)>)
 // CHECK-NEXT:   }

--- a/experimental/sql/test/iterators_dialect_tests/simple-plan.xdsl
+++ b/experimental/sql/test/iterators_dialect_tests/simple-plan.xdsl
@@ -1,33 +1,33 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
  func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
-    %0 : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
-    %1 : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.reduce(%0 : !iterators.stream<!llvm.struct<"", [!i32]>>) ["reduceFuncRef" = @sum_struct]
-    iterators.sink(%1 : !iterators.stream<!llvm.struct<"", [!i32]>>)
+    %0 : !iterators.stream<!llvm.struct<(!i32)>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+    %1 : !iterators.stream<!llvm.struct<(!i32)>> = iterators.reduce(%0 : !iterators.stream<!llvm.struct<(!i32)>>) ["reduceFuncRef" = @sum_struct]
+    iterators.sink(%1 : !iterators.stream<!llvm.struct<(!i32)>>)
     func.return()
   }
-  func.func() ["sym_name" = "sum_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>, !llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-  ^0(%2 : !llvm.struct<"", [!i32]>, %3 : !llvm.struct<"", [!i32]>):
-    %lhsi : !i32 = llvm.extractvalue(%2 : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
-    %rhsi : !i32 = llvm.extractvalue(%3 : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+  func.func() ["sym_name" = "sum_struct", "function_type" = !fun<[!llvm.struct<(!i32)>, !llvm.struct<(!i32)>], [!llvm.struct<(!i32)>]>, "sym_visibility" = "private"] {
+  ^0(%2 : !llvm.struct<(!i32)>, %3 : !llvm.struct<(!i32)>):
+    %lhsi : !i32 = llvm.extractvalue(%2 : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
+    %rhsi : !i32 = llvm.extractvalue(%3 : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
     %i : !i32 = arith.addi(%lhsi : !i32, %rhsi : !i32)
-    %result : !llvm.struct<"", [!i32]> = llvm.insertvalue(%2 : !llvm.struct<"", [!i32]>, %i : !i32) ["position" = [0 : !index]]
-    func.return(%result : !llvm.struct<"", [!i32]>)
+    %result : !llvm.struct<(!i32)> = llvm.insertvalue(%2 : !llvm.struct<(!i32)>, %i : !i32) ["position" = [0 : !index]]
+    func.return(%result : !llvm.struct<(!i32)>)
   }
 }
 
 //      CHECK: func.func() ["sym_name" = "main", "function_type" = !fun<[], []>, "sym_visibility" = "private"] {
-// CHECK-NEXT:     %0 : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
-// CHECK-NEXT:     %1 : !iterators.stream<!llvm.struct<"", [!i32]>> = iterators.reduce(%0 : !iterators.stream<!llvm.struct<"", [!i32]>>) ["reduceFuncRef" = @sum_struct]
-// CHECK-NEXT:     iterators.sink(%1 : !iterators.stream<!llvm.struct<"", [!i32]>>)
+// CHECK-NEXT:     %0 : !iterators.stream<!llvm.struct<(!i32)>> = iterators.constantstream() ["value" = [[0 : !i32], [1 : !i32], [2 : !i32], [3 : !i32]]]
+// CHECK-NEXT:     %1 : !iterators.stream<!llvm.struct<(!i32)>> = iterators.reduce(%0 : !iterators.stream<!llvm.struct<(!i32)>>) ["reduceFuncRef" = @sum_struct]
+// CHECK-NEXT:     iterators.sink(%1 : !iterators.stream<!llvm.struct<(!i32)>>)
 // CHECK-NEXT:     func.return()
 // CHECK-NEXT:   }
-// CHECK-NEXT:   func.func() ["sym_name" = "sum_struct", "function_type" = !fun<[!llvm.struct<"", [!i32]>, !llvm.struct<"", [!i32]>], [!llvm.struct<"", [!i32]>]>, "sym_visibility" = "private"] {
-// CHECK-NEXT:   ^0(%2 : !llvm.struct<"", [!i32]>, %3 : !llvm.struct<"", [!i32]>):
-// CHECK-NEXT:     %lhsi : !i32 = llvm.extractvalue(%2 : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
-// CHECK-NEXT:     %rhsi : !i32 = llvm.extractvalue(%3 : !llvm.struct<"", [!i32]>) ["position" = [0 : !index]]
+// CHECK-NEXT:   func.func() ["sym_name" = "sum_struct", "function_type" = !fun<[!llvm.struct<(!i32)>, !llvm.struct<(!i32)>], [!llvm.struct<(!i32)>]>, "sym_visibility" = "private"] {
+// CHECK-NEXT:   ^0(%2 : !llvm.struct<(!i32)>, %3 : !llvm.struct<(!i32)>):
+// CHECK-NEXT:     %lhsi : !i32 = llvm.extractvalue(%2 : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
+// CHECK-NEXT:     %rhsi : !i32 = llvm.extractvalue(%3 : !llvm.struct<(!i32)>) ["position" = [0 : !index]]
 // CHECK-NEXT:     %i : !i32 = arith.addi(%lhsi : !i32, %rhsi : !i32)
-// CHECK-NEXT:     %result : !llvm.struct<"", [!i32]> = llvm.insertvalue(%2 : !llvm.struct<"", [!i32]>, %i : !i32) ["position" = [0 : !index]]
-// CHECK-NEXT:     func.return(%result : !llvm.struct<"", [!i32]>)
+// CHECK-NEXT:     %result : !llvm.struct<(!i32)> = llvm.insertvalue(%2 : !llvm.struct<(!i32)>, %i : !i32) ["position" = [0 : !index]]
+// CHECK-NEXT:     func.return(%result : !llvm.struct<(!i32)>)
 // CHECK-NEXT:   }

--- a/experimental/sql/test/projection_pushdown_tests/cart_prod.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/cart_prod.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.cartesian_product() {
       rel_alg.table() ["table_name" = "t"] {
           rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/projection_pushdown_tests/cart_prod_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/cart_prod_extended.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = ["c"]] {
     rel_alg.cartesian_product() {
         rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/extended_case.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/extended_case.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["im"], "functions" = ["sum"], "res_names" = ["revenue"], "by" = []] {
     rel_alg.project() ["names" = ["im"]] {
       rel_alg.select() {

--- a/experimental/sql/test/projection_pushdown_tests/grouped_aggregation.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/grouped_aggregation.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = ["b"]] {
       rel_alg.table() ["table_name" = "t"] {
           rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/projection_pushdown_tests/limit.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/limit.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.limit() ["n" = 10 : !i64] {
       rel_alg.table() ["table_name" = "t"] {
           rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/projection_pushdown_tests/limit_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/limit_extended.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = []] {
     rel_alg.limit() ["n" = 10 : !i64] {
         rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/multiply.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/multiply.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["im"]] {
     rel_alg.select() {
         rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/order_by.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/order_by.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.order_by() ["by" = [!rel_alg.order<"a", "desc">, !rel_alg.order<"b", "asc">]] {
       rel_alg.table() ["table_name" = "t"] {
           rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/projection_pushdown_tests/order_by_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/order_by_extended.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = []] {
     rel_alg.order_by() ["by" = [!rel_alg.order<"a", "desc">, !rel_alg.order<"b", "asc">]] {
         rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/rename.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/rename.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["b"], "by" = []] {
     rel_alg.project() ["names" = ["b", "a"]] {
       rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/rename_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/rename_extended.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["add"], "functions" = ["sum"], "res_names" = ["b"], "by" = ["a"]] {
     rel_alg.project() ["names" = ["b", "a", "add"]] {
       rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/rename_select.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/rename_select.xdsl
@@ -4,7 +4,7 @@
 // The renaming projection outside could be pushed through the select and then
 // fused with a projection on the basetables.
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["c"]] {
     rel_alg.select() {
         rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/simple_case.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/simple_case.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["id"]] {
     rel_alg.select() {
         rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/projection_pushdown_tests/sum.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["b"], "by" = []] {
       rel_alg.table() ["table_name" = "t"] {
           rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/projection_pushdown_tests/sum_with_select.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/sum_with_select.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["id"], "functions" = ["sum"], "res_names" = ["b"], "by" = []] {
     rel_alg.select() {
       rel_alg.table() ["table_name" = "lineitem"] {

--- a/experimental/sql/test/projection_pushdown_tests/table_op.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/table_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.table() ["table_name" = "some_name"] {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
     }

--- a/experimental/sql/test/projection_pushdown_tests/useless_project.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/useless_project.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["b"], "by" = []] {
     rel_alg.project() ["names" = ["a", "b"]] {
       rel_alg.table() ["table_name" = "t"] {

--- a/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/datatypes.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.table() ["table_name" = "some_name"] {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
         rel_alg.schema_element() ["elt_name" = "price", "elt_type" = !rel_alg.decimal<4 : !i32, 2 : !i32>]

--- a/experimental/sql/test/relational_algebra_dialect_tests/multiply.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/multiply.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["bc"]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]

--- a/experimental/sql/test/relational_algebra_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/projection.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
 
-module() {
+builtin.module() {
   rel_alg.project() ["names" = ["a", "b"]] {
     rel_alg.table() ["table_name" = "t"] {
       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.string]

--- a/experimental/sql/test/relational_algebra_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/selection_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.select() {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/relational_algebra_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.aggregate() ["col_names" = ["b"], "functions" = ["sum"], "res_names" = ["b"], "by" = []] {
         rel_alg.table() ["table_name" = "t"] {
             rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]

--- a/experimental/sql/test/relational_algebra_dialect_tests/table_op.xdsl
+++ b/experimental/sql/test/relational_algebra_dialect_tests/table_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     rel_alg.table() ["table_name" = "some_name"] {
         rel_alg.schema_element() ["elt_name" = "id", "elt_type" = !rel_alg.int32]
     }

--- a/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/datatypes.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 }
 

--- a/experimental/sql/test/relational_implementation_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/projection.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]> = rel_impl.full_table_scan() ["table_name" = "t"]
   %1 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>) {
     ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.string>, !rel_impl.schema_element<"b", !rel_impl.int64>, !rel_impl.schema_element<"c", !rel_impl.int64>]>):

--- a/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/selection_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.select(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) {
       ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"id", !rel_impl.int32>]>):

--- a/experimental/sql/test/relational_implementation_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
     %1 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.aggregate(%0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }

--- a/experimental/sql/test/relational_implementation_dialect_tests/table_op.xdsl
+++ b/experimental/sql/test/relational_implementation_dialect_tests/table_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
 }
 

--- a/experimental/sql/test/relational_ssa_dialect_tests/datatypes.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/datatypes.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 

--- a/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/projection.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.string = rel_ssa.column() ["col_name" = "a"]

--- a/experimental/sql/test/relational_ssa_dialect_tests/selection_op.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/selection_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
     %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.select(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) {
         %2 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 5 : !i32]

--- a/experimental/sql/test/relational_ssa_dialect_tests/sum.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
     %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }

--- a/experimental/sql/test/relational_ssa_dialect_tests/table_op.xdsl
+++ b/experimental/sql/test/relational_ssa_dialect_tests/table_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 

--- a/experimental/sql/test/ssa_to_impl/cartesian.xdsl
+++ b/experimental/sql/test/ssa_to_impl/cartesian.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.int64>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>, !rel_ssa.schema_element<"d", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "u"]
   %2 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.int64>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>, !rel_ssa.schema_element<"d", !rel_ssa.int64>]> = rel_ssa.cartesian_product(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.int64>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]>, %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>, !rel_ssa.schema_element<"d", !rel_ssa.int64>]>)

--- a/experimental/sql/test/ssa_to_impl/count.xdsl
+++ b/experimental/sql/test/ssa_to_impl/count.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
     %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = [""], "functions" = ["count"], "by" = []]
 }

--- a/experimental/sql/test/ssa_to_impl/count_column.xdsl
+++ b/experimental/sql/test/ssa_to_impl/count_column.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
     %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["b"], "functions" = ["count"], "by" = []]
 }

--- a/experimental/sql/test/ssa_to_impl/datatypes.xdsl
+++ b/experimental/sql/test/ssa_to_impl/datatypes.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"fraction", !rel_ssa.float64>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 

--- a/experimental/sql/test/ssa_to_impl/datatypes.xdsl
+++ b/experimental/sql/test/ssa_to_impl/datatypes.xdsl
@@ -1,12 +1,7 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-<<<<<<< HEAD
 module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"fraction", !rel_ssa.float64>]> = rel_ssa.table() ["table_name" = "some_name"]
-=======
-builtin.module() {
-  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>]> = rel_ssa.table() ["table_name" = "some_name"]
->>>>>>> 1ea577aac5f1 (update xdsl)
 }
 
 // CHECK: %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>, !rel_impl.schema_element<"second_name", !rel_impl.nullable<!rel_impl.string>>, !rel_impl.schema_element<"fraction", !rel_impl.float64>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/ssa_to_impl/datatypes.xdsl
+++ b/experimental/sql/test/ssa_to_impl/datatypes.xdsl
@@ -1,7 +1,12 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
+<<<<<<< HEAD
 module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"fraction", !rel_ssa.float64>]> = rel_ssa.table() ["table_name" = "some_name"]
+=======
+builtin.module() {
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>]> = rel_ssa.table() ["table_name" = "some_name"]
+>>>>>>> 1ea577aac5f1 (update xdsl)
 }
 
 // CHECK: %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>, !rel_impl.schema_element<"second_name", !rel_impl.nullable<!rel_impl.string>>, !rel_impl.schema_element<"fraction", !rel_impl.float64>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]

--- a/experimental/sql/test/ssa_to_impl/group_by.xdsl
+++ b/experimental/sql/test/ssa_to_impl/group_by.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"c_sum", !rel_ssa.int64>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["col_names" = ["c"], "functions" = ["sum"], "by" = ["a", "b"]]
 }

--- a/experimental/sql/test/ssa_to_impl/limit.xdsl
+++ b/experimental/sql/test/ssa_to_impl/limit.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"b", !rel_ssa.nullable<!rel_ssa.int64>>, !rel_ssa.schema_element<"c", !rel_ssa.nullable<!rel_ssa.int64>>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"b", !rel_ssa.nullable<!rel_ssa.int64>>, !rel_ssa.schema_element<"c", !rel_ssa.nullable<!rel_ssa.int64>>]> = rel_ssa.limit(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"b", !rel_ssa.nullable<!rel_ssa.int64>>, !rel_ssa.schema_element<"c", !rel_ssa.nullable<!rel_ssa.int64>>]>) ["n" = 10 : !i64]
 }

--- a/experimental/sql/test/ssa_to_impl/multi_cond.xdsl
+++ b/experimental/sql/test/ssa_to_impl/multi_cond.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"b", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"b", !rel_ssa.int32>]> = rel_ssa.select(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"b", !rel_ssa.int32>]>) {
       %2 : !rel_ssa.int32 = rel_ssa.column() ["col_name" = "id"]

--- a/experimental/sql/test/ssa_to_impl/multiply.xdsl
+++ b/experimental/sql/test/ssa_to_impl/multiply.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"bc", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.int64 = rel_ssa.column() ["col_name" = "b"]

--- a/experimental/sql/test/ssa_to_impl/order_by.xdsl
+++ b/experimental/sql/test/ssa_to_impl/order_by.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.order_by(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) ["by" = [!rel_ssa.order<"a", "asc">, !rel_ssa.order<"b", "asc">]]
 }

--- a/experimental/sql/test/ssa_to_impl/projection.xdsl
+++ b/experimental/sql/test/ssa_to_impl/projection.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
   %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]> = rel_ssa.table() ["table_name" = "t"]
   %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>]> = rel_ssa.project(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"a", !rel_ssa.string>, !rel_ssa.schema_element<"b", !rel_ssa.int64>, !rel_ssa.schema_element<"c", !rel_ssa.int64>]>) {
     %2 : !rel_ssa.string = rel_ssa.column() ["col_name" = "a"]

--- a/experimental/sql/test/ssa_to_impl/selection_op.xdsl
+++ b/experimental/sql/test/ssa_to_impl/selection_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
     %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.select(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) {
         %2 : !rel_ssa.int32 = rel_ssa.literal() ["value" = 5 : !i32]

--- a/experimental/sql/test/ssa_to_impl/sum.xdsl
+++ b/experimental/sql/test/ssa_to_impl/sum.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
     %1 : !rel_ssa.bag<[!rel_ssa.schema_element<"idsum", !rel_ssa.int32>]> = rel_ssa.aggregate(%0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]>) ["col_names" = ["id"], "functions" = ["sum"], "by" = []]
 }

--- a/experimental/sql/test/ssa_to_impl/table_op.xdsl
+++ b/experimental/sql/test/ssa_to_impl/table_op.xdsl
@@ -1,6 +1,6 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
-module() {
+builtin.module() {
     %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 


### PR DESCRIPTION
This PR updates xdsl to v0.7.0. This contains a renaming for `module` to `builtin.module` and a new way of printing and parsing structs. I need some newer features in order to represent Float values in the IR, which is needed for one of the TPC-H queries.