### PR TITLE
Update ccache Github action to v1.2.3.

### DIFF
--- a/.github/workflows/buildAndTestIreeDialects.yml
+++ b/.github/workflows/buildAndTestIreeDialects.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
     - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@ed038da2f2f09b0c8387c00e1498290a4808da2e # v1.2.2
+      uses: hendrikmuhs/ccache-action@621a41397ed83711c72862638d9ff6e63fca3041 # v1.2.3
       with:
         key: ${{ runner.os }}-buildtestasserts
         # LLVM needs serious cache size

--- a/.github/workflows/buildAndTestIterators.yml
+++ b/.github/workflows/buildAndTestIterators.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Install Ninja
       uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
     - name: Ccache for C++ compilation
-      uses: hendrikmuhs/ccache-action@ed038da2f2f09b0c8387c00e1498290a4808da2e # v1.2.2
+      uses: hendrikmuhs/ccache-action@621a41397ed83711c72862638d9ff6e63fca3041 # v1.2.3
       with:
         key: ${{ runner.os }}-buildtestasserts
         # LLVM needs serious cache size


### PR DESCRIPTION
This version updates the dependency @actions/core to the latest version, which, in turn, updates the way state is preserved, which the ccache action depends on. The old way is going to be deprecated, so this updated will eventually be mandatory.