### PR TITLE
Iterators: Create iterator state type and extract/insert/undef ops.

### DIFF
--- a/experimental/iterators/include/iterators/Conversion/Passes.h
+++ b/experimental/iterators/include/iterators/Conversion/Passes.h
@@ -10,6 +10,7 @@
 #define ITERATORS_CONVERSION_PASSES_H
 
 #include "iterators/Conversion/IteratorsToLLVM/IteratorsToLLVM.h"
+#include "iterators/Conversion/StatesToLLVM/StatesToLLVM.h"
 #include "iterators/Conversion/TabularToLLVM/TabularToLLVM.h"
 #include "mlir/Pass/Pass.h"
 

--- a/experimental/iterators/include/iterators/Conversion/Passes.td
+++ b/experimental/iterators/include/iterators/Conversion/Passes.td
@@ -29,8 +29,8 @@ def ConvertIteratorsToLLVM : Pass<"convert-iterators-to-llvm", "ModuleOp"> {
     currently only works if the use-def chains of `Stream`s form a tree, i.e.,
     every `Stream` is used as an operand by exactly one subsequent iterator.
 
-    More precisely, for each iterator, the lowering produces a state in the form
-    of an `!llvm.struct<...>`, including any local state that the iterator might
+    More precisely, for each iterator, the lowering produces a state with a
+    number of typed fields, including any local state that the iterator might
     require **plus the states of all iterators in the transitive use-def chain**
     of its operands. The computations are expressed as three functions, `Open`,
     `Next`, and `Close`, which operate on that state and which continuously pass
@@ -55,6 +55,26 @@ def ConvertIteratorsToLLVM : Pass<"convert-iterators-to-llvm", "ModuleOp"> {
     "func::FuncDialect",
     "LLVM::LLVMDialect",
     "scf::SCFDialect"
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// IteratorsToLLVM
+//===----------------------------------------------------------------------===//
+
+def ConvertStatesToLLVM : Pass<"convert-states-to-llvm", "ModuleOp"> {
+  let summary = "Convert the operations on iterator states into the LLVM "
+                "dialect";
+  let description = [{
+    This lowering pass converts operations on iterator states into equivalent
+    operations of the LLVM dialect. Currently, the ops on iterator states are
+    essentially equivalent to the LLVM ops dealing with structs (but allow
+    arbitrary types), so the lowering only consists of straightforward,
+    one-to-one patterns.
+  }];
+  let constructor = "mlir::createConvertStatesToLLVMPass()";
+  let dependentDialects = [
+    "LLVM::LLVMDialect"
   ];
 }
 

--- a/experimental/iterators/include/iterators/Conversion/StatesToLLVM/StatesToLLVM.h
+++ b/experimental/iterators/include/iterators/Conversion/StatesToLLVM/StatesToLLVM.h
@@ -1,0 +1,35 @@
+//===-- StatesToLLVM.h - Utils to convert from Iterators states -*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ITERATORS_CONVERSION_STATESTOLLVM_STATESTOLLVM_H
+#define ITERATORS_CONVERSION_STATESTOLLVM_STATESTOLLVM_H
+
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+template <typename T>
+class OperationPass;
+class RewritePatternSet;
+class TypeConverter;
+
+namespace iterators {
+
+/// Populate the given list with patterns that convert from Iterator states to
+/// LLVM.
+void populateStatesToLLVMConversionPatterns(RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter);
+
+} // namespace iterators
+
+/// Create a pass to convert operations on Iterator states to the LLVM dialect.
+std::unique_ptr<OperationPass<ModuleOp>> createConvertStatesToLLVMPass();
+
+} // namespace mlir
+
+#endif // ITERATORS_CONVERSION_STATESTOLLVM_STATESTOLLVM_H

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -310,7 +310,7 @@ def Iterators_SinkOp : Iterators_Base_Op<"sink"> {
 def Iterators_UndefStateOp : Iterators_Base_Op<"undefstate", [NoSideEffect]> {
   let summary = "Create an undefined iterator state";
   let results = (outs Iterators_State:$result);
-  let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat = "attr-dict `:` qualified(type($result))";
   let description = [{
     Creates an iterator state of the given type with undefined field values.
     All fields have to be set individually with `insertvalue` before the whole
@@ -340,7 +340,8 @@ def Iterators_ExtractValueOp : Iterators_Base_Op<"extractvalue", [
   let arguments = (ins Iterators_State:$state, IndexAttr:$index);
   let results = (outs AnyType:$result);
   let assemblyFormat = [{
-    $state `[` $index `]` attr-dict `:` type($state) `->` type($result)
+    $state `[` $index `]` attr-dict `:`
+      qualified(type($state)) `->` qualified(type($result))
   }];
   let description = [{
     Extracts the value of the given iterator state at the given index.
@@ -372,7 +373,8 @@ def Iterators_InsertValueOp : Iterators_Base_Op<"insertvalue", [
   let arguments = (ins Iterators_State:$state, IndexAttr:$index, AnyType:$value);
   let results = (outs Iterators_State:$result);
   let assemblyFormat = [{
-    $state `[` $index `]` `(` $value `:` type($value) `)` attr-dict `:` type($result)
+    $state `[` $index `]` `(` $value `:` qualified(type($value)) `)`
+      attr-dict `:` qualified(type($result))
   }];
   let description = [{
     Inserts the given value into the given iterator state at the given index.

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -303,4 +303,90 @@ def Iterators_SinkOp : Iterators_Base_Op<"sink"> {
   let arguments = (ins Iterators_StreamOfLLVMStructOfNumerics:$input);
 }
 
+//===----------------------------------------------------------------------===//
+// Ops related to Iterator bodies.
+//===----------------------------------------------------------------------===//
+
+def Iterators_UndefStateOp : Iterators_Base_Op<"undefstate", [NoSideEffect]> {
+  let summary = "Create an undefined iterator state";
+  let results = (outs Iterators_State:$result);
+  let assemblyFormat = "attr-dict `:` type($result)";
+  let description = [{
+    Creates an iterator state of the given type with undefined field values.
+    All fields have to be set individually with `insertvalue` before the whole
+    state is fully defined.
+
+    This is similar to `llvm.undef` for `llvm.struct`.
+
+    Example:
+
+    ```
+    %undef_state = iterators.undefstate : !iterators.state<i32, tensor<?xi32>>
+    ```
+  }];
+}
+
+def Iterators_ExtractValueOp : Iterators_Base_Op<"extractvalue", [
+    NoSideEffect,
+    PredOpTrait<"index must exist in state",
+      CPred<"static_cast<uint64_t>($index.cast<IntegerAttr>().getInt())"
+            "    < $state.getType().cast<StateType>().getFieldTypes().size()">>,
+    AllMatch<["$state.getType().cast<StateType>().getFieldTypes()"
+              "    [$index.cast<IntegerAttr>().getInt()]",
+              "$result.getType()"],
+             "the return type must match the field type at the given index">
+    ]> {
+  let summary = "Extract the field value of the state";
+  let arguments = (ins Iterators_State:$state, IndexAttr:$index);
+  let results = (outs AnyType:$result);
+  let assemblyFormat = [{
+    $state `[` $index `]` attr-dict `:` type($state) `->` type($result)
+  }];
+  let description = [{
+    Extracts the value of the given iterator state at the given index.
+
+    This is similar to `llvm.extractvalue` for `llvm.struct`.
+
+    Example:
+
+    ```
+    %state = ...
+    %value = iterators.extractvalue %state[0] : !iterators.state<i32, tensor<?xi32>> -> i32
+    ```
+  }];
+}
+
+def Iterators_InsertValueOp : Iterators_Base_Op<"insertvalue", [
+    NoSideEffect,
+    PredOpTrait<
+      "index must exist in state",
+      CPred<"static_cast<uint64_t>($index.cast<IntegerAttr>().getInt())"
+            "    < $state.getType().cast<StateType>().getFieldTypes().size()">>,
+    AllMatch<["$state.getType().cast<StateType>().getFieldTypes()"
+              "    [$index.cast<IntegerAttr>().getInt()]",
+              "$value.getType()"],
+             "the value type must match the field type at the given index">,
+    AllTypesMatch<["state", "result"]>
+    ]> {
+  let summary = "Insert a field value into the state";
+  let arguments = (ins Iterators_State:$state, IndexAttr:$index, AnyType:$value);
+  let results = (outs Iterators_State:$result);
+  let assemblyFormat = [{
+    $state `[` $index `]` `(` $value `:` type($value) `)` attr-dict `:` type($result)
+  }];
+  let description = [{
+    Inserts the given value into the given iterator state at the given index.
+
+    This is similar to `llvm.insertvalue` for `llvm.struct`.
+
+    Example:
+
+    ```
+    %state = ...
+    %value = ...
+    %updated_state = iterators.insertvalue %state[0] (%value : i32) : !iterators.state<i32, tensor<?xi32>>
+    ```
+  }];
+}
+
 #endif // ITERATORS_DIALECT_ITERATORS_IR_ITERATORSOPS

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -352,7 +352,8 @@ def Iterators_ExtractValueOp : Iterators_Base_Op<"extractvalue", [
 
     ```
     %state = ...
-    %value = iterators.extractvalue %state[0] : !iterators.state<i32, tensor<?xi32>> -> i32
+    %value = iterators.extractvalue %state[0] :
+                 !iterators.state<i32, tensor<?xi32>> -> i32
     ```
   }];
 }
@@ -386,7 +387,8 @@ def Iterators_InsertValueOp : Iterators_Base_Op<"insertvalue", [
     ```
     %state = ...
     %value = ...
-    %updated_state = iterators.insertvalue %state[0] (%value : i32) : !iterators.state<i32, tensor<?xi32>>
+    %updated_state = iterators.insertvalue %state[0] (%value : i32) :
+                         !iterators.state<i32, tensor<?xi32>>
     ```
   }];
 }

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -334,14 +334,14 @@ def Iterators_ExtractValueOp : Iterators_Base_Op<"extractvalue", [
     AllMatch<["$state.getType().cast<StateType>().getFieldTypes()"
               "    [$index.cast<IntegerAttr>().getInt()]",
               "$result.getType()"],
-             "the return type must match the field type at the given index">
+             "the return type must match the field type at the given index">,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
     ]> {
   let summary = "Extract the field value of the state";
   let arguments = (ins Iterators_State:$state, IndexAttr:$index);
   let results = (outs AnyType:$result);
   let assemblyFormat = [{
-    $state `[` $index `]` attr-dict `:`
-      qualified(type($state)) `->` qualified(type($result))
+    $state `[` $index `]` attr-dict `:` qualified(type($state))
   }];
   let description = [{
     Extracts the value of the given iterator state at the given index.
@@ -353,7 +353,7 @@ def Iterators_ExtractValueOp : Iterators_Base_Op<"extractvalue", [
     ```
     %state = ...
     %value = iterators.extractvalue %state[0] :
-                 !iterators.state<i32, tensor<?xi32>> -> i32
+                 !iterators.state<i32, tensor<?xi32>>
     ```
   }];
 }
@@ -374,8 +374,8 @@ def Iterators_InsertValueOp : Iterators_Base_Op<"insertvalue", [
   let arguments = (ins Iterators_State:$state, IndexAttr:$index, AnyType:$value);
   let results = (outs Iterators_State:$result);
   let assemblyFormat = [{
-    $state `[` $index `]` `(` $value `:` qualified(type($value)) `)`
-      attr-dict `:` qualified(type($result))
+    $value `into` $state `[` $index `]` attr-dict `:` qualified(type($state))
+      custom<InsertValueType>(type($value), ref(type($state)), ref($index))
   }];
   let description = [{
     Inserts the given value into the given iterator state at the given index.

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -154,4 +154,32 @@ class Iterators_IsStreamOf<string name, Type type>
 class Iterators_IsStreamOfLLVMStructOfNumericsPred<string name>
   : Iterators_IsStreamOf<name, Iterators_StreamOfLLVMStructOfNumerics>;
 
+//===----------------------------------------------------------------------===//
+// Types related to Iterator bodies.
+//===----------------------------------------------------------------------===//
+
+def Iterators_State : Iterators_Type<"State", "state"> {
+  let summary = "State of an iterator used by its body";
+  let parameters =  (ins ArrayRefParameter<"Type", "list of types">:$fieldTypes);
+  let assemblyFormat = "`<` qualified($fieldTypes) `>`";
+  let description = [{
+    An iterator state is a collection of values identified by ordinal numbers,
+    i.e., an (unnamed but typed) tuple. The values are referred to as "fields";
+    their types are referred to as "field types". An iterator state is used by
+    iterator bodies, i.e., by the open, next, and close functions that implement
+    the logic that iterator ops get lowered to, and holds the state that is
+    required during the iteration (which gets passed around different calls to
+    open, next, and close).
+
+    This is similar to (anonymous) `llvm.struct` but allows for storing values
+    of arbitrary types.
+
+    Example:
+
+    ```
+    %undef_state = iterators.undefstate : !iterators.state<i32, tensor<?xi32>>
+    ```
+  }];
+}
+
 #endif // ITERATORS_DIALECT_ITERATORS_IR_ITERATORSTYPES

--- a/experimental/iterators/lib/CAPI/CMakeLists.txt
+++ b/experimental/iterators/lib/CAPI/CMakeLists.txt
@@ -7,4 +7,5 @@ add_mlir_public_c_api_library(IteratorsCAPI
     MLIRTabular
     MLIRTabularToLLVM
     MLIRPass
+    MLIRStatesToLLVM
 )

--- a/experimental/iterators/lib/Conversion/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(IteratorsToLLVM)
+add_subdirectory(StatesToLLVM)
 add_subdirectory(TabularToLLVM)

--- a/experimental/iterators/lib/Conversion/StatesToLLVM/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/StatesToLLVM/CMakeLists.txt
@@ -1,0 +1,14 @@
+add_mlir_conversion_library(MLIRStatesToLLVM
+  StatesToLLVM.cpp
+
+  DEPENDS
+  MLIRIteratorsConversionIncGen
+
+  LINK_LIBS PUBLIC
+  IteratorsUtils
+  MLIRFuncDialect
+  MLIRFuncTransforms
+  MLIRIterators
+  MLIRLLVMDialect
+  MLIRPass
+)

--- a/experimental/iterators/lib/Conversion/StatesToLLVM/StatesToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/StatesToLLVM/StatesToLLVM.cpp
@@ -1,0 +1,99 @@
+//===-- StatesToLLVM.h - Conversion from Iterator states to LLVM-*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Conversion/StatesToLLVM/StatesToLLVM.h"
+
+#include "../PassDetail.h"
+#include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Utils/MLIRSupport.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/FuncConversions.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+class MLIRContext;
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::func;
+using namespace mlir::iterators;
+using namespace mlir::LLVM;
+
+namespace {
+struct ConvertStatesToLLVMPass
+    : public ConvertStatesToLLVMBase<ConvertStatesToLLVMPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+/// Maps state types from the Iterators dialect to corresponding types in LLVM.
+class StateTypeConverter : public TypeConverter {
+public:
+  StateTypeConverter() {
+    addConversion([](Type type) { return type; });
+  }
+
+private:
+};
+
+void mlir::iterators::populateStatesToLLVMConversionPatterns(
+    RewritePatternSet &patterns, TypeConverter &typeConverter) {
+  // patterns.add<
+  //     // clang-format off
+  //     // clang-format on
+  //     >(typeConverter, patterns.getContext());
+}
+
+void ConvertStatesToLLVMPass::runOnOperation() {
+  auto module = getOperation();
+  StateTypeConverter typeConverter;
+
+  // Convert the remaining ops of this dialect using dialect conversion.
+  ConversionTarget target(getContext());
+  target.addLegalDialect<LLVMDialect>();
+  target.addLegalOp<ModuleOp>();
+  RewritePatternSet patterns(&getContext());
+
+  populateStatesToLLVMConversionPatterns(patterns, typeConverter);
+
+  // Add patterns that converts function signature and calls.
+  populateFunctionOpInterfaceTypeConversionPattern<FuncOp>(patterns,
+                                                           typeConverter);
+  populateCallOpTypeConversionPattern(patterns, typeConverter);
+  populateReturnOpTypeConversionPattern(patterns, typeConverter);
+
+  // Force application of that pattern if signature is not legal yet.
+  target.addDynamicallyLegalOp<func::FuncOp>([&](func::FuncOp op) {
+    return typeConverter.isSignatureLegal(op.getFunctionType());
+  });
+  target.addDynamicallyLegalOp<func::ReturnOp>([&](func::ReturnOp op) {
+    return typeConverter.isLegal(op.getOperandTypes());
+  });
+  target.addDynamicallyLegalOp<func::CallOp>([&](func::CallOp op) {
+    return typeConverter.isSignatureLegal(op.getCalleeType());
+  });
+
+  // Use UnrealizedConversionCast as materializations, which have to be cleaned
+  // up by later passes.
+  auto addUnrealizedCast = [](OpBuilder &builder, Type type, ValueRange inputs,
+                              Location loc) {
+    auto cast = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
+    return Optional<Value>(cast.getResult(0));
+  };
+  typeConverter.addSourceMaterialization(addUnrealizedCast);
+  typeConverter.addTargetMaterialization(addUnrealizedCast);
+
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> mlir::createConvertStatesToLLVMPass() {
+  return std::make_unique<ConvertStatesToLLVMPass>();
+}

--- a/experimental/iterators/test/Dialect/Iterators/state.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/state.mlir
@@ -6,13 +6,13 @@
 func.func @testUndefInsertExtract() {
 // CHECK-LABEL: func.func @testUndefInsertExtract() {
   %initial_state = iterators.undefstate : !iterators.state<i32>
-// CHECK-NEXT:     %[[V0:.*]] = iterators.undefstate : <i32>
+// CHECK-NEXT:     %[[V0:.*]] = iterators.undefstate : !iterators.state<i32>
   %value = arith.constant 0 : i32
 // CHECK-NEXT:     %[[V1:.*]] = arith.constant 0 : i32
   %inserted_state = iterators.insertvalue %initial_state[0] (%value : i32) : !iterators.state<i32>
-// CHECK-NEXT:     %[[V2:.*]] = iterators.insertvalue %[[V0]][0] (%[[V1]] : i32) : <i32>
+// CHECK-NEXT:     %[[V2:.*]] = iterators.insertvalue %[[V0]][0] (%[[V1]] : i32) : !iterators.state<i32>
   %extracted_value = iterators.extractvalue %inserted_state[0] : !iterators.state<i32> -> i32
-// CHECK-NEXT:     %[[V3:.*]] = iterators.extractvalue %[[V2]][0] : <i32> -> i32
+// CHECK-NEXT:     %[[V3:.*]] = iterators.extractvalue %[[V2]][0] : !iterators.state<i32> -> i32
   return
 // CHECK-NEXT:     return
 }

--- a/experimental/iterators/test/Dialect/Iterators/state.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/state.mlir
@@ -1,0 +1,19 @@
+// Test that we can parse and verify ops on iterator state correctly, and that
+// they round-trip through assembly.
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+func.func @testUndefInsertExtract() {
+// CHECK-LABEL: func.func @testUndefInsertExtract() {
+  %initial_state = iterators.undefstate : !iterators.state<i32>
+// CHECK-NEXT:     %[[V0:.*]] = iterators.undefstate : <i32>
+  %value = arith.constant 0 : i32
+// CHECK-NEXT:     %[[V1:.*]] = arith.constant 0 : i32
+  %inserted_state = iterators.insertvalue %initial_state[0] (%value : i32) : !iterators.state<i32>
+// CHECK-NEXT:     %[[V2:.*]] = iterators.insertvalue %[[V0]][0] (%[[V1]] : i32) : <i32>
+  %extracted_value = iterators.extractvalue %inserted_state[0] : !iterators.state<i32> -> i32
+// CHECK-NEXT:     %[[V3:.*]] = iterators.extractvalue %[[V2]][0] : <i32> -> i32
+  return
+// CHECK-NEXT:     return
+}
+// CHECK-NEXT:   }

--- a/experimental/iterators/test/Dialect/Iterators/state.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/state.mlir
@@ -9,10 +9,10 @@ func.func @testUndefInsertExtract() {
 // CHECK-NEXT:     %[[V0:.*]] = iterators.undefstate : !iterators.state<i32>
   %value = arith.constant 0 : i32
 // CHECK-NEXT:     %[[V1:.*]] = arith.constant 0 : i32
-  %inserted_state = iterators.insertvalue %initial_state[0] (%value : i32) : !iterators.state<i32>
-// CHECK-NEXT:     %[[V2:.*]] = iterators.insertvalue %[[V0]][0] (%[[V1]] : i32) : !iterators.state<i32>
-  %extracted_value = iterators.extractvalue %inserted_state[0] : !iterators.state<i32> -> i32
-// CHECK-NEXT:     %[[V3:.*]] = iterators.extractvalue %[[V2]][0] : !iterators.state<i32> -> i32
+  %inserted_state = iterators.insertvalue %value into %initial_state[0] : !iterators.state<i32>
+// CHECK-NEXT:     %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[V0]][0] : !iterators.state<i32>
+  %extracted_value = iterators.extractvalue %inserted_state[0] : !iterators.state<i32>
+// CHECK-NEXT:     %[[V3:.*]] = iterators.extractvalue %[[V2]][0] : !iterators.state<i32>
   return
 // CHECK-NEXT:     return
 }

--- a/tools/mlir-proto-lsp-server/CMakeLists.txt
+++ b/tools/mlir-proto-lsp-server/CMakeLists.txt
@@ -16,6 +16,7 @@ if(SANDBOX_ENABLE_ITERATORS)
   list(APPEND dialect_libs MLIRTabular)
   list(APPEND conversion_libs MLIRIteratorsToLLVM)
   list(APPEND conversion_libs MLIRTabularToLLVM)
+  list(APPEND conversion_libs MLIRStatesToLLVM)
 endif()
 
 target_link_libraries(mlir-proto-lsp-server

--- a/tools/mlir-proto-opt/CMakeLists.txt
+++ b/tools/mlir-proto-opt/CMakeLists.txt
@@ -16,6 +16,7 @@ if(SANDBOX_ENABLE_ITERATORS)
   list(APPEND dialect_libs MLIRTabular)
   list(APPEND conversion_libs MLIRIteratorsToLLVM)
   list(APPEND conversion_libs MLIRTabularToLLVM)
+  list(APPEND conversion_libs MLIRStatesToLLVM)
 endif()
 
 target_link_libraries(mlir-proto-opt


### PR DESCRIPTION
This PR depends on and therefore includes #605.

One point for discussion is the assembly format, which we may want to decide to change in order to make it similar to other ops with similar semantics.