### PR TITLE
Iterators: Add boilerplate code for new tabular dialect and lowering to LLVM

### DIFF
--- a/experimental/iterators/include/iterators-c/Dialects.h
+++ b/experimental/iterators/include/iterators-c/Dialects.h
@@ -29,6 +29,12 @@ bool mlirTypeIsAIteratorsStreamType(MlirType type);
 MLIR_CAPI_EXPORTED
 MlirType mlirIteratorsStreamTypeGet(MlirContext context, MlirType elementType);
 
+//===----------------------------------------------------------------------===//
+// Tabular dialect and types
+//===----------------------------------------------------------------------===//
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Tabular, tabular);
+
 #ifdef __cplusplus
 }
 #endif

--- a/experimental/iterators/include/iterators/Conversion/Passes.h
+++ b/experimental/iterators/include/iterators/Conversion/Passes.h
@@ -10,6 +10,7 @@
 #define ITERATORS_CONVERSION_PASSES_H
 
 #include "iterators/Conversion/IteratorsToLLVM/IteratorsToLLVM.h"
+#include "iterators/Conversion/TabularToLLVM/TabularToLLVM.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {

--- a/experimental/iterators/include/iterators/Conversion/Passes.td
+++ b/experimental/iterators/include/iterators/Conversion/Passes.td
@@ -58,4 +58,19 @@ def ConvertIteratorsToLLVM : Pass<"convert-iterators-to-llvm", "ModuleOp"> {
   ];
 }
 
+//===----------------------------------------------------------------------===//
+// TabularToLLVM
+//===----------------------------------------------------------------------===//
+
+def ConvertTabularToLLVM : Pass<"convert-tabular-to-llvm", "ModuleOp"> {
+  let summary = "Convert the tabular dialect to the LLVM dialect";
+  let description = [{
+    Convert the data types and ops from the tabular dialect to the LLVM dialect.
+    The data types are typically variations of LLVM's structs and pointers; the
+    ops, thus, translate to the LLVM ops handling structs and pointers.
+  }];
+  let constructor = "mlir::createConvertTabularToLLVMPass()";
+  let dependentDialects = ["LLVM::LLVMDialect"];
+}
+
 #endif // ITERATORS_CONVERSION_PASSES

--- a/experimental/iterators/include/iterators/Conversion/TabularToLLVM/TabularToLLVM.h
+++ b/experimental/iterators/include/iterators/Conversion/TabularToLLVM/TabularToLLVM.h
@@ -1,0 +1,34 @@
+//===-- TabularToLLVM.h - Utils to convert from Tabular ---------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ITERATORS_CONVERSION_TABULARTOLLVM_TABULARTOLLVM_H
+#define ITERATORS_CONVERSION_TABULARTOLLVM_TABULARTOLLVM_H
+
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+template <typename T>
+class OperationPass;
+class RewritePatternSet;
+class TypeConverter;
+
+namespace iterators {
+
+/// Populate the given list with patterns that convert from Tabular to LLVM.
+void populateTabularToLLVMConversionPatterns(RewritePatternSet &patterns,
+                                             TypeConverter &typeConverter);
+
+} // namespace iterators
+
+/// Create a pass to convert Tabular operations to the LLVM dialect.
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTabularToLLVMPass();
+
+} // namespace mlir
+
+#endif // ITERATORS_CONVERSION_TABULARTOLLVM_TABULARTOLLVM_H

--- a/experimental/iterators/include/iterators/Dialect/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Iterators)
+add_subdirectory(Tabular)

