### PR TITLE
SQL: fix projection pushdown and partial loading

### DIFF
--- a/experimental/sql/dialects/rel_impl.py
+++ b/experimental/sql/dialects/rel_impl.py
@@ -585,7 +585,7 @@ class Project(Operator):
   def get(input: Operation, res_names: List[str], res_types: List[DataType],
           projection: Region) -> 'Project':
     return Project.create(operands=[input.result],
-                          result_types=[Bag.get(res_names, res_types)],
+                          result_types=[Bag.get(res_types, res_names)],
                           regions=[projection])
 
   @staticmethod

--- a/experimental/sql/src/fuse_proj_into_scan.py
+++ b/experimental/sql/src/fuse_proj_into_scan.py
@@ -25,29 +25,45 @@ class ProjScanFuser(RewritePattern):
     if not isinstance(op.input.op, RelImpl.FullTableScanOp):
       return
 
-    # This rewrite expects that the projection only maps onto a subset of the
-    # columns of the input. Therefore, we first check that only IndexByName is
-    # present and then that there are equally as many cols that are yielded as
-    # there are in the result.
-    if not all([
-        isinstance(o.op, RelImpl.IndexByName) for o in op.projection.ops[-1].ops
-    ]):
-      return
-
     assert isinstance(op.projection.ops[-1], RelImpl.YieldTuple)
     yielded_ssa_values = op.projection.ops[-1].ops
 
-    col_names = [o.op.col_name.data for o in yielded_ssa_values]
-    res_names = [s.elt_name.data for s in op.input.typ.schema.data]
-    if len(col_names) == len(res_names):
+    # Get the list of used columns. The dict magic removes duplicates.
+    used_cols = list(
+        dict.fromkeys([
+            o.col_name.data
+            for o in op.projection.ops
+            if isinstance(o, RelImpl.IndexByName)
+        ]))
+    input_names = [s.elt_name.data for s in op.input.typ.schema.data]
+
+    # If all the input cols are used, there is nothing to fuse.
+    if len(used_cols) == len(input_names):
       return
 
     col_types = [o.typ for o in yielded_ssa_values]
 
     new_op = RelImpl.FullTableScanOp.get(op.input.op.table_name.data,
-                                         RelImpl.Bag.get(col_types, col_names),
-                                         col_names)
-    rewriter.replace_matched_op(new_op)
+                                         RelImpl.Bag.get(col_types, used_cols),
+                                         used_cols)
+
+    if all([
+        isinstance(o.op, RelImpl.IndexByName) for o in op.projection.ops[-1].ops
+    ]):
+      # If the projection is simple, replace the projection by a partial load.
+      rewriter.replace_matched_op(new_op)
+    else:
+      # For a complex projection, replace the projection with a projection
+      # reading from the partial load.
+      new_reg = rewriter.move_region_contents_to_new_regions(op.projection)
+      rewriter.modify_block_argument_type(
+          new_reg.blocks[0].args[0],
+          RelImpl.Tuple.get(
+              col_types,
+              [s.elt_name.data for s in new_op.result.typ.schema.data]))
+      rewriter.insert_op_before_matched_op(new_op)
+      rewriter.replace_matched_op(
+          RelImpl.Project.from_result_type(new_op, op.result.typ, new_reg))
 
     if len(op.input.uses) == 0:
       # TODO: remove that safe_erase is False, when we have some kind of dead code

