### PR TITLE
Update setup-python Github action to v4.3.0.

### DIFF
--- a/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
+++ b/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
@@ -17,7 +17,7 @@ jobs:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: 3.9
 

--- a/.github/workflows/buildAndTestIreeDialects.yml
+++ b/.github/workflows/buildAndTestIreeDialects.yml
@@ -17,7 +17,7 @@ jobs:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: 3.9
 

--- a/.github/workflows/buildAndTestIterators.yml
+++ b/.github/workflows/buildAndTestIterators.yml
@@ -17,7 +17,7 @@ jobs:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: 3.9
 

--- a/.github/workflows/testSQLDialect.yml
+++ b/.github/workflows/testSQLDialect.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
         python-version: "3.10"
 


### PR DESCRIPTION
Similar to #640, this updates the Github action setup-python to the latest version in order to follow a change in how Github manages CI state.