### PR TITLE
Iterators: Use new iterator states in IteratorsToLLVM.

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorAnalysis.h
@@ -9,8 +9,8 @@
 #ifndef EXPERIMENTAL_ITERATORS_LIB_CONVERSION_ITERATORSTOLLVM_ITERATORANALYSIS_H
 #define EXPERIMENTAL_ITERATORS_LIB_CONVERSION_ITERATORSTOLLVM_ITERATORANALYSIS_H
 
+#include "iterators/Dialect/Iterators/IR/Iterators.h"
 #include "iterators/Utils/NameAssigner.h"
-#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 namespace mlir {
 class ModuleOp;
@@ -23,10 +23,9 @@ class IteratorOpInterface;
 
 /// Information about each iterator op constructed by IteratorAnalysis.
 struct IteratorInfo {
-  /// Takes the `LLVM::LLVMStructType` as a parameter, to ensure proper build
-  /// order (all uses are visited before any def).
-  IteratorInfo(IteratorOpInterface op, NameAssigner &nameAssigner,
-               LLVM::LLVMStructType t);
+  /// Takes the `StateType` as a parameter, to ensure proper build order (all
+  /// uses are visited before any def).
+  IteratorInfo(IteratorOpInterface op, NameAssigner &nameAssigner, StateType t);
 
   // Rule of five: default constructors/assignment operators
   IteratorInfo() = default;
@@ -42,7 +41,7 @@ struct IteratorInfo {
   SymbolRefAttr closeFunc;
 
   /// State of the iterator including the state of its potential upstreams.
-  LLVM::LLVMStructType stateType;
+  StateType stateType;
 };
 
 /// Constructs information about the state type and the Open/Next/Close

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -258,8 +258,7 @@ struct PrintOpLowering : public OpConversionPattern<PrintOp> {
 /// Builds IR that resets the current index to 0. Possible result:
 ///
 /// %0 = llvm.mlir.constant(0 : i32) : i32
-/// %1 = llvm.insertvalue %0, %arg0[0 : index] :
-///          !llvm.struct<"iterators.constant_stream_state", (i32)>
+/// %1 = iterators.insertvalue %arg0[0] (%0 : i32) : <i32>
 static Value buildOpenBody(ConstantStreamOp op, OpBuilder &builder,
                            Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
@@ -270,7 +269,8 @@ static Value buildOpenBody(ConstantStreamOp op, OpBuilder &builder,
   Type i32 = b.getI32Type();
   Attribute zeroAttr = b.getI32IntegerAttr(0);
   Value zeroValue = b.create<LLVM::ConstantOp>(i32, zeroAttr);
-  Value updatedState = createInsertValueOp(b, initialState, zeroValue, {0});
+  Value updatedState = b.create<iterators::InsertValueOp>(
+      initialState, b.getIndexAttr(0), zeroValue);
 
   return updatedState;
 }
@@ -348,16 +348,13 @@ static GlobalOp buildGlobalData(ConstantStreamOp op, OpBuilder &builder,
 ///
 /// llvm.mlir.global internal constant @iterators.constant_stream_data.0() : ...
 /// // ...
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.constant_stream_state", (i32)>
+/// %0 = iterators.extractvalue %arg0[0] : <i32> -> i32
 /// %c4_i32 = arith.constant 4 : i32
 /// %1 = arith.cmpi slt, %0, %c4_i32 : i32
-/// %2:2 = scf.if %1 -> (!llvm.struct<"iterators.constant_stream_state", (i32)>,
-///                      !element_type) {
+/// %2:2 = scf.if %1 -> (!iterators.state<i32>, !element_type) {
 ///   %c1_i32 = arith.constant 1 : i32
 ///   %3 = arith.addi %0, %c1_i32 : i32
-///   %4 = llvm.insertvalue %3, %arg0[0 : index] :
-///            !llvm.struct<"iterators.constant_stream_state", (i32)>
+///   %4 = iterators.insertvalue %arg0[0] (%3 : i32) : <i32>
 ///   %5 = llvm.mlir.addressof @iterators.constant_stream_data.0 :
 ///            !llvm.ptr<array<4 x !element_type>>
 ///   %c0_i32 = arith.constant 0 : i32
@@ -365,12 +362,10 @@ static GlobalOp buildGlobalData(ConstantStreamOp op, OpBuilder &builder,
 ///            (!llvm.ptr<array<4 x !element_type>>, i32, i32)
 ///                -> !llvm.ptr<!element_type>
 ///   %7 = llvm.load %6 : !llvm.ptr<!element_type>
-///   scf.yield %4, %7 :
-///       !llvm.struct<"iterators.constant_stream_state", (i32)>, !element_type
+///   scf.yield %4, %7 : !iterators.state<i32>, !element_type
 /// } else {
 ///   %3 = llvm.mlir.undef : !element_type
-///   scf.yield %arg0, %3 :
-///       !llvm.struct<"iterators.constant_stream_state", (i32)>, !element_type
+///   scf.yield %arg0, %3 : !iterators.state<i32>, !element_type
 /// }
 static llvm::SmallVector<Value, 4>
 buildNextBody(ConstantStreamOp op, OpBuilder &builder, Value initialState,
@@ -380,7 +375,8 @@ buildNextBody(ConstantStreamOp op, OpBuilder &builder, Value initialState,
   Type i32 = b.getI32Type();
 
   // Extract current index.
-  Value currentIndex = createExtractValueOp(b, i32, initialState, {0});
+  Value currentIndex = b.create<iterators::ExtractValueOp>(
+      loc, i32, initialState, b.getIndexAttr(0));
 
   // Test if we have reached the end of the range.
   int64_t numElements = op.value().size();
@@ -399,8 +395,8 @@ buildNextBody(ConstantStreamOp op, OpBuilder &builder, Value initialState,
                                                    /*width=*/32);
         ArithBuilder ab(b, b.getLoc());
         Value updatedCurrentIndex = ab.add(currentIndex, one);
-        Value updatedState =
-            createInsertValueOp(b, initialState, updatedCurrentIndex, {0});
+        Value updatedState = b.create<iterators::InsertValueOp>(
+            initialState, b.getIndexAttr(0), updatedCurrentIndex);
 
         // Load element from global data at current index.
         GlobalOp globalArray = buildGlobalData(op, b, elementType);
@@ -439,14 +435,11 @@ static Value buildCloseBody(ConstantStreamOp /*op*/, OpBuilder & /*builder*/,
 /// (uninitialized) current index. Possible result:
 ///
 /// %0 = llvm.mlir.constant(0 : i32) : i32
-/// %1 = llvm.insertvalue %0, %arg0[0 : index] :
-///          !llvm.struct<"iterators.constant_stream_state", (i32)>
-/// return %1 : !llvm.struct<"iterators.constant_stream_state", (i32)>
+/// %1 = iterators.insertvalue %arg0[0] (%0 : i32) : <i32>
 static Value buildStateCreation(ConstantStreamOp op,
                                 ConstantStreamOp::Adaptor /*adaptor*/,
-                                OpBuilder &builder,
-                                LLVM::LLVMStructType stateType) {
-  return builder.create<UndefOp>(op.getLoc(), stateType);
+                                OpBuilder &builder, StateType stateType) {
+  return builder.create<UndefStateOp>(op.getLoc(), stateType);
 }
 
 //===----------------------------------------------------------------------===//
@@ -455,12 +448,9 @@ static Value buildStateCreation(ConstantStreamOp op,
 
 /// Builds IR that opens the nested upstream iterator. Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.filter_state", !nested_state>
-/// %1 = call @iterators.upstream.open.0(%0) :
-///          (!nested_state) -> !nested_state
-/// %2 = llvm.insertvalue %1, %arg0[0 : index] :
-///          !llvm.struct<"iterators.filter_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
+/// %1 = call @iterators.upstream.open.0(%0) : (!nested_state) -> !nested_state
+/// %2 = iterators.insertvalue %arg0[0] (%1 : !nested_state) : <!nested_state>
 static Value buildOpenBody(FilterOp op, OpBuilder &builder, Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -469,8 +459,8 @@ static Value buildOpenBody(FilterOp op, OpBuilder &builder, Value initialState,
   Type upstreamStateType = upstreamInfos[0].stateType;
 
   // Extract upstream state.
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Call Open on upstream.
   SymbolRefAttr openFunc = upstreamInfos[0].openFunc;
@@ -479,8 +469,8 @@ static Value buildOpenBody(FilterOp op, OpBuilder &builder, Value initialState,
 
   // Update upstream state.
   Value updatedUpstreamState = openCallOp->getResult(0);
-  Value updatedState =
-      createInsertValueOp(b, initialState, updatedUpstreamState, {0});
+  Value updatedState = b.create<iterators::InsertValueOp>(
+      initialState, b.getIndexAttr(0), updatedUpstreamState);
 
   return updatedState;
 }
@@ -495,8 +485,7 @@ static Value buildOpenBody(FilterOp op, OpBuilder &builder, Value initialState,
 ///
 /// Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.filter_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
 /// %1:3 = scf.while (%arg1 = %0) :
 ///            (!nested_state) -> (!nested_state, i1, !element_type) {
 ///   %3:3 = func.call @iterators.upstream.next.0(%arg1) :
@@ -515,8 +504,7 @@ static Value buildOpenBody(FilterOp op, OpBuilder &builder, Value initialState,
 /// ^bb0(%arg1: !nested_state, %arg2: i1, %arg3: !element_type):
 ///   scf.yield %arg1 : !nested_state
 /// }
-/// %2 = llvm.insertvalue %1#0, %arg0[0 : index] :
-///          !llvm.struct<"iterators.filter_state", (!nested_state)>
+/// %2 = iterators.insertvalue %arg0[0] (%1#0 : !nested_state) : <!nested_state>
 static llvm::SmallVector<Value, 4>
 buildNextBody(FilterOp op, OpBuilder &builder, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
@@ -525,8 +513,8 @@ buildNextBody(FilterOp op, OpBuilder &builder, Value initialState,
 
   // Extract upstream state.
   Type upstreamStateType = upstreamInfos[0].stateType;
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Main while loop.
   Type i1 = b.getI1Type();
@@ -584,8 +572,8 @@ buildNextBody(FilterOp op, OpBuilder &builder, Value initialState,
 
   // Update state.
   Value finalUpstreamState = whileOp->getResult(0);
-  Value finalState =
-      createInsertValueOp(b, initialState, finalUpstreamState, {0});
+  Value finalState = b.create<iterators::InsertValueOp>(
+      initialState, b.getIndexAttr(0), finalUpstreamState);
   Value hasNext = whileOp->getResult(1);
   Value nextElement = whileOp->getResult(2);
 
@@ -594,12 +582,9 @@ buildNextBody(FilterOp op, OpBuilder &builder, Value initialState,
 
 /// Builds IR that closes the nested upstream iterator. Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.filter_state", (!nested_state)>
-/// %1 = call @iterators.upstream.close.0(%0) :
-///          (!nested_state) -> !nested_state
-/// %2 = llvm.insertvalue %1, %arg0[0 : index] :
-///          !llvm.struct<"iterators.filter_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
+/// %1 = call @iterators.upstream.close.0(%0) : (!nested_state) -> !nested_state
+/// %2 = iterators.insertvalue %arg0[0] (%1 : !nested_state) : <!nested_state>
 static Value buildCloseBody(FilterOp op, OpBuilder &builder, Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -608,8 +593,8 @@ static Value buildCloseBody(FilterOp op, OpBuilder &builder, Value initialState,
   Type upstreamStateType = upstreamInfos[0].stateType;
 
   // Extract upstream state.
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Call Close on upstream.
   SymbolRefAttr closeFunc = upstreamInfos[0].closeFunc;
@@ -618,7 +603,9 @@ static Value buildCloseBody(FilterOp op, OpBuilder &builder, Value initialState,
 
   // Update upstream state.
   Value updatedUpstreamState = closeCallOp->getResult(0);
-  return createInsertValueOp(b, initialState, updatedUpstreamState, {0})
+  return b
+      .create<iterators::InsertValueOp>(initialState, b.getIndexAttr(0),
+                                        updatedUpstreamState)
       .getResult();
 }
 
@@ -626,18 +613,16 @@ static Value buildCloseBody(FilterOp op, OpBuilder &builder, Value initialState,
 /// iterator. Possible output:
 ///
 /// %0 = ...
-/// %1 = llvm.mlir.undef : !llvm.struct<"iterators.filter_state",
-///                                     (!nested_state)>
-/// %2 = llvm.insertvalue %0, %1[0 : index] :
-///          !llvm.struct<"iterators.filter_state", (!nested_state)>
+/// %1 = iterators.undefstate : <!nested_state>
+/// %2 = iterators.insertvalue %1[0] (%0 : !nested_state) : <!nested_state>
 static Value buildStateCreation(FilterOp op, FilterOp::Adaptor adaptor,
-                                OpBuilder &builder,
-                                LLVM::LLVMStructType stateType) {
+                                OpBuilder &builder, StateType stateType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder b(loc, builder);
-  Value undefState = b.create<UndefOp>(stateType);
+  Value undefState = b.create<UndefStateOp>(stateType);
   Value upstreamState = adaptor.input();
-  return createInsertValueOp(b, undefState, upstreamState, {0});
+  return b.create<iterators::InsertValueOp>(undefState, b.getIndexAttr(0),
+                                            upstreamState);
 }
 
 //===----------------------------------------------------------------------===//
@@ -646,12 +631,9 @@ static Value buildStateCreation(FilterOp op, FilterOp::Adaptor adaptor,
 
 /// Builds IR that opens the nested upstream iterator. Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.map_state", !nested_state>
-/// %1 = call @iterators.upstream.open.0(%0) :
-///          (!nested_state) -> !nested_state
-/// %2 = llvm.insertvalue %1, %arg0[0 : index] :
-///          !llvm.struct<"iterators.map_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
+/// %1 = call @iterators.upstream.open.0(%0) : (!nested_state) -> !nested_state
+/// %2 = iterators.insertvalue %arg0[0] (%1 : !nested_state) : <!nested_state>
 static Value buildOpenBody(MapOp op, OpBuilder &builder, Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -660,8 +642,8 @@ static Value buildOpenBody(MapOp op, OpBuilder &builder, Value initialState,
   Type upstreamStateType = upstreamInfos[0].stateType;
 
   // Extract upstream state.
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Call Open on upstream.
   SymbolRefAttr openFunc = upstreamInfos[0].openFunc;
@@ -670,8 +652,8 @@ static Value buildOpenBody(MapOp op, OpBuilder &builder, Value initialState,
 
   // Update upstream state.
   Value updatedUpstreamState = openCallOp->getResult(0);
-  Value updatedState =
-      createInsertValueOp(b, initialState, updatedUpstreamState, {0});
+  Value updatedState = b.create<iterators::InsertValueOp>(
+      initialState, b.getIndexAttr(0), updatedUpstreamState);
 
   return updatedState;
 }
@@ -686,28 +668,17 @@ static Value buildOpenBody(MapOp op, OpBuilder &builder, Value initialState,
 ///
 /// Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.map_state", (!nested_state)>
-/// %1:3 = scf.while (%arg1 = %0) :
-///            (!nested_state) -> (!nested_state, i1, !element_type) {
-///   %3:3 = func.call @iterators.upstream.next.0(%arg1) :
-///              (!nested_state) -> (!nested_state, i1, !element_type)
-///   %4 = scf.if %3#1 -> (i1) {
-///     %7 = func.call @predicate(%3#2) : (!element_type) -> i1
-///     scf.yield %7 : i1
-///   } else {
-///     scf.yield %3#1 : i1
-///   }
-///   %true = arith.constant true
-///   %5 = arith.xori %4, %true : i1
-///   %6 = arith.andi %3#1, %5 : i1
-///   scf.condition(%6) %3#0, %3#1, %3#2 : !nested_state, i1, !element_type
-/// } do {
-/// ^bb0(%arg1: !nested_state, %arg2: i1, %arg3: !element_type):
-///   scf.yield %arg1 : !nested_state
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
+/// %1:3 = call @iterators.upstream.next.0(%0) :
+///            (!nested_state) -> (!nested_state, i1, !element_type)
+/// %2 = scf.if %1#1 -> (!element_type) {
+///   %4 = func.call @map_function(%1#2) : (!element_type) -> !element_type
+///   scf.yield %4 : !element_type
+/// } else {
+///   %4 = llvm.mlir.undef : !element_type
+///   scf.yield %4 : !element_type
 /// }
-/// %2 = llvm.insertvalue %1#0, %arg0[0 : index] :
-///          !llvm.struct<"iterators.map_state", (!nested_state)>
+/// %3 = iterators.insertvalue %arg0[0] (%1#0 : !nested_state) : <!nested_state>
 static llvm::SmallVector<Value, 4>
 buildNextBody(MapOp op, OpBuilder &builder, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
@@ -716,8 +687,8 @@ buildNextBody(MapOp op, OpBuilder &builder, Value initialState,
 
   // Extract upstream state.
   Type upstreamStateType = upstreamInfos[0].stateType;
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Extract input element type.
   StreamType inputStreamType = op.input().getType().cast<StreamType>();
@@ -755,20 +726,17 @@ buildNextBody(MapOp op, OpBuilder &builder, Value initialState,
 
   // Update state.
   Value finalUpstreamState = nextCall.getResult(0);
-  Value finalState =
-      createInsertValueOp(b, initialState, finalUpstreamState, {0});
+  Value finalState = b.create<iterators::InsertValueOp>(
+      initialState, b.getIndexAttr(0), finalUpstreamState);
 
   return {finalState, hasNext, mappedElement};
 }
 
 /// Builds IR that closes the nested upstream iterator. Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.map_state", (!nested_state)>
-/// %1 = call @iterators.upstream.close.0(%0) :
-///          (!nested_state) -> !nested_state
-/// %2 = llvm.insertvalue %1, %arg0[0 : index] :
-///          !llvm.struct<"iterators.map_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
+/// %1 = call @iterators.upstream.close.0(%0) : (!nested_state) -> !nested_state
+/// %2 = iterators.insertvalue %arg0[0] (%1 : !nested_state) : <!nested_state>
 static Value buildCloseBody(MapOp op, OpBuilder &builder, Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -777,8 +745,8 @@ static Value buildCloseBody(MapOp op, OpBuilder &builder, Value initialState,
   Type upstreamStateType = upstreamInfos[0].stateType;
 
   // Extract upstream state.
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Call Close on upstream.
   SymbolRefAttr closeFunc = upstreamInfos[0].closeFunc;
@@ -787,25 +755,24 @@ static Value buildCloseBody(MapOp op, OpBuilder &builder, Value initialState,
 
   // Update upstream state.
   Value updatedUpstreamState = closeCallOp->getResult(0);
-  return createInsertValueOp(b, initialState, updatedUpstreamState, {0})
-      .getResult();
+  return b.create<iterators::InsertValueOp>(initialState, b.getIndexAttr(0),
+                                            updatedUpstreamState);
 }
 
 /// Builds IR that initializes the iterator state with the state of the upstream
 /// iterator. Possible output:
 ///
 /// %0 = ...
-/// %1 = llvm.mlir.undef : !llvm.struct<"iterators.map_state", (!nested_state)>
-/// %2 = llvm.insertvalue %0, %1[0 : index] :
-///          !llvm.struct<"iterators.filter_state", (!nested_state)>
+/// %1 = iterators.undefstate : <!nested_state>
+/// %2 = iterators.insertvalue %1[0] (%0 : !nested_state) : <!nested_state>
 static Value buildStateCreation(MapOp op, MapOp::Adaptor adaptor,
-                                OpBuilder &builder,
-                                LLVM::LLVMStructType stateType) {
+                                OpBuilder &builder, StateType stateType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder b(loc, builder);
-  Value undefState = b.create<UndefOp>(stateType);
+  Value undefState = b.create<UndefStateOp>(stateType);
   Value upstreamState = adaptor.input();
-  return createInsertValueOp(b, undefState, upstreamState, {0});
+  return b.create<iterators::InsertValueOp>(undefState, b.getIndexAttr(0),
+                                            upstreamState);
 }
 
 //===----------------------------------------------------------------------===//
@@ -814,12 +781,9 @@ static Value buildStateCreation(MapOp op, MapOp::Adaptor adaptor,
 
 /// Builds IR that opens the nested upstream iterator. Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.reduce_state", !nested_state>
-/// %1 = call @iterators.upstream.open.0(%0) :
-///          (!nested_state) -> !nested_state
-/// %2 = llvm.insertvalue %1, %arg0[0 : index] :
-///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
+/// %1 = call @iterators.upstream.open.0(%0) : (!nested_state) -> !nested_state
+/// %2 = iterators.insertvalue %arg0[0] (%1 : !nested_state) : <!nested_state>
 static Value buildOpenBody(ReduceOp op, OpBuilder &builder, Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -828,8 +792,8 @@ static Value buildOpenBody(ReduceOp op, OpBuilder &builder, Value initialState,
   Type upstreamStateType = upstreamInfos[0].stateType;
 
   // Extract upstream state.
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Call Open on upstream.
   SymbolRefAttr openFunc = upstreamInfos[0].openFunc;
@@ -838,8 +802,8 @@ static Value buildOpenBody(ReduceOp op, OpBuilder &builder, Value initialState,
 
   // Update upstream state.
   Value updatedUpstreamState = openCallOp->getResult(0);
-  Value updatedState =
-      createInsertValueOp(b, initialState, updatedUpstreamState, {0});
+  Value updatedState = b.create<iterators::InsertValueOp>(
+      initialState, b.getIndexAttr(0), updatedUpstreamState);
 
   return updatedState;
 }
@@ -855,31 +819,29 @@ static Value buildOpenBody(ReduceOp op, OpBuilder &builder, Value initialState,
 ///
 /// Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
 /// %1:3 = call @iterators.upstream.next.0(%0) :
 ///            (!nested_state) -> (!nested_state, i1, !element_type)
 /// %2:3 = scf.if %1#1 -> (!nested_state, i1, !element_type) {
 ///   %4:3 = scf.while (%arg1 = %1#0, %arg2 = %1#2) :
 ///              (!nested_state, !element_type) ->
-///                 (!nested_state, !element_type, !element_type) {
-///     %5:3 = call @iterators.upstream.next.0(%arg1) :
+///                  (!nested_state, !element_type, !element_type) {
+///     %5:3 = func.call @iterators.upstream.next.0(%arg1) :
 ///                (!nested_state) -> (!nested_state, i1, !element_type)
-///     scf.condition(%5#1) %5#0, %5#2, %arg2 :
+///     scf.condition(%5#1) %5#0, %arg2, %5#2 :
 ///         !nested_state, !element_type, !element_type
 ///   } do {
 ///   ^bb0(%arg1: !nested_state, %arg2: !element_type, %arg3: !element_type):
-///     %5 = call @reduce_func(%arg2, %arg3) :
+///     %5 = func.call @reduce_func(%arg2, %arg3) :
 ///              (!element_type, !element_type) -> !element_type
-///     scf.yield %arg1, %8 : !nested_state, !element_type
+///     scf.yield %arg1, %5 : !nested_state, !element_type
 ///   }
 ///   %true = arith.constant true
-///   scf.yield %4#0, %true, %4#2 : !nested_state, i1, !element_type
+///   scf.yield %4#0, %true, %4#1 : !nested_state, i1, !element_type
 /// } else {
 ///   scf.yield %1#0, %1#1, %1#2 : !nested_state, i1, !element_type
 /// }
-/// %3 = llvm.insertvalue %2#0, %arg0[0 : index] :
-///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
+/// %3 = iterators.insertvalue %arg0[0] (%2#0 : !nested_state) : <!nested_state>
 static llvm::SmallVector<Value, 4>
 buildNextBody(ReduceOp op, OpBuilder &builder, Value initialState,
               ArrayRef<IteratorInfo> upstreamInfos, Type elementType) {
@@ -888,8 +850,8 @@ buildNextBody(ReduceOp op, OpBuilder &builder, Value initialState,
 
   // Extract upstream state.
   Type upstreamStateType = upstreamInfos[0].stateType;
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Get first result from upstream.
   Type i1 = b.getI1Type();
@@ -972,8 +934,8 @@ buildNextBody(ReduceOp op, OpBuilder &builder, Value initialState,
 
   // Update state.
   Value finalUpstreamState = ifOp->getResult(0);
-  Value finalState =
-      createInsertValueOp(b, initialState, finalUpstreamState, {0});
+  Value finalState = b.create<iterators::InsertValueOp>(
+      initialState, b.getIndexAttr(0), finalUpstreamState);
   Value hasNext = ifOp->getResult(1);
   Value nextElement = ifOp->getResult(2);
 
@@ -982,12 +944,9 @@ buildNextBody(ReduceOp op, OpBuilder &builder, Value initialState,
 
 /// Builds IR that closes the nested upstream iterator. Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
-/// %1 = call @iterators.upstream.close.0(%0) :
-///          (!nested_state) -> !nested_state
-/// %2 = llvm.insertvalue %1, %arg0[0 : index] :
-///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
+/// %0 = iterators.extractvalue %arg0[0] : <!nested_state> -> !nested_state
+/// %1 = call @iterators.upstream.close.0(%0) : (!nested_state) -> !nested_state
+/// %2 = iterators.insertvalue %arg0[0] (%1 : !nested_state) : <!nested_state>
 static Value buildCloseBody(ReduceOp op, OpBuilder &builder, Value initialState,
                             ArrayRef<IteratorInfo> upstreamInfos) {
   Location loc = op.getLoc();
@@ -996,8 +955,8 @@ static Value buildCloseBody(ReduceOp op, OpBuilder &builder, Value initialState,
   Type upstreamStateType = upstreamInfos[0].stateType;
 
   // Extract upstream state.
-  Value initialUpstreamState =
-      createExtractValueOp(b, upstreamStateType, initialState, {0});
+  Value initialUpstreamState = b.create<iterators::ExtractValueOp>(
+      upstreamStateType, initialState, b.getIndexAttr(0));
 
   // Call Close on upstream.
   SymbolRefAttr closeFunc = upstreamInfos[0].closeFunc;
@@ -1006,7 +965,9 @@ static Value buildCloseBody(ReduceOp op, OpBuilder &builder, Value initialState,
 
   // Update upstream state.
   Value updatedUpstreamState = closeCallOp->getResult(0);
-  return createInsertValueOp(b, initialState, updatedUpstreamState, {0})
+  return b
+      .create<iterators::InsertValueOp>(initialState, b.getIndexAttr(0),
+                                        updatedUpstreamState)
       .getResult();
 }
 
@@ -1014,18 +975,16 @@ static Value buildCloseBody(ReduceOp op, OpBuilder &builder, Value initialState,
 /// iterator. Possible output:
 ///
 /// %0 = ...
-/// %1 = llvm.mlir.undef : !llvm.struct<"iterators.reduce_state",
-///                                     (!nested_state)>
-/// %2 = llvm.insertvalue %0, %1[0 : index] :
-///          !llvm.struct<"iterators.reduce_state", (!nested_state)>
+/// %1 = iterators.undefstate : <!nested_state>
+/// %2 = iterators.insertvalue %1[0] (%0 : !nested_state) : <!nested_state>
 static Value buildStateCreation(ReduceOp op, ReduceOp::Adaptor adaptor,
-                                OpBuilder &builder,
-                                LLVM::LLVMStructType stateType) {
+                                OpBuilder &builder, StateType stateType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder b(loc, builder);
-  Value undefState = b.create<UndefOp>(loc, stateType);
+  Value undefState = b.create<UndefStateOp>(loc, stateType);
   Value upstreamState = adaptor.input();
-  return createInsertValueOp(b, undefState, upstreamState, {0});
+  return b.create<iterators::InsertValueOp>(undefState, b.getIndexAttr(0),
+                                            upstreamState);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1035,9 +994,7 @@ static Value buildStateCreation(ReduceOp op, ReduceOp::Adaptor adaptor,
 /// Builds IR that (re) sets the current index to zero. Possible output:
 ///
 /// %0 = llvm.mlir.constant(0 : i64) : i64
-/// %1 = llvm.insertvalue %0, %arg0[0 : index] :
-///          !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                       (i64, !tabular_view_type)>
+/// %1 = iterators.insertvalue %arg0[0] (%0 : i64) : <i64, !tabular_view_type>
 static Value buildOpenBody(TabularViewToStreamOp op, OpBuilder &builder,
                            Value initialState,
                            ArrayRef<IteratorInfo> upstreamInfos) {
@@ -1048,9 +1005,8 @@ static Value buildOpenBody(TabularViewToStreamOp op, OpBuilder &builder,
   Type i64 = b.getI64Type();
   Attribute zeroAttr = b.getI64IntegerAttr(0);
   Value zeroValue = b.create<LLVM::ConstantOp>(i64, zeroAttr);
-  Value updatedState = createInsertValueOp(b, initialState, zeroValue, {0});
-
-  return updatedState;
+  return b.create<iterators::InsertValueOp>(initialState, b.getIndexAttr(0),
+                                            zeroValue);
 }
 
 /// Builds IR that assembles an element from the values in the buffers at the
@@ -1062,38 +1018,27 @@ static Value buildOpenBody(TabularViewToStreamOp op, OpBuilder &builder,
 ///
 /// Possible output:
 ///
-/// %0 = llvm.extractvalue %arg0[0 : index] :
-///          !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                       (i64, !tabular_view_type)>
-/// %1 = llvm.extractvalue %arg0[1 : index] :
-///          !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                       (i64, !tabular_view_type)>
-/// %2 = llvm.extractvalue %1[0 : index] : !llvm.!tabular_view_type
+/// %0 = iterators.extractvalue %arg0[0] : <i64, !tabular_view_type> -> i64
+/// %1 = iterators.extractvalue %arg0[1] :
+///          <i64, !tabular_view_type> -> !tabular_view_type
+/// %2 = llvm.extractvalue %1[0 : index] : !tabular_view_type
 /// %3 = arith.cmpi slt, %0, %2 : i64
-/// %4:2 = scf.if %3 -> (!llvm.struct<"iterators.tabular_view_to_stream_state",
-///                                   (i64, !tabular_view_type)>,
+/// %4:2 = scf.if %3 -> (!iterators.state<i64, !tabular_view_type>,
 ///                      !element_type) {
 ///   %c1_i64 = arith.constant 1 : i64
 ///   %5 = arith.addi %0, %c1_i64 : i64
-///   %6 = llvm.insertvalue %5, %arg0[0 : index] :
-///            !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                         (i64, !tabular_view_type)>
+///   %6 = iterators.insertvalue %arg0[0] (%5 : i64) : <i64, !tabular_view_type>
 ///   %7 = llvm.mlir.undef : !element_type
-///   %8 = llvm.extractvalue %1[1 : index] : !llvm.!tabular_view_type
-///   %9 = llvm.getelementptr %8[%0] :
-///            (!llvm.ptr<!column_type_0>, i64) -> !llvm.ptr<!column_type_0>
-///   %10 = llvm.load %9 : !llvm.ptr<!column_type_0>
+///   %8 = llvm.extractvalue %1[1 : index] : !tabular_view_type
+///   %9 = llvm.getelementptr %8[%0] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+///   %10 = llvm.load %9 : !llvm.ptr<i32>
 ///   %11 = llvm.insertvalue %10, %7[0 : index] : !element_type
 ///   scf.yield %6, %11 :
-///       !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                    (i64, !tabular_view_type)>,
-///       !element_type
+///       !iterators.state<i64, !tabular_view_type>, !element_type
 /// } else {
 ///   %5 = llvm.mlir.undef : !element_type
 ///   scf.yield %arg0, %5 :
-///       !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                    (i64, !tabular_view_type)>,
-///       !element_type
+///       !iterators.state<i64, !tabular_view_type>, !element_type
 /// }
 static llvm::SmallVector<Value, 4>
 buildNextBody(TabularViewToStreamOp op, OpBuilder &builder, Value initialState,
@@ -1105,13 +1050,14 @@ buildNextBody(TabularViewToStreamOp op, OpBuilder &builder, Value initialState,
   auto elementStructType = elementType.cast<LLVMStructType>();
 
   // Extract current index.
-  Value currentIndex = createExtractValueOp(b, i64, initialState, {0});
+  Value currentIndex =
+      b.create<iterators::ExtractValueOp>(i64, initialState, b.getIndexAttr(0));
 
   // Extract input column buffers.
-  auto stateType = initialState.getType().cast<LLVMStructType>();
-  Type structOfInputBuffersType = stateType.getBody()[1];
-  Value structOfInputBuffers =
-      createExtractValueOp(b, structOfInputBuffersType, initialState, {1});
+  auto stateType = initialState.getType().cast<StateType>();
+  Type structOfInputBuffersType = stateType.getFieldTypes()[1];
+  Value structOfInputBuffers = b.create<iterators::ExtractValueOp>(
+      structOfInputBuffersType, initialState, b.getIndexAttr(1));
 
   // Test if we have reached the end of the range.
   Value lastIndex = createExtractValueOp(b, i64, structOfInputBuffers, {0});
@@ -1129,8 +1075,8 @@ buildNextBody(TabularViewToStreamOp op, OpBuilder &builder, Value initialState,
                                                    /*width=*/64);
         ArithBuilder ab(b, b.getLoc());
         Value updatedCurrentIndex = ab.add(currentIndex, one);
-        Value updatedState =
-            createInsertValueOp(b, initialState, updatedCurrentIndex, {0});
+        Value updatedState = b.create<iterators::InsertValueOp>(
+            initialState, b.getIndexAttr(0), updatedCurrentIndex);
 
         // Assemble field values from values at current index of column
         // buffers.
@@ -1184,25 +1130,20 @@ static Value buildCloseBody(TabularViewToStreamOp /*op*/,
 /// buffers and an undefined current index. Possible output:
 ///
 /// %0 = ...
-/// %1 = llvm.mlir.undef :
-///          !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                       (i64, !tabular_view_type)>
-/// %2 = llvm.insertvalue %0, %1[1 : index] :
-///          !llvm.struct<"iterators.tabular_view_to_stream_state",
-///                       (i64, !tabular_view_type)>
+/// %1 = iterators.undefstate : <i64, !tabular_view_type>
+/// %2 = iterators.insertvalue %1[1] (%0 : !tabular_view_type) :
+///          <i64, !tabular_view_type>
 static Value buildStateCreation(TabularViewToStreamOp op,
                                 TabularViewToStreamOp::Adaptor adaptor,
-                                OpBuilder &builder,
-                                LLVM::LLVMStructType stateType) {
+                                OpBuilder &builder, StateType stateType) {
   Location loc = op.getLoc();
   ImplicitLocOpBuilder b(loc, builder);
 
   // Insert input into iterator state.
-  Value iteratorState = b.create<UndefOp>(stateType);
+  Value iteratorState = b.create<UndefStateOp>(stateType);
   Value input = adaptor.input();
-  iteratorState = createInsertValueOp(b, iteratorState, input, {1});
-
-  return iteratorState;
+  return b.create<iterators::InsertValueOp>(iteratorState, b.getIndexAttr(1),
+                                            input);
 }
 
 //===----------------------------------------------------------------------===//
@@ -1309,8 +1250,7 @@ static Value buildCloseBody(Operation *op, OpBuilder &builder,
 
 /// Type-switching proxy for builders of iterator state creation.
 static Value buildStateCreation(IteratorOpInterface op, OpBuilder &builder,
-                                LLVM::LLVMStructType stateType,
-                                ValueRange operands) {
+                                StateType stateType, ValueRange operands) {
   return llvm::TypeSwitch<Operation *, Value>(op)
       .Case<
           // clang-format off
@@ -1409,7 +1349,7 @@ static Value convert(IteratorOpInterface op, ValueRange operands,
   buildCloseFuncInParentModule(op, builder, opInfo, upstreamInfos);
 
   // Create initial state.
-  LLVMStructType stateType = opInfo.stateType;
+  StateType stateType = opInfo.stateType;
   return buildStateCreation(op, builder, stateType, operands);
 }
 
@@ -1425,11 +1365,11 @@ static Value convert(IteratorOpInterface op, ValueRange operands,
 /// Possible result:
 ///
 /// %2 = ... // initialize state of input iterator
-/// %3 = call @iterators.reduce.open.1(%2) :
+/// %3 = call @iterators.upstream.open.1(%2) :
 ///          (!input_state_type) -> !input_state_type
 /// %4:3 = scf.while (%arg0 = %3) :
 ///            (!input_state_type) -> (!input_state_type, i1, !element_type) {
-///   %6:3 = call @iterators.reduce.next.1(%arg0) :
+///   %6:3 = call @iterators.upstream.next.1(%arg0) :
 ///              (!input_state_type) -> (!input_state_type, i1, !element_type)
 ///   scf.condition(%6#1) %6#0, %6#1, %6#2 :
 ///       !input_state_type, i1, !element_type
@@ -1438,7 +1378,7 @@ static Value convert(IteratorOpInterface op, ValueRange operands,
 ///   "iterators.print"(%arg1) : (!element_type) -> ()
 ///   scf.yield %arg0 : !input_state_type
 /// }
-/// %5 = call @iterators.reduce.close.1(%4#0) :
+/// %5 = call @iterators.upstream.close.1(%4#0) :
 ///          (!input_state_type) -> !input_state_type
 static SmallVector<Value> convert(SinkOp op, SinkOpAdaptor adaptor,
                                   ArrayRef<IteratorInfo> upstreamInfos,
@@ -1702,7 +1642,8 @@ void ConvertIteratorsToLLVMPass::runOnOperation() {
   ConversionTarget target(getContext());
   target.addLegalDialect<arith::ArithmeticDialect, LLVMDialect,
                          scf::SCFDialect>();
-  target.addLegalOp<ModuleOp>();
+  target.addLegalOp<ModuleOp, UndefStateOp, iterators::ExtractValueOp,
+                    iterators::InsertValueOp>();
   RewritePatternSet patterns(&getContext());
 
   populateIteratorsToLLVMConversionPatterns(patterns, typeConverter);

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
@@ -3,8 +3,8 @@
 
 !element_type = !llvm.struct<(i32)>
 
-// CHECK-LABEL: func private @iterators.constantstream.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.constant_stream_state{{.*}}", (i32)>) -> !llvm.struct<"iterators.constant_stream_state{{.*}}", (i32)>
-// CHECK-NEXT:    return %[[arg0:.*]] : !llvm.struct<"[[inputStateType:iterators\.constant_stream_state.*]]", (i32)>
+// CHECK-LABEL: func private @iterators.constantstream.close.{{[0-9]+}}(%{{.*}}: !iterators.state<i32>) -> !iterators.state<i32>
+// CHECK-NEXT:    return %[[arg0:.*]] : !iterators.state<i32>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL:  llvm.mlir.global internal constant @iterators.constant_stream_data{{.*}}() : !llvm.array<4 x struct<(i32)>> {
@@ -28,30 +28,30 @@
 // CHECK-NEXT:     llvm.return %[[V16]] : !llvm.array<4 x struct<(i32)>>
 // CHECK-NEXT:   }
 
-// CHECK-LABEL: func private @iterators.constantstream.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.constant_stream_state{{.*}}", (i32)>) -> (!llvm.struct<"iterators.constant_stream_state{{.*}}", (i32)>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[inputStateType:iterators\.constant_stream_state.*]]", (i32)>
+// CHECK-LABEL: func private @iterators.constantstream.next.{{[0-9]+}}(%{{.*}}: !iterators.state<i32>) -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <i32> -> i32
 // CHECK-NEXT:    %[[V1:.*]] = arith.constant 4 : i32
 // CHECK-NEXT:    %[[V2:.*]] = arith.cmpi slt, %[[V0]], %[[V1]] : i32
-// CHECK-NEXT:    %[[V3:.*]]:2 = scf.if %[[V2]] -> (!llvm.struct<"[[inputStateType]]", (i32)>, !llvm.struct<(i32)>) {
+// CHECK-NEXT:    %[[V3:.*]]:2 = scf.if %[[V2]] -> (!iterators.state<i32>, !llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[V4:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[V5:.*]] = arith.addi %[[V0]], %[[V4]] : i32
-// CHECK-NEXT:      %[[V6:.*]] = llvm.insertvalue %[[V5]], %[[arg0]][0 : index] : !llvm.struct<"[[inputStateType]]", (i32)>
+// CHECK-NEXT:      %[[V6:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V5]] : i32) : <i32>
 // CHECK-NEXT:      %[[V7:.*]] = llvm.mlir.addressof @iterators.constant_stream_data{{.*}} : !llvm.ptr<array<4 x struct<(i32)>>>
 // CHECK-NEXT:      %[[V8:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[V9:.*]] = llvm.getelementptr %[[V7]][%[[V8]], %[[V0]]] : (!llvm.ptr<array<4 x struct<(i32)>>>, i32, i32) -> !llvm.ptr<struct<(i32)>>
 // CHECK-NEXT:      %[[Va:.*]] = llvm.load %[[V9]] : !llvm.ptr<struct<(i32)>>
-// CHECK-NEXT:      scf.yield %[[V6]], %[[Va]] : !llvm.struct<"[[inputStateType]]", (i32)>, !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[V6]], %[[Va]] : !iterators.state<i32>, !llvm.struct<(i32)>
 // CHECK-NEXT:    } else {
 // CHECK-NEXT:      %[[Vb:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
-// CHECK-NEXT:      scf.yield %[[arg0]], %[[Vb]] : !llvm.struct<"[[inputStateType]]", (i32)>, !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[arg0]], %[[Vb]] : !iterators.state<i32>, !llvm.struct<(i32)>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    return %[[V3]]#0, %[[V2]], %[[V3]]#1 : !llvm.struct<"[[inputStateType]]", (i32)>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:    return %[[V3]]#0, %[[V2]], %[[V3]]#1 : !iterators.state<i32>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func private @iterators.constantstream.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.constant_stream_state{{.*}}", (i32)>) -> !llvm.struct<"iterators.constant_stream_state{{.*}}", (i32)>
+// CHECK-LABEL: func private @iterators.constantstream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i32>) -> !iterators.state<i32>
 // CHECK-NEXT:    %[[V0:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:    %[[V1:.*]] = llvm.insertvalue %[[V0]], %[[arg0:.*]][0 : index] : !llvm.struct<"[[inputStateType:iterators\.constant_stream_state.*]]", (i32)>
-// CHECK-NEXT:    return %[[V1]] : !llvm.struct<"[[inputStateType]]", (i32)>
+// CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[arg0:.*]][0] (%[[V0]] : i32) : <i32>
+// CHECK-NEXT:    return %[[V1]] : !iterators.state<i32>
 // CHECK-NEXT:  }
 
 func.func @main() {
@@ -59,7 +59,7 @@ func.func @main() {
   %input = "iterators.constantstream"()
       { value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]] }
       : () -> (!iterators.stream<!element_type>)
-  // CHECK-NEXT:   %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<"[[inputStateType:iterators\.constant_stream_state.*]]", (i32)>
+  // CHECK-NEXT:   %[[V0:.*]] = iterators.undefstate : <i32>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
@@ -29,13 +29,13 @@
 // CHECK-NEXT:   }
 
 // CHECK-LABEL: func private @iterators.constantstream.next.{{[0-9]+}}(%{{.*}}: !iterators.state<i32>) -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <i32> -> i32
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<i32>
 // CHECK-NEXT:    %[[V1:.*]] = arith.constant 4 : i32
 // CHECK-NEXT:    %[[V2:.*]] = arith.cmpi slt, %[[V0]], %[[V1]] : i32
 // CHECK-NEXT:    %[[V3:.*]]:2 = scf.if %[[V2]] -> (!iterators.state<i32>, !llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[V4:.*]] = arith.constant 1 : i32
 // CHECK-NEXT:      %[[V5:.*]] = arith.addi %[[V0]], %[[V4]] : i32
-// CHECK-NEXT:      %[[V6:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V5]] : i32) : <i32>
+// CHECK-NEXT:      %[[V6:.*]] = iterators.insertvalue %[[V5]] into %[[arg0]][0] : !iterators.state<i32>
 // CHECK-NEXT:      %[[V7:.*]] = llvm.mlir.addressof @iterators.constant_stream_data{{.*}} : !llvm.ptr<array<4 x struct<(i32)>>>
 // CHECK-NEXT:      %[[V8:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:      %[[V9:.*]] = llvm.getelementptr %[[V7]][%[[V8]], %[[V0]]] : (!llvm.ptr<array<4 x struct<(i32)>>>, i32, i32) -> !llvm.ptr<struct<(i32)>>
@@ -50,7 +50,7 @@
 
 // CHECK-LABEL: func private @iterators.constantstream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i32>) -> !iterators.state<i32>
 // CHECK-NEXT:    %[[V0:.*]] = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[arg0:.*]][0] (%[[V0]] : i32) : <i32>
+// CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[V0]] into %[[arg0:.*]][0] : !iterators.state<i32>
 // CHECK-NEXT:    return %[[V1]] : !iterators.state<i32>
 // CHECK-NEXT:  }
 
@@ -59,7 +59,7 @@ func.func @main() {
   %input = "iterators.constantstream"()
       { value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]] }
       : () -> (!iterators.stream<!element_type>)
-  // CHECK-NEXT:   %[[V0:.*]] = iterators.undefstate : <i32>
+  // CHECK-NEXT:   %[[V0:.*]] = iterators.undefstate : !iterators.state<i32>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
@@ -4,14 +4,14 @@
 !element_type = !llvm.struct<(i32)>
 
 // CHECK-LABEL: func.func private @iterators.filter.close.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>> {
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func.func private @iterators.filter.next.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> (!iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]]:3 = scf.while (%[[arg1:.*]] = %[[V0]]) : ([[upstreamStateType:.*]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[V3:.*]]:3 = func.call @iterators.{{[a-zA-Z]+}}.next.0(%[[arg1]]) : ([[upstreamStateType]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>)
 // CHECK-NEXT:      %[[V4:.*]] = scf.if %[[V3]]#1 -> (i1) {
@@ -28,14 +28,14 @@
 // CHECK-NEXT:    ^bb0(%[[arg2:.*]]: [[upstreamStateType]], %arg2: i1, %arg3: !llvm.struct<(i32)>):
 // CHECK-NEXT:      scf.yield %[[arg2]] : [[upstreamStateType]]
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]]#0 : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]]#0 into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V2]], %[[V1]]#1, %[[V1]]#2 : !iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func.func private @iterators.filter.open.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>>
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
@@ -57,8 +57,8 @@ func.func @main() {
   %input = "iterators.constantstream"() { value = [] } : () -> (!iterators.stream<!element_type>)
   %filter = "iterators.filter"(%input) {predicateRef = @is_positive_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  // CHECK:        %[[V1:.*]] = iterators.undefstate : <!iterators.state<i32>>
-  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V1]][0] (%[[V0:.*]] : !iterators.state<i32>) : <!iterators.state<i32>>
+  // CHECK:        %[[V1:.*]] = iterators.undefstate : !iterators.state<!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V0:.*]] into %[[V1]][0] : !iterators.state<!iterators.state<i32>>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
@@ -3,15 +3,15 @@
 
 !element_type = !llvm.struct<(i32)>
 
-// CHECK-LABEL: func.func private @iterators.filter.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})> {
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-LABEL: func.func private @iterators.filter.close.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>> {
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
-// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func.func private @iterators.filter.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>) -> (!llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-LABEL: func.func private @iterators.filter.next.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> (!iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
 // CHECK-NEXT:    %[[V1:.*]]:3 = scf.while (%[[arg1:.*]] = %[[V0]]) : ([[upstreamStateType:.*]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[V3:.*]]:3 = func.call @iterators.{{[a-zA-Z]+}}.next.0(%[[arg1]]) : ([[upstreamStateType]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>)
 // CHECK-NEXT:      %[[V4:.*]] = scf.if %[[V3]]#1 -> (i1) {
@@ -28,15 +28,15 @@
 // CHECK-NEXT:    ^bb0(%[[arg2:.*]]: [[upstreamStateType]], %arg2: i1, %arg3: !llvm.struct<(i32)>):
 // CHECK-NEXT:      scf.yield %[[arg2]] : [[upstreamStateType]]
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]]#0, %arg0[0 : index] : !llvm.struct<"iterators.filter_state", (struct<"iterators.constant_stream_state", (i32)>)>
-// CHECK-NEXT:    return %[[V2]], %[[V1]]#1, %[[V1]]#2 : !llvm.struct<"iterators.filter_state", (struct<"iterators.constant_stream_state", (i32)>)>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]]#0 : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V2]], %[[V1]]#1, %[[V1]]#2 : !iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func.func private @iterators.filter.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.filter_state{{.*}}", ({{.*}})>
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
+// CHECK-LABEL: func.func private @iterators.filter.open.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
-// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
 func.func private @is_positive_struct(%struct : !element_type) -> i1 {
@@ -57,8 +57,8 @@ func.func @main() {
   %input = "iterators.constantstream"() { value = [] } : () -> (!iterators.stream<!element_type>)
   %filter = "iterators.filter"(%input) {predicateRef = @is_positive_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  // CHECK:        %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[filterStateName:iterators\.filter_state.*]]", ([[nestedUpstreamStateType:.*]])>
-  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0:.*]], %[[V1]][0 : index] : !llvm.struct<"[[filterStateName]]", ([[nestedUpstreamStateType]])>
+  // CHECK:        %[[V1:.*]] = iterators.undefstate : <!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V1]][0] (%[[V0:.*]] : !iterators.state<i32>) : <!iterators.state<i32>>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
@@ -4,14 +4,14 @@
 !element_type = !llvm.struct<(i32)>
 
 // CHECK-LABEL: func.func private @iterators.map.close.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>> {
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func.func private @iterators.map.next.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> (!iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]]:3 = call @iterators.{{[a-zA-Z]+}}.next.0(%[[V0]]) : (!iterators.state<i32>) -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>)
 // CHECK-NEXT:    %[[V2:.*]] = scf.if %[[V1]]#1 -> (!llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[V4:.*]] = func.call @double_struct(%[[V1]]#2) : (!llvm.struct<(i32)>) -> !llvm.struct<(i32)>
@@ -20,14 +20,14 @@
 // CHECK-NEXT:      %[[V4]] = llvm.mlir.undef : !llvm.struct<(i32)>
 // CHECK-NEXT:      scf.yield %[[V4]] : !llvm.struct<(i32)>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[V3:.*]] = iterators.insertvalue %arg0[0] (%[[V1]]#0 : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V3:.*]] = iterators.insertvalue %[[V1]]#0 into %arg0[0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V3]], %[[V1]]#1, %[[V2]] : !iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func.func private @iterators.map.open.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>>
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
@@ -52,7 +52,7 @@ func.func @main() {
   %reduce = "iterators.map"(%input) {mapFuncRef = @double_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
   "iterators.sink"(%reduce) : (!iterators.stream<!element_type>) -> ()
-  // CHECK:        %[[V1:.*]] = iterators.undefstate : <!iterators.state<i32>>
-  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V1]][0] (%[[V0:.*]] : !iterators.state<i32>) : <!iterators.state<i32>>
+  // CHECK:        %[[V1:.*]] = iterators.undefstate : !iterators.state<!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V0:.*]] into %[[V1]][0] : !iterators.state<!iterators.state<i32>>
   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
@@ -3,16 +3,16 @@
 
 !element_type = !llvm.struct<(i32)>
 
-// CHECK-LABEL: func.func private @iterators.map.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})> {
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[mapStateName:iterators\.map_state.*]]", ([[nestedUpstreamStateType:.*]])>
-// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
-// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-LABEL: func.func private @iterators.map.close.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>> {
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func.func private @iterators.map.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>) -> (!llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"iterators.map_state", (struct<"iterators.constant_stream_state", (i32)>)>
-// CHECK-NEXT:    %[[V1:.*]]:3 = call @iterators.constantstream.next.0(%[[V0]]) : (!llvm.struct<"iterators.constant_stream_state", (i32)>) -> (!llvm.struct<"iterators.constant_stream_state", (i32)>, i1, !llvm.struct<(i32)>)
+// CHECK-LABEL: func.func private @iterators.map.next.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> (!iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V1:.*]]:3 = call @iterators.{{[a-zA-Z]+}}.next.0(%[[V0]]) : (!iterators.state<i32>) -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>)
 // CHECK-NEXT:    %[[V2:.*]] = scf.if %[[V1]]#1 -> (!llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[V4:.*]] = func.call @double_struct(%[[V1]]#2) : (!llvm.struct<(i32)>) -> !llvm.struct<(i32)>
 // CHECK-NEXT:      scf.yield %[[V4]] : !llvm.struct<(i32)>
@@ -20,15 +20,15 @@
 // CHECK-NEXT:      %[[V4]] = llvm.mlir.undef : !llvm.struct<(i32)>
 // CHECK-NEXT:      scf.yield %[[V4]] : !llvm.struct<(i32)>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[V3:.*]] = llvm.insertvalue %[[V1]]#0, %arg0[0 : index] : !llvm.struct<"iterators.map_state", (struct<"iterators.constant_stream_state", (i32)>)>
-// CHECK-NEXT:    return %[[V3]], %[[V1]]#1, %[[V2]] : !llvm.struct<"iterators.map_state", (struct<"iterators.constant_stream_state", (i32)>)>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:    %[[V3:.*]] = iterators.insertvalue %arg0[0] (%[[V1]]#0 : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V3]], %[[V1]]#1, %[[V2]] : !iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func.func private @iterators.map.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.map_state{{.*}}", ({{.*}})>
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[mapStateName:iterators\.map_state.*]]", ([[nestedUpstreamStateType:.*]])>
-// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
-// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-LABEL: func.func private @iterators.map.open.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
 func.func private @double_struct(%struct : !element_type) -> !element_type {
@@ -52,7 +52,7 @@ func.func @main() {
   %reduce = "iterators.map"(%input) {mapFuncRef = @double_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
   "iterators.sink"(%reduce) : (!iterators.stream<!element_type>) -> ()
-  // CHECK:        %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[mapStateName:iterators\.map_state.*]]", ([[nestedUpstreamStateType:.*]])>
-  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0:.*]], %[[V1]][0 : index] : !llvm.struct<"[[mapStateName]]", ([[nestedUpstreamStateType]])>
+  // CHECK:        %[[V1:.*]] = iterators.undefstate : <!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V1]][0] (%[[V0:.*]] : !iterators.state<i32>) : <!iterators.state<i32>>
   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/reduce.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/reduce.mlir
@@ -4,14 +4,14 @@
 !element_type = !llvm.struct<(i32)>
 
 // CHECK-LABEL: func private @iterators.reduce.close.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>> {
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func private @iterators.reduce.next.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> (!iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]]:3 = call @iterators.{{[a-zA-Z]+}}.next.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>)
 // CHECK-NEXT:    %[[V2:.*]]:3 = scf.if %[[V1]]#1 -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[V4:.*]]:3 = scf.while (%[[arg1:.*]] = %[[V1]]#0, %[[arg2:.*]] = %[[V1]]#2) : (!iterators.state<i32>, !llvm.struct<(i32)>) -> (!iterators.state<i32>, !llvm.struct<(i32)>, !llvm.struct<(i32)>) {
@@ -27,14 +27,14 @@
 // CHECK-NEXT:    } else {
 // CHECK-NEXT:      scf.yield %[[V1]]#0, %[[V1]]#1, %[[V1]]#2 : !iterators.state<i32>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[V3:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V2]]#0 : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V3:.*]] = iterators.insertvalue %[[V2]]#0 into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V3]], %[[V2]]#1, %[[V2]]#2 : !iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func private @iterators.reduce.open.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>>
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[arg0]][0] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
@@ -58,8 +58,8 @@ func.func @main() {
   %input = "iterators.constantstream"() { value = [] } : () -> (!iterators.stream<!element_type>)
   %reduce = "iterators.reduce"(%input) {reduceFuncRef = @sum_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  // CHECK:        %[[V1:.*]] = iterators.undefstate : <!iterators.state<i32>>
-  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V1]][0] (%[[V0:.*]] : !iterators.state<i32>) : <!iterators.state<i32>>
+  // CHECK:        %[[V1:.*]] = iterators.undefstate : !iterators.state<!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V0:.*]] into %[[V1]][0] : !iterators.state<!iterators.state<i32>>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/reduce.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/reduce.mlir
@@ -3,39 +3,39 @@
 
 !element_type = !llvm.struct<(i32)>
 
-// CHECK-LABEL: func private @iterators.reduce.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.reduce_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.reduce_state{{.*}}", ({{.*}})> {
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[reduceStateName:iterators\.reduce_state.*]]", ([[nestedUpstreamStateType:.*]])>
-// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[reduceStateName]]", ([[nestedUpstreamStateType]])>
-// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[reduceStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-LABEL: func private @iterators.reduce.close.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>> {
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.close.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func private @iterators.reduce.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.reduce_state{{.*}}", ({{.*}})>) -> (!llvm.struct<"iterators.reduce_state{{.*}}", ({{.*}})>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[reduceStateName:iterators\.reduce_state.*]]", ([[nestedUpstreamStateType:.*]])>
-// CHECK-NEXT:    %[[V1:.*]]:3 = call @iterators.{{[a-zA-Z]+}}.next.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V2:.*]]:3 = scf.if %[[V1]]#1 -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>) {
-// CHECK-NEXT:      %[[V4:.*]]:3 = scf.while (%[[arg1:.*]] = %[[V1]]#0, %[[arg2:.*]] = %[[V1]]#2) : ([[upstreamStateType]], !llvm.struct<(i32)>) -> ([[upstreamStateType]], !llvm.struct<(i32)>, !llvm.struct<(i32)>) {
-// CHECK-NEXT:        %[[V5:.*]]:3 = func.call @iterators.{{[a-zA-Z]+}}.next.{{[0-9]+}}(%[[arg1]]) : ([[upstreamStateType]]) -> ([[upstreamStateType]], i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:        scf.condition(%[[V5]]#1) %[[V5]]#0, %[[arg2]], %[[V5]]#2 : [[upstreamStateType]], !llvm.struct<(i32)>, !llvm.struct<(i32)>
+// CHECK-LABEL: func private @iterators.reduce.next.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> (!iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V1:.*]]:3 = call @iterators.{{[a-zA-Z]+}}.next.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V2:.*]]:3 = scf.if %[[V1]]#1 -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>) {
+// CHECK-NEXT:      %[[V4:.*]]:3 = scf.while (%[[arg1:.*]] = %[[V1]]#0, %[[arg2:.*]] = %[[V1]]#2) : (!iterators.state<i32>, !llvm.struct<(i32)>) -> (!iterators.state<i32>, !llvm.struct<(i32)>, !llvm.struct<(i32)>) {
+// CHECK-NEXT:        %[[V5:.*]]:3 = func.call @iterators.{{[a-zA-Z]+}}.next.{{[0-9]+}}(%[[arg1]]) : (!iterators.state<i32>) -> (!iterators.state<i32>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:        scf.condition(%[[V5]]#1) %[[V5]]#0, %[[arg2]], %[[V5]]#2 : !iterators.state<i32>, !llvm.struct<(i32)>, !llvm.struct<(i32)>
 // CHECK-NEXT:      } do {
-// CHECK-NEXT:      ^[[bb0:.*]](%[[arg1:.*]]: [[upstreamStateType]], %[[arg2:.*]]: !llvm.struct<(i32)>, %[[arg3:.*]]: !llvm.struct<(i32)>):
+// CHECK-NEXT:      ^[[bb0:.*]](%[[arg1:.*]]: !iterators.state<i32>, %[[arg2:.*]]: !llvm.struct<(i32)>, %[[arg3:.*]]: !llvm.struct<(i32)>):
 // CHECK-NEXT:        %[[V5:.*]] = func.call @sum_struct(%[[arg2]], %[[arg3]]) : (!llvm.struct<(i32)>, !llvm.struct<(i32)>) -> !llvm.struct<(i32)>
-// CHECK-NEXT:        scf.yield %[[arg1]], %[[V5]] : [[upstreamStateType]], !llvm.struct<(i32)>
+// CHECK-NEXT:        scf.yield %[[arg1]], %[[V5]] : !iterators.state<i32>, !llvm.struct<(i32)>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[true:.*]] = arith.constant true
-// CHECK-NEXT:      scf.yield %[[V4]]#0, %[[true]], %[[V4]]#1 : [[upstreamStateType]], i1, !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[V4]]#0, %[[true]], %[[V4]]#1 : !iterators.state<i32>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:    } else {
-// CHECK-NEXT:      scf.yield %[[V1]]#0, %[[V1]]#1, %[[V1]]#2 : [[upstreamStateType]], i1, !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[V1]]#0, %[[V1]]#1, %[[V1]]#2 : !iterators.state<i32>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    %[[V3:.*]] = llvm.insertvalue %[[V2]]#0, %[[arg0]][0 : index] : !llvm.struct<"[[reduceStateName]]", ([[nestedUpstreamStateType]])>
-// CHECK-NEXT:    return %[[V3]], %[[V2]]#1, %[[V2]]#2 : !llvm.struct<"[[reduceStateName]]", ([[nestedUpstreamStateType]])>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:    %[[V3:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V2]]#0 : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V3]], %[[V2]]#1, %[[V2]]#2 : !iterators.state<!iterators.state<i32>>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func private @iterators.reduce.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.reduce_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.reduce_state{{.*}}", ({{.*}})>
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[reduceStateName:iterators\.reduce_state.*]]", ([[nestedUpstreamStateType:.*]])>
-// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : ([[upstreamStateType:.*]]) -> [[upstreamStateType]]
-// CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[arg0]][0 : index] : !llvm.struct<"[[reduceStateName]]", ([[nestedUpstreamStateType]])>
-// CHECK-NEXT:    return %[[V2]] : !llvm.struct<"[[reduceStateName]]", ([[nestedUpstreamStateType]])>
+// CHECK-LABEL: func private @iterators.reduce.open.{{[0-9]+}}(%{{.*}}: !iterators.state<!iterators.state<i32>>) -> !iterators.state<!iterators.state<i32>>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <!iterators.state<i32>> -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V1:.*]] = call @iterators.{{[a-zA-Z]+}}.open.{{[0-9]+}}(%[[V0]]) : (!iterators.state<i32>) -> !iterators.state<i32>
+// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V1]] : !iterators.state<i32>) : <!iterators.state<i32>>
+// CHECK-NEXT:    return %[[V2]] : !iterators.state<!iterators.state<i32>>
 // CHECK-NEXT:  }
 
 func.func private @sum_struct(%lhs : !element_type, %rhs : !element_type) -> !element_type {
@@ -58,8 +58,8 @@ func.func @main() {
   %input = "iterators.constantstream"() { value = [] } : () -> (!iterators.stream<!element_type>)
   %reduce = "iterators.reduce"(%input) {reduceFuncRef = @sum_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  // CHECK:        %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[reduceStateName:iterators\.reduce_state.*]]", ([[nestedUpstreamStateType:.*]])>
-  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0:.*]], %[[V1]][0 : index] : !llvm.struct<"[[reduceStateName]]", ([[nestedUpstreamStateType]])>
+  // CHECK:        %[[V1:.*]] = iterators.undefstate : <!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V1]][0] (%[[V0:.*]] : !iterators.state<i32>) : <!iterators.state<i32>>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
@@ -2,44 +2,44 @@
 // RUN:   -convert-iterators-to-llvm -reconcile-unrealized-casts \
 // RUN: | FileCheck --enable-var-scope %s
 
-// CHECK-LABEL: func private @iterators.tabular_view_to_stream.close.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})> {
-// CHECK-NEXT:    return %[[arg0:.*]] : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-LABEL: func private @iterators.tabular_view_to_stream.close.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>) -> !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>> {
+// CHECK-NEXT:    return %[[arg0:.*]] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func private @iterators.tabular_view_to_stream.next.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>) -> (!llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = llvm.extractvalue %[[arg0:.*]][0 : index] : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
-// CHECK-NEXT:    %[[V1:.*]] = llvm.extractvalue %[[arg0]][1 : index] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-LABEL: func private @iterators.tabular_view_to_stream.next.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>) -> (!iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>, i1, !llvm.struct<(i32)>)
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <i64, !llvm.struct<(i64, ptr<i32>)>> -> i64
+// CHECK-NEXT:    %[[V1:.*]] = iterators.extractvalue %[[arg0]][1] : <i64, !llvm.struct<(i64, ptr<i32>)>> -> !llvm.struct<(i64, ptr<i32>)>
 // CHECK-NEXT:    %[[V2:.*]] = llvm.extractvalue %[[V1]][0 : index] : !llvm.struct<(i64, ptr<i32>)>
 // CHECK-NEXT:    %[[V3:.*]] = arith.cmpi slt, %[[V0]], %[[V2]] : i64
-// CHECK-NEXT:    %[[V4:.*]]:2 = scf.if %[[V3]] -> (!llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, !llvm.struct<(i32)>) {
+// CHECK-NEXT:    %[[V4:.*]]:2 = scf.if %[[V3]] -> (!iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>, !llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[V5:.*]] = arith.addi %[[V0]], %[[C1]] : i64
-// CHECK-NEXT:      %[[V6:.*]] = llvm.insertvalue %[[V5]], %[[arg0]][0 : index] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:      %[[V6:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V5]] : i64) : <i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:      %[[V7:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
 // CHECK-NEXT:      %[[V8:.*]] = llvm.extractvalue %[[V1]][1 : index] : !llvm.struct<(i64, ptr<i32>)>
 // CHECK-NEXT:      %[[V9:.*]] = llvm.getelementptr %[[V8]][%[[V0]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
 // CHECK-NEXT:      %[[Va:.*]] = llvm.load %[[V9]] : !llvm.ptr<i32>
 // CHECK-NEXT:      %[[Vb:.*]] = llvm.insertvalue %[[Va]], %[[V7]][0 : index] : !llvm.struct<(i32)>
-// CHECK-NEXT:      scf.yield %[[V6]], %[[Vb]] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[V6]], %[[Vb]] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>, !llvm.struct<(i32)>
 // CHECK-NEXT:    } else {
 // CHECK-NEXT:      %[[V5:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
-// CHECK-NEXT:      scf.yield %[[arg0]], %[[V5]] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, !llvm.struct<(i32)>
+// CHECK-NEXT:      scf.yield %[[arg0]], %[[V5]] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>, !llvm.struct<(i32)>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    return %[[V4]]#0, %[[V3]], %[[V4]]#1 : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:    return %[[V4]]#0, %[[V3]], %[[V4]]#1 : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>, i1, !llvm.struct<(i32)>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func private @iterators.tabular_view_to_stream.open.{{[0-9]+}}(%{{.*}}: !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>) -> !llvm.struct<"iterators.tabular_view_to_stream_state{{.*}}", ({{.*}})>
+// CHECK-LABEL: func private @iterators.tabular_view_to_stream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>) -> !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:    %[[V0:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:    %[[V1:.*]] = llvm.insertvalue %[[V0]], %[[arg0:.*]][0 : index] : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
-// CHECK-NEXT:    return %[[V1]] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+// CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[arg0:.*]][0] (%[[V0]] : i64) : <i64, !llvm.struct<(i64, ptr<i32>)>>
+// CHECK-NEXT:    return %[[V1]] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:  }
 
 func.func @main(%input : !tabular.tabular_view<i32>) {
   // CHECK-LABEL: func.func @main(%{{arg.*}}: !llvm.struct<(i64, ptr<i32>)>) {
   %stream = iterators.tabular_view_to_stream %input
                 to !iterators.stream<!llvm.struct<(i32)>>
-  // CHECK-NEXT:    %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"[[tabularViewToStreamStateName:iterators\.tabular_view_to_stream_state.*]]", (i64, struct<(i64, ptr<i32>)>)>
-  // CHECK-NEXT:    %[[V2:.*]] = llvm.insertvalue %[[arg:.*]], %[[V1]][1 : index] : !llvm.struct<"[[tabularViewToStreamStateName]]", (i64, struct<(i64, ptr<i32>)>)>
+  // CHECK-NEXT:    %[[V1:.*]] = iterators.undefstate : <i64, !llvm.struct<(i64, ptr<i32>)>>
+  // CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]][1] (%[[arg:.*]]: !llvm.struct<(i64, ptr<i32>)>) : <i64, !llvm.struct<(i64, ptr<i32>)>>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
@@ -7,14 +7,14 @@
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func private @iterators.tabular_view_to_stream.next.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>) -> (!iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>, i1, !llvm.struct<(i32)>)
-// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : <i64, !llvm.struct<(i64, ptr<i32>)>> -> i64
-// CHECK-NEXT:    %[[V1:.*]] = iterators.extractvalue %[[arg0]][1] : <i64, !llvm.struct<(i64, ptr<i32>)>> -> !llvm.struct<(i64, ptr<i32>)>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
+// CHECK-NEXT:    %[[V1:.*]] = iterators.extractvalue %[[arg0]][1] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:    %[[V2:.*]] = llvm.extractvalue %[[V1]][0 : index] : !llvm.struct<(i64, ptr<i32>)>
 // CHECK-NEXT:    %[[V3:.*]] = arith.cmpi slt, %[[V0]], %[[V2]] : i64
 // CHECK-NEXT:    %[[V4:.*]]:2 = scf.if %[[V3]] -> (!iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>, !llvm.struct<(i32)>) {
 // CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[V5:.*]] = arith.addi %[[V0]], %[[C1]] : i64
-// CHECK-NEXT:      %[[V6:.*]] = iterators.insertvalue %[[arg0]][0] (%[[V5]] : i64) : <i64, !llvm.struct<(i64, ptr<i32>)>>
+// CHECK-NEXT:      %[[V6:.*]] = iterators.insertvalue %[[V5]] into %[[arg0]][0] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:      %[[V7:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
 // CHECK-NEXT:      %[[V8:.*]] = llvm.extractvalue %[[V1]][1 : index] : !llvm.struct<(i64, ptr<i32>)>
 // CHECK-NEXT:      %[[V9:.*]] = llvm.getelementptr %[[V8]][%[[V0]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
@@ -30,7 +30,7 @@
 
 // CHECK-LABEL: func private @iterators.tabular_view_to_stream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>) -> !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:    %[[V0:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[arg0:.*]][0] (%[[V0]] : i64) : <i64, !llvm.struct<(i64, ptr<i32>)>>
+// CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[V0]] into %[[arg0:.*]][0] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:    return %[[V1]] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:  }
 
@@ -38,8 +38,8 @@ func.func @main(%input : !tabular.tabular_view<i32>) {
   // CHECK-LABEL: func.func @main(%{{arg.*}}: !llvm.struct<(i64, ptr<i32>)>) {
   %stream = iterators.tabular_view_to_stream %input
                 to !iterators.stream<!llvm.struct<(i32)>>
-  // CHECK-NEXT:    %[[V1:.*]] = iterators.undefstate : <i64, !llvm.struct<(i64, ptr<i32>)>>
-  // CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V1]][1] (%[[arg:.*]]: !llvm.struct<(i64, ptr<i32>)>) : <i64, !llvm.struct<(i64, ptr<i32>)>>
+  // CHECK-NEXT:    %[[V1:.*]] = iterators.undefstate : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
+  // CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg:.*]] into %[[V1]][1] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/constant-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/constant-stream.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-proto-opt %s \
 // RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-states-to-llvm \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-proto-opt %s \
 // RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-states-to-llvm \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-proto-opt %s \
 // RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-states-to-llvm \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-proto-opt %s \
 // RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-states-to-llvm \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/symbol-collision-resolution.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/symbol-collision-resolution.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-proto-opt %s \
 // RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-states-to-llvm \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
@@ -1,5 +1,7 @@
 // RUN: mlir-proto-opt %s \
-// RUN:   -convert-tabular-to-llvm -convert-iterators-to-llvm \
+// RUN:   -convert-tabular-to-llvm \
+// RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-states-to-llvm \
 // RUN:   -arith-bufferize -cse -convert-memref-to-llvm -reconcile-unrealized-casts \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tpch-q6.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tpch-q6.mlir
@@ -1,5 +1,6 @@
 // RUN: mlir-proto-opt %s \
 // RUN:   -convert-iterators-to-llvm \
+// RUN:   -convert-states-to-llvm \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/python/dialects/iterators/dialect.py
+++ b/experimental/iterators/test/python/dialects/iterators/dialect.py
@@ -97,7 +97,8 @@ def testEndToEndStandalone():
         return
       }
       ''')
-  pm = PassManager.parse('convert-iterators-to-llvm,convert-func-to-llvm,' +
+  pm = PassManager.parse('convert-iterators-to-llvm,convert-states-to-llvm,' +
+                         'convert-func-to-llvm,' +
                          'convert-scf-to-cf,convert-cf-to-llvm')
   pm.run(mod)
   engine = ExecutionEngine(mod)
@@ -120,7 +121,8 @@ def testEndToEndWithInput():
       }
       ''')
   pm = PassManager.parse(
-      'convert-iterators-to-llvm,convert-memref-to-llvm,convert-func-to-llvm,'
+      'convert-iterators-to-llvm,convert-states-to-llvm,'
+      'convert-memref-to-llvm,convert-func-to-llvm,'
       'reconcile-unrealized-casts,convert-scf-to-cf,convert-cf-to-llvm')
   pm.run(mod)
 


### PR DESCRIPTION
This PR depends on and therefore includes #605, #606, and #607.

This PR finalizes the removal of one big dependency on LLVM, namely that for using LLVM structs for the states of iterators. Instead, the new type introduced for that purpose is used.

We may consider renaming the pass, either now, or after we removed the other dependencies to LLVM. (There are still several other dependencies, but they aren't related to iterators *in general* but rather to specific iterator ops such as `TabularViewToStreamOp` returning each row as an LLVM struct instead of a dedicated row type.)