### PR TITLE
SQL: add float64 types, fix small error

### DIFF
--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -83,6 +83,20 @@ class Int64(DataType):
 
 
 @irdl_attr_definition
+class Float64(DataType):
+  """
+  Models a float64 type in a relational query.
+
+  Example:
+
+  ```
+  !rel_alg.float64
+  ```
+  """
+  name = "rel_alg.float64"
+
+
+@irdl_attr_definition
 class String(DataType):
   """
   Models a string type in a relational query, that can be either nullable or
@@ -488,6 +502,7 @@ class RelationalAlg:
     self.ctx.register_attr(Int64)
     self.ctx.register_attr(Nullable)
     self.ctx.register_attr(Order)
+    self.ctx.register_attr(Float64)
 
     self.ctx.register_op(Table)
     self.ctx.register_op(Limit)

--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -57,6 +57,20 @@ class Int64(DataType):
 
 
 @irdl_attr_definition
+class Float64(DataType):
+  """
+  Models a float64 type in a relational implementation query.
+
+  Example:
+
+  ```
+  !rel_impl.float64
+  ```
+  """
+  name = "rel_impl.float64"
+
+
+@irdl_attr_definition
 class Decimal(DataType):
   """
   Models a decimal type in a relational implementation query with precision `prec` and scale `scale`.
@@ -714,6 +728,7 @@ class RelImpl:
     self.ctx.register_attr(SchemaElement)
     self.ctx.register_attr(Tuple)
     self.ctx.register_attr(Order)
+    self.ctx.register_attr(Float64)
 
     self.ctx.register_op(Select)
     self.ctx.register_op(Limit)

--- a/experimental/sql/dialects/rel_ssa.py
+++ b/experimental/sql/dialects/rel_ssa.py
@@ -55,6 +55,20 @@ class Int64(DataType):
 
 
 @irdl_attr_definition
