### PR TITLE
SQL. add support for and

### DIFF
--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -72,7 +72,11 @@ def visit_schema(schema: ibis.expr.schema.Schema) -> Region:
 def visit_ibis_expr_list(l: List[ibis.expr.types.Expr]) -> Region:
   ops = []
   for op in l:
-    ops.append(visit(op))
+    if isinstance(op.op(), ibis.expr.operations.logical.And):
+      ops.append(visit(op.op().left))
+      ops.append(visit(op.op().right))
+    else:
+      ops.append(visit(op))
   return Region.from_operation_list(ops)
 
 

--- a/experimental/sql/src/ibis_frontend.py
+++ b/experimental/sql/src/ibis_frontend.py
@@ -72,6 +72,10 @@ def visit_schema(schema: ibis.expr.schema.Schema) -> Region:
 def visit_ibis_expr_list(l: List[ibis.expr.types.Expr]) -> Region:
   ops = []
   for op in l:
+    # TODO: This is a hack that rewrites top-level Ands. To do this properly,
+    # and handle all adds, first model And in ibis, then either rewrite this to
+    # a version using an optimization on the ibis dialect or model And in
+    # rel_alg and lower to that.
     if isinstance(op.op(), ibis.expr.operations.logical.And):
       ops.append(visit(op.op().left))
       ops.append(visit(op.op().right))

--- a/experimental/sql/test/frontend/and.ibis
+++ b/experimental/sql/test/frontend/and.ibis
@@ -1,0 +1,11 @@
+# RUN: rel_opt.py -f ibis %s | filecheck %s
+
+table = ibis.table([("a", "string"), ("b", "int64"), ("c", "int64")], 't')
+table.filter([(table['a'] == 'AS') & (table.b == ibis.literal(5, "int64"))])
+
+# CHECK: ibis.equals()
+# CHECK: ibis.table_column() ["col_name" = "a"]
+# CHECK: ibis.literal() ["val" = "AS", "type" = !ibis.nullable<!ibis.string>]
+# CHECK: ibis.equals()
+# CHECK: ibis.table_column() ["col_name" = "b"]
+# CHECK: ibis.literal() ["val" = 5 : !i64, "type" = !ibis.nullable<!ibis.int64>]


### PR DESCRIPTION
This PR adds support for the `And` not. In our current prototype, this can only occur in selections over lists of conditions, something like:

```python
table.filter([table.a == 5 & table.b == 7])
```

However, this is equivalent to writing:

```python
table.filter([table.a == 5, table.b == 7])
```

With this change, we lower to the latter form, if the former is encountered.

This might be a bit hacky, but it works for the TPC-H queries nad it closes the second not-so-nice thing about our representations.