### PR TITLE
[NFC] Iterators: Make TabularToLLVM compose with IteratorsToLLVM.

### DIFF
--- a/experimental/iterators/include/iterators/Conversion/TabularToLLVM/TabularToLLVM.h
+++ b/experimental/iterators/include/iterators/Conversion/TabularToLLVM/TabularToLLVM.h
@@ -11,14 +11,28 @@
 
 #include <memory>
 
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+
 namespace mlir {
 class ModuleOp;
 template <typename T>
 class OperationPass;
 class RewritePatternSet;
-class TypeConverter;
 
 namespace iterators {
+
+/// Maps types from the Tabular dialect to corresponding types in LLVM.
+class TabularTypeConverter : public TypeConverter {
+public:
+  TabularTypeConverter(LLVMTypeConverter &llvmTypeConverter);
+
+  /// Maps a TabularViewType to an LLVMStruct of pointers, i.e., to a "struct of
+  /// arrays".
+  static Optional<Type> convertTabularViewType(Type type);
+
+private:
+  LLVMTypeConverter llvmTypeConverter;
+};
 
 /// Populate the given list with patterns that convert from Tabular to LLVM.
 void populateTabularToLLVMConversionPatterns(RewritePatternSet &patterns,


### PR DESCRIPTION
This commit makes TabularTypeConverter part of the public API of TabularToLLVM such that other conversions can reuse that converter. It also turns TabularToLLVM into a partial conversion such that it can be run before IteratorsToLLVM (i.e., with ops from that dialect present).