### PR TITLE
Iterators: Use arith.constant where unrelated to LLVM.

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -157,7 +157,7 @@ struct ConstantTupleLowering : public OpConversionPattern<ConstantTupleOp> {
       // Create constant value op.
       Attribute field = values[i];
       Type fieldType = field.getType();
-      auto valueOp = rewriter.create<LLVM::ConstantOp>(loc, fieldType, field);
+      auto valueOp = rewriter.create<arith::ConstantOp>(loc, fieldType, field);
 
       // Insert into struct.
       structValue =
@@ -268,7 +268,7 @@ static Value buildOpenBody(ConstantStreamOp op, OpBuilder &builder,
   // Insert constant zero into state.
   Type i32 = b.getI32Type();
   Attribute zeroAttr = b.getI32IntegerAttr(0);
-  Value zeroValue = b.create<LLVM::ConstantOp>(i32, zeroAttr);
+  Value zeroValue = b.create<arith::ConstantOp>(i32, zeroAttr);
   Value updatedState = b.create<iterators::InsertValueOp>(
       initialState, b.getIndexAttr(0), zeroValue);
 
@@ -1014,7 +1014,7 @@ static Value buildOpenBody(TabularViewToStreamOp op, OpBuilder &builder,
   // Insert constant zero into state.
   Type i64 = b.getI64Type();
   Attribute zeroAttr = b.getI64IntegerAttr(0);
-  Value zeroValue = b.create<LLVM::ConstantOp>(i64, zeroAttr);
+  Value zeroValue = b.create<arith::ConstantOp>(i64, zeroAttr);
   return b.create<iterators::InsertValueOp>(initialState, b.getIndexAttr(0),
                                             zeroValue);
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
@@ -49,7 +49,7 @@
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func private @iterators.constantstream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i32>) -> !iterators.state<i32>
-// CHECK-NEXT:    %[[V0:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:    %[[V0:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[V0]] into %[[arg0:.*]][0] : !iterators.state<i32>
 // CHECK-NEXT:    return %[[V1]] : !iterators.state<i32>
 // CHECK-NEXT:  }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/printconstant.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/printconstant.mlir
@@ -11,7 +11,7 @@ func.func @main() {
 
   %one_field_tuple = "iterators.constanttuple"() { values = [1 : i32] } : () -> tuple<i32>
   // CHECK-NEXT:     %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S1:.*]]", (i32)>
-  // CHECK-NEXT:     %[[V2:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT:     %[[V2:.*]] = arith.constant 1 : i32
   // CHECK-NEXT:     %[[V3:.*]] = llvm.insertvalue %[[V2]], %[[V1]][0 : index] : !llvm.struct<"tuple[[S1]]", (i32)>
 
   "iterators.printtuple"(%one_field_tuple) : (tuple<i32>) -> ()
@@ -24,11 +24,11 @@ func.func @main() {
 
   %three_field_tuple = "iterators.constanttuple"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
   // CHECK-NEXT:     %[[V4:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S2:.*]]", (i32, i32, i32)>
-  // CHECK-NEXT:     %[[V5:.*]] = llvm.mlir.constant(1 : i32) : i32
+  // CHECK-NEXT:     %[[V5:.*]] = arith.constant 1 : i32
   // CHECK-NEXT:     %[[V6:.*]] = llvm.insertvalue %[[V5]], %[[V4]][0 : index] : !llvm.struct<"tuple[[S2]]", (i32, i32, i32)>
-  // CHECK-NEXT:     %[[V7:.*]] = llvm.mlir.constant(2 : i32) : i32
+  // CHECK-NEXT:     %[[V7:.*]] = arith.constant 2 : i32
   // CHECK-NEXT:     %[[V8:.*]] = llvm.insertvalue %[[V7]], %[[V6]][1 : index] : !llvm.struct<"tuple[[S2]]", (i32, i32, i32)>
-  // CHECK-NEXT:     %[[V9:.*]] = llvm.mlir.constant(3 : i32) : i32
+  // CHECK-NEXT:     %[[V9:.*]] = arith.constant 3 : i32
   // CHECK-NEXT:     %[[Va:.*]] = llvm.insertvalue %[[V9]], %[[V8]][2 : index] : !llvm.struct<"tuple[[S2]]", (i32, i32, i32)>
 
   return

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
@@ -29,7 +29,7 @@
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func private @iterators.tabular_view_to_stream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>) -> !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
-// CHECK-NEXT:    %[[V0:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:    %[[V0:.*]] = arith.constant 0 : i64
 // CHECK-NEXT:    %[[V1:.*]] = iterators.insertvalue %[[V0]] into %[[arg0:.*]][0] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:    return %[[V1]] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
 // CHECK-NEXT:  }


### PR DESCRIPTION
This PR depends on and therefore includes #608 (and, transitively, others). It removes some minor dependencies to the LLVM dialect via `llvm.mlir.constant`, which weren't necessary in any way.