### PR TITLE
Iterators: Fix handling of operands produced by non-iterator ops.

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -1469,6 +1469,8 @@ static void convertIteratorOps(ModuleOp module, TypeConverter &typeConverter) {
                               .create<UnrealizedConversionCastOp>(
                                   loc, convertedType, operand)
                               .getResult(0);
+        } else {
+          mappedOperand = operand;
         }
       }
 


### PR DESCRIPTION
The current conversion driver was handling operands produced by non-iterator ops incorrectly. In case they needed a type conversion, an unrealized cast was inserted correctly; in case they don't, they were simply dropped. That case didn't occur anywhere until now but I ran into it in a work-in-progress PR.