### PR TITLE
SQL: adjust proj pushdown

### DIFF
--- a/experimental/sql/dialects/rel_alg.py
+++ b/experimental/sql/dialects/rel_alg.py
@@ -255,7 +255,7 @@ class Operator(Operation):
 @irdl_op_definition
 class Limit(Operator):
   """
-  Limits the number of tuples in `table` to `n` .
+  Limits the number of tuples in `input` to `n` .
 
   Example:
 
@@ -267,7 +267,7 @@ class Limit(Operator):
   """
   name = "rel_alg.limit"
 
-  table = SingleBlockRegionDef()
+  input = SingleBlockRegionDef()
   n = AttributeDef(IntegerAttr)
 
   @staticmethod

--- a/experimental/sql/src/alg_to_ssa.py
+++ b/experimental/sql/src/alg_to_ssa.py
@@ -278,7 +278,7 @@ class LimitRewriter(RelAlgRewriter):
 
   @op_type_rewrite_pattern
   def match_and_rewrite(self, op: RelAlg.Limit, rewriter: PatternRewriter):
-    rewriter.inline_block_before_matched_op(op.table.blocks[0])
+    rewriter.inline_block_before_matched_op(op.input.blocks[0])
     rewriter.insert_op_before_matched_op([
         RelSSA.Limit.get(rewriter.added_operations_before[-1], op.n.value.data)
     ])

--- a/experimental/sql/src/projection_pushdown.py
+++ b/experimental/sql/src/projection_pushdown.py
@@ -213,6 +213,7 @@ def projection_pushdown(ctx: MLContext, query: ModuleOp):
       apply_recursively=False,
       walk_reverse=False)
   simplify_projections_walker.rewrite_module(query)