--- a/experimental/iterators/include/iterators/Dialect/Tabular/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/Tabular/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/experimental/iterators/include/iterators/Dialect/Tabular/IR/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/Tabular/IR/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_mlir_dialect(TabularOps tabular)
+add_dependencies(MLIRTabular MLIRTabularOpsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS TabularInterfaces.td)
+mlir_tablegen(TabularOpInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(TabularOpInterfaces.cpp.inc -gen-op-interface-defs)
+mlir_tablegen(TabularTypeInterfaces.h.inc -gen-type-interface-decls)
+mlir_tablegen(TabularTypeInterfaces.cpp.inc -gen-type-interface-defs)
+add_public_tablegen_target(MLIRTabularInterfacesIncGen)
+add_dependencies(MLIRTabular MLIRTabularInterfacesIncGen)
+
+add_dependencies(mlir-headers
+  MLIRTabularInterfacesIncGen
+  MLIRTabularOpsIncGen
+)

--- a/experimental/iterators/include/iterators/Dialect/Tabular/IR/Tabular.h
+++ b/experimental/iterators/include/iterators/Dialect/Tabular/IR/Tabular.h
@@ -1,0 +1,33 @@
+//===-- TabularDialect.h - Tabular dialect ----------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TABULAR_DIALECT_TABULAR_IR_TABULAR_H
+#define TABULAR_DIALECT_TABULAR_IR_TABULAR_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Interfaces/InferTypeOpInterface.h"
+
+#include "iterators/Dialect/Tabular/IR/TabularOpsDialect.h.inc"
+
+namespace mlir {
+namespace iterators {
+#include "iterators/Dialect/Tabular/IR/TabularOpInterfaces.h.inc"
+#include "iterators/Dialect/Tabular/IR/TabularTypeInterfaces.h.inc"
+} // namespace iterators
+} // namespace mlir
+
+#define GET_TYPEDEF_CLASSES
+#include "iterators/Dialect/Tabular/IR/TabularOpsTypes.h.inc"
+
+#define GET_OP_CLASSES
+#include "iterators/Dialect/Tabular/IR/TabularOps.h.inc"
+
+#endif // TABULAR_DIALECT_TABULAR_IR_TABULAR_H

--- a/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularDialect.td
+++ b/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularDialect.td
@@ -1,0 +1,34 @@
+//===-- TabularDialect.td - Tabular dialect ----------------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TABULAR_DIALECT_TABULAR_IR_TABULARDIALECT
+#define TABULAR_DIALECT_TABULAR_IR_TABULARDIALECT
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// Dialect definition
+//===----------------------------------------------------------------------===//
+
+def Tabular_Dialect : Dialect {
+  let name = "tabular";
+  let cppNamespace = "::mlir::iterators";
+  let summary = "Dialect for dealing with tabular data.";
+  let description = [{
+    This dialect models data types and ops related to tabular data, i.e.,
+    two-dimensional data where different values in the row dimension may have
+    mixed types but all values in each column have the same type. It is largely
+    orthogonal to the Iterators dialect; the connection consists in the fact
+    that one may want to "iterate" over tabular data, i.e., convert tabular data
+    to a stream of data. The lowering of the two dialects is currently somewhat
+    intervowen but they should ideally be independent of each other.
+  }];
+  let useDefaultTypePrinterParser = 0;
+}
+
+#endif // TABULAR_DIALECT_TABULAR_IR_TABULARDIALECT

--- a/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularInterfaces.td
+++ b/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularInterfaces.td
@@ -1,0 +1,14 @@
+//===-- TabularInterfaces.td - Tabular interfaces ----------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TABULAR_DIALECT_TABULAR_IR_TABULARINTERFACES
+#define TABULAR_DIALECT_TABULAR_IR_TABULARINTERFACES
+
+include "mlir/IR/OpBase.td"
+
+#endif // TABULAR_DIALECT_TABULAR_IR_TABULARINTERFACES

--- a/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularOps.td
@@ -1,0 +1,20 @@
+//===-- TabularOps.td - Tabular operations definitions -----*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TABULAR_DIALECT_TABULAR_IR_TABULAROPS
+#define TABULAR_DIALECT_TABULAR_IR_TABULAROPS
+
+include "iterators/Dialect/Tabular/IR/TabularDialect.td"
+include "iterators/Dialect/Tabular/IR/TabularTypes.td"
+include "mlir/IR/OpBase.td"
+
+class Tabular_Op<string mnemonic, list<Trait> traits = []> :
+  Op<Tabular_Dialect, mnemonic, traits> {
+}
+
+#endif // TABULAR_DIALECT_TABULAR_IR_TABULAROPS

--- a/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Tabular/IR/TabularTypes.td
@@ -1,0 +1,25 @@
+//===-- TabularTypes.td - Tabular dialect types ------------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TABULAR_DIALECT_TABULAR_IR_TABULARTYPES
+#define TABULAR_DIALECT_TABULAR_IR_TABULARTYPES
+
+include "iterators/Dialect/Tabular/IR/TabularDialect.td"
+include "iterators/Dialect/Tabular/IR/TabularInterfaces.td"
+include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/OpBase.td"
+
+// Base class for Tabular dialect types.
+class Tabular_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<Tabular_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+#endif // TABULAR_DIALECT_TABULAR_IR_TABULARTYPES

--- a/experimental/iterators/lib/CAPI/CMakeLists.txt
+++ b/experimental/iterators/lib/CAPI/CMakeLists.txt
@@ -5,5 +5,6 @@ add_mlir_public_c_api_library(IteratorsCAPI
     MLIRIterators
     MLIRIteratorsToLLVM
     MLIRTabular
+    MLIRTabularToLLVM
     MLIRPass
 )

--- a/experimental/iterators/lib/CAPI/CMakeLists.txt
+++ b/experimental/iterators/lib/CAPI/CMakeLists.txt
@@ -4,5 +4,6 @@ add_mlir_public_c_api_library(IteratorsCAPI
   LINK_LIBS PUBLIC
     MLIRIterators
     MLIRIteratorsToLLVM
+    MLIRTabular
     MLIRPass
 )

--- a/experimental/iterators/lib/CAPI/Dialects.cpp
+++ b/experimental/iterators/lib/CAPI/Dialects.cpp
@@ -9,6 +9,7 @@
 #include "iterators-c/Dialects.h"
 
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Dialect/Tabular/IR/Tabular.h"
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
@@ -30,3 +31,9 @@ bool mlirTypeIsAIteratorsStreamType(MlirType type) {
 MlirType mlirIteratorsStreamTypeGet(MlirContext context, MlirType elementType) {
   return wrap(StreamType::get(unwrap(context), unwrap(elementType)));
 }
+
+//===----------------------------------------------------------------------===//
+// Tabular dialect and types
+//===----------------------------------------------------------------------===//
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Tabular, tabular, TabularDialect)

--- a/experimental/iterators/lib/Conversion/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IteratorsToLLVM)
+add_subdirectory(TabularToLLVM)