--- a/experimental/sql/test/fuse_proj_into_scan_tests/complex_projection.xdsl
+++ b/experimental/sql/test/fuse_proj_into_scan_tests/complex_projection.xdsl
@@ -1,0 +1,18 @@
+// RUN: rel_opt.py -p fuse-proj-into-scan  %s | filecheck %s
+
+module() {
+  %0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t"]
+  %1 : !rel_impl.bag<[!rel_impl.schema_element<"add", !rel_impl.int32>, !rel_impl.schema_element<"a", !rel_impl.int32>]> = rel_impl.project(%0 : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]>) {
+  ^0(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]>):
+    %3 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]>) ["col_name" = "a"]
+    %4 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]>) ["col_name" = "b"]
+    %5 : !rel_impl.int32 = rel_impl.bin_op(%3 : !rel_impl.int32, %4 : !rel_impl.int32) ["operator" = "+"]
+    %6 : !rel_impl.int32 = rel_impl.index_by_name(%2 : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>, !rel_impl.schema_element<"c", !rel_impl.int32>, !rel_impl.schema_element<"d", !rel_impl.int32>]>) ["col_name" = "b"]
+    rel_impl.yield_tuple(%5 : !rel_impl.int32, %6 : !rel_impl.int32)
+  }
+  %7 : !rel_impl.bag<[!rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.aggregate(%1 : !rel_impl.bag<[!rel_impl.schema_element<"add", !rel_impl.int32>, !rel_impl.schema_element<"a", !rel_impl.int32>]>) ["col_names" = ["add"], "functions" = ["sum"], "by" = ["a"]]
+}
+
+//      CHECK:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]> = rel_impl.full_table_scan() ["table_name" = "t", "cols" = ["a", "b"]]
+// CHECK-NEXT:  %{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"add", !rel_impl.int32>, !rel_impl.schema_element<"a", !rel_impl.int32>]> = rel_impl.project(%{{.*}} : !rel_impl.bag<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>) {
+// CHECK-NEXT:  ^0(%{{.*}} : !rel_impl.tuple<[!rel_impl.schema_element<"a", !rel_impl.int32>, !rel_impl.schema_element<"b", !rel_impl.int32>]>):

--- a/experimental/sql/test/projection_pushdown_tests/rename_extended.xdsl
+++ b/experimental/sql/test/projection_pushdown_tests/rename_extended.xdsl
@@ -1,0 +1,40 @@
+// RUN: rel_opt.py -p projection-pushdown %s | filecheck %s
+
+module() {
+  rel_alg.aggregate() ["col_names" = ["add"], "functions" = ["sum"], "res_names" = ["b"], "by" = ["a"]] {
+    rel_alg.project() ["names" = ["b", "a", "add"]] {
+      rel_alg.table() ["table_name" = "t"] {
+          rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+          rel_alg.schema_element() ["elt_name" = "d", "elt_type" = !rel_alg.int32]
+      }
+    } {
+      rel_alg.column() ["col_name" = "a"]
+      rel_alg.column() ["col_name" = "b"]
+      rel_alg.bin_op() ["operator" = "+"] {
+        rel_alg.column() ["col_name" = "a"]
+      } {
+        rel_alg.column() ["col_name" = "b"]
+      }
+    }
+  }
+}
+
+//      CHECK:  rel_alg.aggregate() ["col_names" = ["add"], "functions" = ["sum"], "res_names" = ["b"], "by" = ["a"]] {
+// CHECK-NEXT:    rel_alg.project() ["names" = ["add", "a"]] {
+// CHECK-NEXT:      rel_alg.table() ["table_name" = "t"] {
+// CHECK-NEXT:        rel_alg.schema_element() ["elt_name" = "a", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:        rel_alg.schema_element() ["elt_name" = "b", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:        rel_alg.schema_element() ["elt_name" = "c", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:        rel_alg.schema_element() ["elt_name" = "d", "elt_type" = !rel_alg.int32]
+// CHECK-NEXT:      }
+// CHECK-NEXT:    } {
+// CHECK-NEXT:      rel_alg.bin_op() ["operator" = "+"] {
+// CHECK-NEXT:        rel_alg.column() ["col_name" = "a"]
+// CHECK-NEXT:      } {
+// CHECK-NEXT:        rel_alg.column() ["col_name" = "b"]
+// CHECK-NEXT:      }
+// CHECK-NEXT:      rel_alg.column() ["col_name" = "b"]
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
This PR addresses an issue I introduced when "fixing" the handling of renames in the projection pushdown, in particular the projection simplifier. What I introduced was to restrictive to handle the TPC-H queries. So, I rewrote it to be able to handle some renames.

I also fixed a problem in the partial loading where projections would not be fused at all if there are complex projections present. I rewrote this to a version that does he partial loading, but also keeps the projection around.