+
   infer_projections_walker = PatternRewriteWalker(GreedyRewritePatternApplier(
       [ProjectionInference()]),
                                                   walk_regions_first=False,

--- a/experimental/sql/src/projection_pushdown.py
+++ b/experimental/sql/src/projection_pushdown.py
@@ -52,7 +52,15 @@ class ProjectionOptimizer(RewritePattern):
       return self.flatten(
           [self.find_cols_in_expr(o) for o in op.projections.ops])
     if isinstance(op, RelAlg.Aggregate):
-      return [s.data for s in op.col_names.data]
+      return [s.data for s in op.col_names.data if s.data != ""
+             ] + [s.data for s in op.by.data]
+    if isinstance(op, RelAlg.OrderBy):
+      return [s.col.data for s in op.by.data] + self.find_cols_upstream(
+          op.parent_op())
+    if isinstance(op, RelAlg.Limit):
+      return self.find_cols_upstream(op.parent_op())
+    if isinstance(op, RelAlg.CartesianProduct):
+      return self.find_cols_upstream(op.parent_op())
 
   def find_schema(self, op: RelAlg.Operator) -> list[str]:
     """
@@ -66,6 +74,31 @@ class ProjectionOptimizer(RewritePattern):
       return [s.data for s in op.names.data]
     if isinstance(op, RelAlg.Aggregate):
       return [s.data for s in op.col_names.data]
+    if isinstance(op, RelAlg.CartesianProduct):
+      return self.find_schema(op.left.op) + self.find_schema(op.right.op)
+    if isinstance(op, RelAlg.OrderBy):
+      return self.find_schema(op.input.op)
+    if isinstance(op, RelAlg.Limit):
+      return self.find_schema(op.input.op)
+
+
+@dataclass
+class ProjectionSimplifier(ProjectionOptimizer):
+
+  @op_type_rewrite_pattern
+  def match_and_rewrite(self, op: RelAlg.Project, rewriter: PatternRewriter):
+    cols = list(dict.fromkeys(self.find_cols_upstream(op.parent_op())))
+    if None in cols or len(op.names.data) == len(cols):
+      return
+
+    for o in op.projections.ops:
+      if isinstance(o, RelAlg.Column) and not o.col_name.data in cols:
+        rewriter.erase_op(o)
+    new_proj = RelAlg.Project.get(
+        Region.from_operation_list([op.input.op.clone()]),
+        rewriter.move_region_contents_to_new_regions(op.projections),
+        ArrayAttr.from_list([StringAttr.from_str(s) for s in cols]))
+    rewriter.replace_matched_op(new_proj)
 
 
 @dataclass
@@ -84,12 +117,26 @@ class ProjectionInference(ProjectionOptimizer):
     if None in cols:
       return
 
-    new_proj = RelAlg.Project.get(
-        Region.from_operation_list([op.input.op.clone()]),
-        Region.from_operation_list([RelAlg.Column.get(s) for s in cols]),
-        ArrayAttr.from_list([StringAttr.from_str(s) for s in cols]))
-
-    rewriter.replace_op(op.input.op, new_proj)
+    if not isinstance(op, RelAlg.CartesianProduct):
+      new_proj = RelAlg.Project.get(
+          Region.from_operation_list([op.input.op.clone()]),
+          Region.from_operation_list([RelAlg.Column.get(s) for s in cols]),
+          ArrayAttr.from_list([StringAttr.from_str(s) for s in cols]))
+      rewriter.replace_op(op.input.op, new_proj)
+    else:
+      left_cols = [c for c in cols if c in self.find_schema(op.left.op)]
+      left_proj = RelAlg.Project.get(
+          Region.from_operation_list([op.left.op.clone()]),
+          Region.from_operation_list([RelAlg.Column.get(s) for s in left_cols]),
+          ArrayAttr.from_list([StringAttr.from_str(s) for s in left_cols]))
+      rewriter.replace_op(op.left.op, left_proj)
+      right_cols = [c for c in cols if c in self.find_schema(op.right.op)]
+      right_proj = RelAlg.Project.get(
+          Region.from_operation_list([op.right.op.clone()]),
+          Region.from_operation_list([RelAlg.Column.get(s) for s in right_cols
+                                     ]),
+          ArrayAttr.from_list([StringAttr.from_str(s) for s in right_cols]))
+      rewriter.replace_op(op.right.op, right_proj)
 
 
 @dataclass
@@ -118,7 +165,8 @@ class ProjectionFuser(ProjectionOptimizer):
     child_dict = dict(zip(child_res, op.input.op.projections.ops))
     new_projections = rewriter.move_region_contents_to_new_regions(
         op.projections)
-    self.replace_expr(new_projections.op, child_dict, rewriter)
+    for o in new_projections.ops:
+      self.replace_expr(o, child_dict, rewriter)
     rewriter.replace_matched_op(
         RelAlg.Project.get(
             rewriter.move_region_contents_to_new_regions(op.input.op.input),
@@ -148,6 +196,12 @@ class IdentityProjectionRemover(ProjectionOptimizer):
 
 
 def projection_pushdown(ctx: MLContext, query: ModuleOp):
+  simplify_projections_walker = PatternRewriteWalker(
+      GreedyRewritePatternApplier([ProjectionSimplifier()]),
+      walk_regions_first=False,
+      apply_recursively=False,
+      walk_reverse=False)
+  simplify_projections_walker.rewrite_module(query)
   infer_projections_walker = PatternRewriteWalker(GreedyRewritePatternApplier(
       [ProjectionInference()]),
                                                   walk_regions_first=False,

--- a/experimental/sql/test/projection_pushdown_tests/cart_prod.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/cart_prod.xdsl
@@ -1,0 +1,27 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.cartesian_product() {
+      rel_alg.table() ["table_name" = "t"] {
+          rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+      }
+    } {
+       rel_alg.table() ["table_name" = "t"] {
+          rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "d", "elt_type" = !rel_alg.int32]
+    }
+  }
+}
+
+//      CHECK:   rel_alg.cartesian_product() {
+// CHECK-NEXT:       rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     } {
+// CHECK-NEXT:        rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:           rel_alg.schema_element() ["elt_name" = "d", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }

--- a/experimental/sql/test/projection_pushdown_tests/cart_prod_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/cart_prod_extended.xdsl
@@ -1,0 +1,40 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = ["c"]] {
+    rel_alg.cartesian_product() {
+        rel_alg.table() ["table_name" = "t"] {
+            rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+            rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+        }
+      } {
+         rel_alg.table() ["table_name" = "t"] {
+            rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+            rel_alg.schema_element() ["elt_name" = "d", "elt_type" = !rel_alg.int32]
+      }
+    }
+  }
+}
+
+
+//      CHECK:  rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = ["c"]] {
+// CHECK-NEXT:    rel_alg.cartesian_product() {
+// CHECK-NEXT:      rel_alg.project() ["names" = ["a"]] {
+// CHECK-NEXT:        rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:          rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:          rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      } {
+// CHECK-NEXT:        rel_alg.column() ["col_name" = "a"]
+// CHECK-NEXT:      }
+// CHECK-NEXT:    } {
+// CHECK-NEXT:      rel_alg.project() ["names" = ["c"]] {
+// CHECK-NEXT:        rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:          rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:          rel_alg.schema_element() ["elt_name" = "d", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:        }
+// CHECK-NEXT:      } {
+// CHECK-NEXT:        rel_alg.column() ["col_name" = "c"]
+// CHECK-NEXT:      }
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }

--- a/experimental/sql/test/projection_pushdown_tests/grouped_aggregation.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/grouped_aggregation.xdsl
@@ -1,0 +1,24 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = ["b"]] {
+      rel_alg.table() ["table_name" = "t"] {
+          rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+      }
+  }
+}
+
+//      CHECK: rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = ["b"]] {
+// CHECK-NEXT:     rel_alg.project() ["names" = ["a", "b"]] {
+// CHECK-NEXT:       rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:         rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:         rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:         rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:       }
+// CHECK-NEXT:     } {
+// CHECK-NEXT:       rel_alg.column() ["col_name" = "a"]
+// CHECK-NEXT:       rel_alg.column() ["col_name" = "b"]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }

--- a/experimental/sql/test/projection_pushdown_tests/limit.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/limit.xdsl
@@ -1,0 +1,19 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.limit() ["n" = 10 : !i64] {
+      rel_alg.table() ["table_name" = "t"] {
+          rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+      }
+  }
+}
+
+//      CHECK:  rel_alg.limit() ["n" = 10 : !i64] {
+// CHECK-NEXT:     rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }

--- a/experimental/sql/test/projection_pushdown_tests/limit_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/limit_extended.xdsl
@@ -1,0 +1,26 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = []] {
+    rel_alg.limit() ["n" = 10 : !i64] {
+        rel_alg.table() ["table_name" = "t"] {
+            rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+            rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+            rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+        }
+    }
+  }
+}
+
+//      CHECK:   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = []] {
+// CHECK-NEXT:       rel_alg.limit() ["n" = 10 : !i64] {
+// CHECK-NEXT:         rel_alg.project() ["names" = ["a"]] {
+// CHECK-NEXT:           rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:             rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:             rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:             rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:           }
+// CHECK-NEXT:         } {
+// CHECK-NEXT:           rel_alg.column() ["col_name" = "a"]
+// CHECK-NEXT:         }
+// CHECK-NEXT:   }

--- a/experimental/sql/test/projection_pushdown_tests/order_by.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/order_by.xdsl
@@ -1,0 +1,19 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.order_by() ["by" = [!rel_alg.order<"a", "desc">, !rel_alg.order<"b", "asc">]] {
+      rel_alg.table() ["table_name" = "t"] {
+          rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+      }
+  }
+}
+
+//      CHECK: rel_alg.order_by() ["by" = [!rel_alg.order<"a", "desc">, !rel_alg.order<"b", "asc">]] {
+// CHECK-NEXT:     rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:       rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:       rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:       rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }

--- a/experimental/sql/test/projection_pushdown_tests/order_by_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/order_by_extended.xdsl
@@ -1,0 +1,32 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = []] {
+    rel_alg.order_by() ["by" = [!rel_alg.order<"a", "desc">, !rel_alg.order<"b", "asc">]] {
+        rel_alg.table() ["table_name" = "t"] {
+            rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+            rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+            rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+        }
+    }
+  }
+}
+
+//      CHECK:   rel_alg.aggregate() ["col_names" = ["a"], "functions" = ["sum"], "res_names" = ["a_sum"], "by" = []] {
+// CHECK-NEXT:     rel_alg.project() ["names" = ["a"]] {
+// CHECK-NEXT:       rel_alg.order_by() ["by" = [!rel_alg.order<"a", "desc">, !rel_alg.order<"b", "asc">]] {
+// CHECK-NEXT:         rel_alg.project() ["names" = ["a", "b"]] {
+// CHECK-NEXT:           rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:             rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:             rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:             rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:           }
+// CHECK-NEXT:         } {
+// CHECK-NEXT:           rel_alg.column() ["col_name" = "a"]
+// CHECK-NEXT:           rel_alg.column() ["col_name" = "b"]
+// CHECK-NEXT:         }
+// CHECK-NEXT:       }
+// CHECK-NEXT:     } {
+// CHECK-NEXT:       rel_alg.column() ["col_name" = "a"]
+// CHECK-NEXT:     }
+// CHECK-NEXT:   }


### PR DESCRIPTION
This PR adjusts the projection pushdown to handle the case of cartesian product, limit and order by. It also adds the ProjectionSimplifier that optimizes projections before new projections are added.

Currently, this is only tested on the TPC-H queries. I will add some testcases now.