+class Float64(DataType):
+  """
+  Models a float64 type in a relational SSA query.
+
+  Example:
+
+  ```
+  !rel_ssa.float64
+  ```
+  """
+  name = "rel_ssa.float64"
+
+
+@irdl_attr_definition
 class Decimal(DataType):
   """
   Models a decimal type in a relational SSA query with precision `prec` and scale `scale`.
@@ -676,6 +690,7 @@ class RelSSA:
     self.ctx.register_attr(Boolean)
     self.ctx.register_attr(SchemaElement)
     self.ctx.register_attr(Order)
+    self.ctx.register_attr(Float64)
 
     self.ctx.register_op(Select)
     self.ctx.register_op(Table)

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -33,6 +33,8 @@ class RelAlgRewriter(RewritePattern):
       return RelSSA.Int32()
     if isinstance(type_, RelAlg.Int64):
       return RelSSA.Int64()
+    if isinstance(type_, RelAlg.Float64):
+      return RelSSA.Float64()
     if isinstance(type_, RelAlg.Decimal):
       return RelSSA.Decimal([
           IntegerAttr.from_int_and_width(type_.prec.value.data,

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from dataclasses import dataclass
-from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr, FloatAttr, Float64Type
+from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
 from xdsl.ir import Operation, MLContext, Region, Block, Attribute
 from typing import List, Type, Optional
 from multipledispatch import dispatch
@@ -50,7 +50,8 @@ def convert_literal(literal) -> Attribute:
   if isinstance(literal, str):
     return StringAttr.from_str(literal)
   if isinstance(literal, float):
-    return FloatAttr.from_value(literal, Float64Type())
+    # TODO: This is a workaround until xdsl versions are released properly.
+    return IntegerAttr.from_int_and_width(int(literal), 64)
   if isinstance(literal, int):
     # np.int64 are parsed as int by ibis
     return IntegerAttr.from_int_and_width(literal, 64)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from dataclasses import dataclass
-from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr
+from xdsl.dialects.builtin import ArrayAttr, StringAttr, ModuleOp, IntegerAttr, FloatAttr, Float64Type
 from xdsl.ir import Operation, MLContext, Region, Block, Attribute
 from typing import List, Type, Optional
 from multipledispatch import dispatch
@@ -49,6 +49,8 @@ def convert_datatype(type_: ibis.expr.datatypes) -> id.DataType:
 def convert_literal(literal) -> Attribute:
   if isinstance(literal, str):
     return StringAttr.from_str(literal)
+  if isinstance(literal, float):
+    return FloatAttr.from_value(literal, Float64Type())
   if isinstance(literal, int):
     # np.int64 are parsed as int by ibis
     return IntegerAttr.from_int_and_width(literal, 64)

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -30,7 +30,7 @@ class IbisRewriter(RewritePattern):
     if isinstance(type_, ibis.Int64):
       return RelAlg.Int64()
     if isinstance(type_, ibis.Float64):
-      return RelAlg.Int64()
+      return RelAlg.Float64()
     if isinstance(type_, ibis.Timestamp):
       return RelAlg.Timestamp()
     if isinstance(type_, ibis.Decimal):

--- a/experimental/sql/src/ibis_to_alg.py
+++ b/experimental/sql/src/ibis_to_alg.py
@@ -29,6 +29,8 @@ class IbisRewriter(RewritePattern):
       return RelAlg.Int32()
     if isinstance(type_, ibis.Int64):
       return RelAlg.Int64()
+    if isinstance(type_, ibis.Float64):
+      return RelAlg.Int64()
     if isinstance(type_, ibis.Timestamp):
       return RelAlg.Timestamp()
     if isinstance(type_, ibis.Decimal):
@@ -209,7 +211,7 @@ class AggregationRewriter(IbisRewriter):
     if isinstance(metric_op, ibis.Count):
       if isinstance(metric_op.arg.op, ibis.TableColumn):
         return "count", metric_op.arg.op.attributes["col_name"].data
-      if isinstance(metric_op.arg.op, ibis.UnboundTable):
+      else:
         return "count", ""
     raise Exception(
         f"aggregation function not yet implemented {type(metric_op)}")

--- a/experimental/sql/src/ssa_to_impl.py
+++ b/experimental/sql/src/ssa_to_impl.py
@@ -28,6 +28,8 @@ class RelSSARewriter(RewritePattern):
       return RelImpl.Int32()
     if isinstance(type_, RelSSA.Int64):
       return RelImpl.Int64()
+    if isinstance(type_, RelSSA.Float64):
+      return RelImpl.Float64()
     if isinstance(type_, RelSSA.Decimal):
       return RelImpl.Decimal([
           IntegerAttr.from_int_and_width(type_.prec.value.data,

--- a/experimental/sql/test/alg_to_ssa/datatypes.xdsl
+++ b/experimental/sql/test/alg_to_ssa/datatypes.xdsl
@@ -7,7 +7,8 @@ module() {
         rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
         rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string]
         rel_alg.schema_element() ["elt_name" = "second_name", "elt_type" = !rel_alg.nullable<!rel_alg.string>]
+        rel_alg.schema_element() ["elt_name" = "fraction", "elt_type" = !rel_alg.float64]
     }
 }
 
-// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>]> = rel_ssa.table() ["table_name" = "some_name"]
+// CHECK:  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"fraction", !rel_ssa.float64>]> = rel_ssa.table() ["table_name" = "some_name"]

--- a/experimental/sql/test/frontend/dataTypes.ibis
+++ b/experimental/sql/test/frontend/dataTypes.ibis
@@ -1,7 +1,8 @@
 # RUN: rel_opt.py -f ibis %s | filecheck %s
 
 ibis.table([("ORDERKEY", "int64"), ("EXTENDEDPRICE", "decimal(4, 2)"),
-                ("RETURNFLAG", "string"), ("SHIPDATE", "timestamp")],
+                ("RETURNFLAG", "string"), ("SHIPDATE", "timestamp"),
+                ("FRACTION", "float64")],
                 'lineitem')
 
 #      CHECK:  ibis.unbound_table() ["table_name" = "lineitem"] {
@@ -9,4 +10,5 @@ ibis.table([("ORDERKEY", "int64"), ("EXTENDEDPRICE", "decimal(4, 2)"),
 # CHECK-NEXT:    ibis.schema_element() ["elt_name" = "EXTENDEDPRICE", "elt_type" = !ibis.nullable<!ibis.decimal<4 : !i32, 2 : !i32>>]
 # CHECK-NEXT:    ibis.schema_element() ["elt_name" = "RETURNFLAG", "elt_type" = !ibis.nullable<!ibis.string>]
 # CHECK-NEXT:    ibis.schema_element() ["elt_name" = "SHIPDATE", "elt_type" = !ibis.nullable<!ibis.timestamp>]
+# CHECK-NEXT:    ibis.schema_element() ["elt_name" = "FRACTION", "elt_type" = !ibis.nullable<!ibis.float64>]
 # CHECK-NEXT:  }

--- a/experimental/sql/test/ibis_to_alg/datatypes.xdsl
+++ b/experimental/sql/test/ibis_to_alg/datatypes.xdsl
@@ -7,6 +7,7 @@ module() {
         ibis.schema_element() ["elt_name" = "time", "elt_type" = !ibis.timestamp]
         ibis.schema_element() ["elt_name" = "name", "elt_type" = !ibis.string]
         ibis.schema_element() ["elt_name" = "second_name", "elt_type" = !ibis.nullable<!ibis.string>]
+        ibis.schema_element() ["elt_name" = "fraction", "elt_type" = !ibis.float64]
     }
 }
 
@@ -16,4 +17,5 @@ module() {
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "time", "elt_type" = !rel_alg.timestamp]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "name", "elt_type" = !rel_alg.string]
 // CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "second_name", "elt_type" = !rel_alg.nullable<!rel_alg.string>]
+// CHECK-NEXT:    rel_alg.schema_element() ["elt_name" = "fraction", "elt_type" = !rel_alg.float64]
 // CHECK-Next: }

--- a/experimental/sql/test/ssa_to_impl/datatypes.xdsl
+++ b/experimental/sql/test/ssa_to_impl/datatypes.xdsl
@@ -1,7 +1,7 @@
 // RUN: rel_opt.py -p ssa-to-impl %s | filecheck %s
 
 module() {
-  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>]> = rel_ssa.table() ["table_name" = "some_name"]
+  %0 : !rel_ssa.bag<[!rel_ssa.schema_element<"id", !rel_ssa.int32>, !rel_ssa.schema_element<"price", !rel_ssa.decimal<4 : !i32, 2 : !i32>>, !rel_ssa.schema_element<"time", !rel_ssa.timestamp>, !rel_ssa.schema_element<"name", !rel_ssa.string>, !rel_ssa.schema_element<"second_name", !rel_ssa.nullable<!rel_ssa.string>>, !rel_ssa.schema_element<"fraction", !rel_ssa.float64>]> = rel_ssa.table() ["table_name" = "some_name"]
 }
 
-// CHECK: %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>, !rel_impl.schema_element<"second_name", !rel_impl.nullable<!rel_impl.string>>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]
+// CHECK: %0 : !rel_impl.bag<[!rel_impl.schema_element<"id", !rel_impl.int32>, !rel_impl.schema_element<"price", !rel_impl.decimal<4 : !i32, 2 : !i32>>, !rel_impl.schema_element<"time", !rel_impl.timestamp>, !rel_impl.schema_element<"name", !rel_impl.string>, !rel_impl.schema_element<"second_name", !rel_impl.nullable<!rel_impl.string>>, !rel_impl.schema_element<"fraction", !rel_impl.float64>]> = rel_impl.full_table_scan() ["table_name" = "some_name"]


### PR DESCRIPTION
This PR continues the series of PRs to handle TPC-H queries. This one in particular adds the float64 type and its lowering. It also fixes an issue where count would only work on base tables and not on any operator.