### PR TITLE
SQL: Add between to ibis and lower it to rel_alg

### DIFF
--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -858,7 +858,7 @@ class SchemaElement(Operation):
 @irdl_op_definition
 class Between(Operation):
   """
-  Returns wheter `arg` is in between `lower_bound` and `upper_bound`.
+  Returns whether `arg` is in between `lower_bound` and `upper_bound`. These bounds are inclusive.
 
   https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/logical.py#L114
 

--- a/experimental/sql/dialects/ibis_dialect.py
+++ b/experimental/sql/dialects/ibis_dialect.py
@@ -856,6 +856,36 @@ class SchemaElement(Operation):
 
 
 @irdl_op_definition
+class Between(Operation):
+  """
+  Returns wheter `arg` is in between `lower_bound` and `upper_bound`.
+
+  https://github.com/ibis-project/ibis/blob/f3d267b96b9f14d3616c17b8f7bdeb8d0a6fc2cf/ibis/expr/operations/logical.py#L114
+
+  Example:
+  '''
+  ibis.between() {
+    ibis.table_colum()...
+  } {
+    ibis.literal() ...
+  } {
+    ibis.literal()
+  }
+  '''
+  """
+  name = "ibis.between"
+
+  arg = SingleBlockRegionDef()
+  lower_bound = SingleBlockRegionDef()
+  upper_bound = SingleBlockRegionDef()
+
+  @builder
+  @staticmethod
+  def get(arg: Region, lower_bound: Region, upper_bound: Region) -> 'Between':
+    return Between.create(regions=[arg, lower_bound, upper_bound])
+
+
+@irdl_op_definition
 class Literal(Operation):
   """
   Defines a literal with value `val` and type `type`.
@@ -903,6 +933,7 @@ class Ibis:
     self.ctx.register_op(Selection)
     self.ctx.register_op(CartesianProduct)
     self.ctx.register_op(Multiply)
+    self.ctx.register_op(Between)
     self.ctx.register_op(Equals)
     self.ctx.register_op(GreaterEqual)
     self.ctx.register_op(GreaterThan)

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -161,6 +161,13 @@ def visit(  #type: ignore
   return id.Selection.get(table, predicates, projections, sort_keys, names)
 
 
+@dispatch(ibis.expr.operations.logical.Between)
+def visit(op):
+  left_reg = Region.from_operation_list([visit(op.lower_bound)])
+  right_reg = Region.from_operation_list([visit(op.upper_bound)])
+  return id.Equals.get(left_reg, right_reg)
+
+
 @dispatch(ibis.expr.operations.sortkeys.SortKey)
 def visit(op: ibis.expr.operations.sortkeys.SortKey) -> Operation:
   return id.SortKey.get(Region.from_operation_list([visit(op.expr)]),

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -163,9 +163,10 @@ def visit(  #type: ignore
 
 @dispatch(ibis.expr.operations.logical.Between)
 def visit(op):
-  left_reg = Region.from_operation_list([visit(op.lower_bound)])
-  right_reg = Region.from_operation_list([visit(op.upper_bound)])
-  return id.Equals.get(left_reg, right_reg)
+  arg = Region.from_operation_list([visit(op.arg)])
+  lower_bound = Region.from_operation_list([visit(op.lower_bound)])
+  upper_bound = Region.from_operation_list([visit(op.upper_bound)])
+  return id.Between.get(arg, lower_bound, upper_bound)
 
 
 @dispatch(ibis.expr.operations.sortkeys.SortKey)

--- a/experimental/sql/test/frontend/between.ibis
+++ b/experimental/sql/test/frontend/between.ibis
@@ -1,0 +1,26 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.filter(table.b.between(ibis.literal(5, "int64"), ibis.literal(7, "int64")))
+
+#      CHECK:   ibis.selection() ["names" = []] {
+# CHECK-NEXT:     ibis.unbound_table() ["table_name" = "t"] {
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:       ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:     }
+# CHECK-NEXT:   } {
+# CHECK-NEXT:     ibis.between() {
+# CHECK-NEXT:       ibis.table_column() ["col_name" = "b"] {
+# CHECK-NEXT:         ibis.unbound_table() ["table_name" = "t"] {
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:           ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:         }
+# CHECK-NEXT:       }
+# CHECK-NEXT:     } {
+# CHECK-NEXT:       ibis.literal() ["val" = 5 : !i64, "type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:     } {
+# CHECK-NEXT:       ibis.literal() ["val" = 7 : !i64, "type" = !ibis.nullable<!ibis.int64>]
+# CHECK-NEXT:     }
+# CHECK-NEXT:   } {} {}

--- a/experimental/sql/test/ibis_to_alg/between.xdsl
+++ b/experimental/sql/test/ibis_to_alg/between.xdsl
@@ -1,0 +1,38 @@
+// RUN: rel_opt.py -p ibis-to-alg %s | filecheck %s
+
+module() {
+ ibis.selection() ["names" = []] {
+    ibis.unbound_table() ["table_name" = "t"] {
+      ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+      ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+      ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
+    }
+  } {
+    ibis.between() {
+      ibis.table_column() ["col_name" = "b"] {
+        ibis.unbound_table() ["table_name" = "t"] {
+          ibis.schema_element() ["elt_name" = "a", "elt_type" = !ibis.nullable<!ibis.string>]
+          ibis.schema_element() ["elt_name" = "b", "elt_type" = !ibis.nullable<!ibis.int64>]
+          ibis.schema_element() ["elt_name" = "c", "elt_type" = !ibis.nullable<!ibis.int64>]
+        }
+      }
+    } {
+      ibis.literal() ["val" = 5 : !i64, "type" = !ibis.nullable<!ibis.int64>]
+    } {
+      ibis.literal() ["val" = 7 : !i64, "type" = !ibis.nullable<!ibis.int64>]
+    }
+  } {} {}
+}
+
+
+//      CHECK:  rel_alg.compare() ["comparator" = "<="] {
+// CHECK-NEXT:      rel_alg.literal() ["val" = 5 : !i64, "type" = !rel_alg.nullable<!rel_alg.int64>]
+// CHECK-NEXT:    } {
+// CHECK-NEXT:      rel_alg.column() ["col_name" = "b"]
+// CHECK-NEXT:    }
+// CHECK-NEXT:    rel_alg.compare() ["comparator" = "<="] {
+// CHECK-NEXT:      rel_alg.column() ["col_name" = "b"]
+// CHECK-NEXT:    } {
+// CHECK-NEXT:      rel_alg.literal() ["val" = 7 : !i64, "type" = !rel_alg.nullable<!rel_alg.int64>]
+// CHECK-NEXT:    }
+// CHECK-NEXT:  }


### PR DESCRIPTION
This PR adds the modeling for the ibis `Between` node and lowers it to two comparisons in rel_alg.