--- a/experimental/iterators/lib/Conversion/TabularToLLVM/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/TabularToLLVM/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_conversion_library(MLIRTabularToLLVM
+  TabularToLLVM.cpp
+
+  DEPENDS
+  MLIRIteratorsConversionIncGen
+
+  LINK_LIBS PUBLIC
+  IteratorsUtils
+  MLIRFuncDialect
+  MLIRFuncTransforms
+  MLIRLLVMDialect
+  MLIRPass
+  MLIRTabular
+)

--- a/experimental/iterators/lib/Conversion/TabularToLLVM/TabularToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/TabularToLLVM/TabularToLLVM.cpp
@@ -1,0 +1,95 @@
+//===-- TabularToLLVM.h - Conversion from Tabular to LLVM -------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Conversion/TabularToLLVM/TabularToLLVM.h"
+
+#include "../PassDetail.h"
+#include "iterators/Dialect/Tabular/IR/Tabular.h"
+#include "iterators/Utils/MLIRSupport.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+class MLIRContext;
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::func;
+using namespace mlir::iterators;
+using namespace mlir::LLVM;
+
+namespace {
+struct ConvertTabularToLLVMPass
+    : public ConvertTabularToLLVMBase<ConvertTabularToLLVMPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Maps types from the Tabular dialect to corresponding types in LLVM.
+class TabularTypeConverter : public TypeConverter {
+public:
+  TabularTypeConverter() {
+    addConversion([](Type type) { return type; });
+  }
+
+private:
+};
+
+void mlir::iterators::populateTabularToLLVMConversionPatterns(
+    RewritePatternSet &patterns, TypeConverter &typeConverter) {}
+
+void ConvertTabularToLLVMPass::runOnOperation() {
+  auto module = getOperation();
+  TabularTypeConverter typeConverter;
+
+  // Convert the remaining ops of this dialect using dialect conversion.
+  ConversionTarget target(getContext());
+  target.addLegalDialect<LLVMDialect>();
+  target.addLegalOp<ModuleOp>();
+  RewritePatternSet patterns(&getContext());
+
+  populateTabularToLLVMConversionPatterns(patterns, typeConverter);
+
+  // Add patterns that converts function signature and calls.
+  populateFunctionOpInterfaceTypeConversionPattern<FuncOp>(patterns,
+                                                           typeConverter);
+  populateCallOpTypeConversionPattern(patterns, typeConverter);
+  populateReturnOpTypeConversionPattern(patterns, typeConverter);
+
+  // Force application of that pattern if signature is not legal yet.
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+    return typeConverter.isSignatureLegal(op.getFunctionType());
+  });
+  target.addDynamicallyLegalOp<func::ReturnOp>([&](func::ReturnOp op) {
+    return typeConverter.isLegal(op.getOperandTypes());
+  });
+  target.addDynamicallyLegalOp<func::CallOp>([&](func::CallOp op) {
+    return typeConverter.isSignatureLegal(op.getCalleeType());
+  });
+
+  // Use UnrealizedConversionCast as materializations, which have to be cleaned
+  // up by later passes.
+  auto addUnrealizedCast = [](OpBuilder &builder, Type type, ValueRange inputs,
+                              Location loc) {
+    auto cast = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
+    return Optional<Value>(cast.getResult(0));
+  };
+  typeConverter.addSourceMaterialization(addUnrealizedCast);
+  typeConverter.addTargetMaterialization(addUnrealizedCast);
+
+  if (failed(applyFullConversion(module, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+mlir::createConvertTabularToLLVMPass() {
+  return std::make_unique<ConvertTabularToLLVMPass>();
+}

--- a/experimental/iterators/lib/Dialects/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialects/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(Iterators)
+add_subdirectory(Tabular)

--- a/experimental/iterators/lib/Dialects/Tabular/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialects/Tabular/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/experimental/iterators/lib/Dialects/Tabular/IR/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialects/Tabular/IR/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_mlir_library(MLIRTabular
+  Tabular.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRFuncDialect
+  MLIRInferTypeOpInterface
+  MLIRIR
+  MLIRLLVMDialect
+
+  DEPENDS
+  MLIRTabularInterfacesIncGen
+  MLIRTabularOpsIncGen
+)

--- a/experimental/iterators/lib/Dialects/Tabular/IR/Tabular.cpp
+++ b/experimental/iterators/lib/Dialects/Tabular/IR/Tabular.cpp
@@ -1,0 +1,55 @@
+//===-- Tabular.cpp - Tabular dialect ---------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Dialect/Tabular/IR/Tabular.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace mlir::iterators;
+
+//===----------------------------------------------------------------------===//
+// Tabular dialect
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Dialect/Tabular/IR/TabularOpsDialect.cpp.inc"
+
+void TabularDialect::initialize() {
+#define GET_OP_LIST
+  addOperations<
+#include "iterators/Dialect/Tabular/IR/TabularOps.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "iterators/Dialect/Tabular/IR/TabularOpsTypes.cpp.inc"
+      >();
+}
+
+//===----------------------------------------------------------------------===//
+// Tabular interfaces
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Dialect/Tabular/IR/TabularOpInterfaces.cpp.inc"
+#include "iterators/Dialect/Tabular/IR/TabularTypeInterfaces.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// Tabular operations
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "iterators/Dialect/Tabular/IR/TabularOps.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// Tabular types
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "iterators/Dialect/Tabular/IR/TabularOpsTypes.cpp.inc"

--- a/experimental/iterators/python/CMakeLists.txt
+++ b/experimental/iterators/python/CMakeLists.txt
@@ -8,14 +8,25 @@ add_compile_definitions("MLIR_PYTHON_PACKAGE_PREFIX=mlir_iterators.")
 # Sources
 # ###############################################################################
 declare_mlir_python_sources(IteratorsPythonSources)
+declare_mlir_python_sources(IteratorsPythonSources.Dialects
+  ADD_TO_PARENT IteratorsPythonSources)
 
 declare_mlir_dialect_python_bindings(
-  ADD_TO_PARENT IteratorsPythonSources
+  ADD_TO_PARENT IteratorsPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_iterators"
   TD_FILE dialects/IteratorsOps.td
   SOURCES
   dialects/iterators.py
   DIALECT_NAME iterators
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT IteratorsPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_iterators"
+  TD_FILE dialects/TabularOps.td
+  SOURCES
+  dialects/tabular.py
+  DIALECT_NAME tabular
 )
 
 declare_mlir_python_extension(IteratorsPythonSources.DialectExtension

--- a/experimental/iterators/python/IteratorsDialects.cpp
+++ b/experimental/iterators/python/IteratorsDialects.cpp
@@ -53,4 +53,30 @@ PYBIND11_MODULE(_iteratorsDialects, mainModule) {
           },
           py::arg("cls"), py::arg("element_type"),
           py::arg("context") = py::none());
+
+  //===--------------------------------------------------------------------===//
+  // Tabular dialect.
+  //===--------------------------------------------------------------------===//
+  auto tabularModule = mainModule.def_submodule("tabular");
+
+  //
+  // Dialect
+  //
+
+  tabularModule.def(
+      "register_dialect",
+      [](MlirContext context, bool doLoad) {
+        MlirDialectHandle handle = mlirGetDialectHandle__tabular__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (doLoad) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context") = py::none(), py::arg("load") = true);
+
+  //
+  // Types
+  //
+
+  // ...
 }

--- a/experimental/iterators/python/mlir_iterators/dialects/TabularOps.td
+++ b/experimental/iterators/python/mlir_iterators/dialects/TabularOps.td
@@ -1,0 +1,13 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYTHON_BINDINGS_TABULAR_OPS
+#define PYTHON_BINDINGS_TABULAR_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "iterators/Dialect/Tabular/IR/TabularOps.td"
+
+#endif // PYTHON_BINDINGS_TABULAR_OPS

--- a/experimental/iterators/python/mlir_iterators/dialects/tabular.py
+++ b/experimental/iterators/python/mlir_iterators/dialects/tabular.py
@@ -1,0 +1,8 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._tabular_ops_gen import *
+from .._mlir_libs._iteratorsDialects.tabular import *

--- a/experimental/iterators/python/mlir_iterators/dialects/tabular.py
+++ b/experimental/iterators/python/mlir_iterators/dialects/tabular.py
@@ -6,3 +6,4 @@
 
 from ._tabular_ops_gen import *
 from .._mlir_libs._iteratorsDialects.tabular import *
+from .._mlir_libs import _mlirIteratorsPasses as _cextIteratorsPasses

--- a/experimental/iterators/test/python/dialects/iterators/dialect.py
+++ b/experimental/iterators/test/python/dialects/iterators/dialect.py
@@ -3,6 +3,7 @@
 import os
 
 from mlir_iterators.dialects import iterators as it
+from mlir_iterators.dialects import tabular as tab
 from mlir_iterators.passmanager import PassManager
 from mlir_iterators.execution_engine import ExecutionEngine
 from mlir_iterators.ir import Context, Module, IntegerType
@@ -13,6 +14,7 @@ def run(f):
   print("\nTEST:", f.__name__)
   with Context():
     it.register_dialect()
+    tab.register_dialect()
     f()
   return f
 

--- a/tools/mlir-proto-lsp-server/CMakeLists.txt
+++ b/tools/mlir-proto-lsp-server/CMakeLists.txt
@@ -15,6 +15,7 @@ if(SANDBOX_ENABLE_ITERATORS)
   list(APPEND dialect_libs MLIRIterators)
   list(APPEND dialect_libs MLIRTabular)
   list(APPEND conversion_libs MLIRIteratorsToLLVM)
+  list(APPEND conversion_libs MLIRTabularToLLVM)
 endif()
 
 target_link_libraries(mlir-proto-lsp-server

--- a/tools/mlir-proto-lsp-server/CMakeLists.txt
+++ b/tools/mlir-proto-lsp-server/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 if(SANDBOX_ENABLE_ITERATORS)
   list(APPEND dialect_libs MLIRIterators)
+  list(APPEND dialect_libs MLIRTabular)
   list(APPEND conversion_libs MLIRIteratorsToLLVM)
 endif()
 

--- a/tools/mlir-proto-lsp-server/mlir-proto-lsp-server.cpp
+++ b/tools/mlir-proto-lsp-server/mlir-proto-lsp-server.cpp
@@ -25,9 +25,15 @@ using namespace mlir;
 #ifdef SANDBOX_ENABLE_ITERATORS
 #include "iterators/Conversion/Passes.h"
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Dialect/Tabular/IR/Tabular.h"
 
 static void registerIteratorDialects(DialectRegistry &registry) {
-  registry.insert<mlir::iterators::IteratorsDialect>();
+  registry.insert<
+      // clang-format off
+      mlir::iterators::IteratorsDialect,
+      mlir::iterators::TabularDialect
+      // clang-format on
+      >();
   registerIteratorsConversionPasses();
 }
 #else

--- a/tools/mlir-proto-opt/CMakeLists.txt
+++ b/tools/mlir-proto-opt/CMakeLists.txt
@@ -15,6 +15,7 @@ if(SANDBOX_ENABLE_ITERATORS)
   list(APPEND dialect_libs MLIRIterators)
   list(APPEND dialect_libs MLIRTabular)
   list(APPEND conversion_libs MLIRIteratorsToLLVM)
+  list(APPEND conversion_libs MLIRTabularToLLVM)
 endif()
 
 target_link_libraries(mlir-proto-opt

--- a/tools/mlir-proto-opt/CMakeLists.txt
+++ b/tools/mlir-proto-opt/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 if(SANDBOX_ENABLE_ITERATORS)
   list(APPEND dialect_libs MLIRIterators)
+  list(APPEND dialect_libs MLIRTabular)
   list(APPEND conversion_libs MLIRIteratorsToLLVM)
 endif()
 

--- a/tools/mlir-proto-opt/mlir-proto-opt.cpp
+++ b/tools/mlir-proto-opt/mlir-proto-opt.cpp
@@ -26,9 +26,15 @@ using namespace mlir;
 #ifdef SANDBOX_ENABLE_ITERATORS
 #include "iterators/Conversion/Passes.h"
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Dialect/Tabular/IR/Tabular.h"
 
 static void registerIteratorDialects(DialectRegistry &registry) {
-  registry.insert<mlir::iterators::IteratorsDialect>();
+  registry.insert<
+      // clang-format off
+      mlir::iterators::IteratorsDialect,
+      mlir::iterators::TabularDialect
+      // clang-format on
+      >();
   registerIteratorsConversionPasses();
 }
 #else


### PR DESCRIPTION
This is a first of a series of PR that should replace #577.