### PR TITLE
Iterators: Add round-trippability tests

### DIFF
--- a/experimental/iterators/test/Dialect/Iterators/constant-stream.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/constant-stream.mlir
@@ -1,14 +1,21 @@
-// Test that we can parse and verify constant streams without errors
-// RUN: mlir-proto-opt %s
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
 
 func.func @main() {
+// CHECK-LABEL: func.func @main() {
   %empty = "iterators.constantstream"() { value = [] } :
                () -> (!iterators.stream<!llvm.struct<(i32)>>)
+// CHECK-NEXT:    %[[V0:.*]] = "iterators.constantstream"() {value = []} : () -> !iterators.stream<!llvm.struct<(i32)>>
   %i32 = "iterators.constantstream"() { value = [[42 : i32]] } :
              () -> (!iterators.stream<!llvm.struct<(i32)>>)
+// CHECK-NEXT:    %[[V1:.*]] = "iterators.constantstream"() {value = {{\[}}[42 : i32]]} : () -> !iterators.stream<!llvm.struct<(i32)>>
   %f32 = "iterators.constantstream"() { value = [[42. : f32]] } :
              () -> (!iterators.stream<!llvm.struct<(f32)>>)
+// CHECK-NEXT:    %[[V2:.*]] = "iterators.constantstream"() {value = {{\[}}[4.200000e+01 : f32]]} : () -> !iterators.stream<!llvm.struct<(f32)>>
   %i32i64 = "iterators.constantstream"() { value = [[42 : i32, 1337 : i64]] } :
                 () -> (!iterators.stream<!llvm.struct<(i32, i64)>>)
+// CHECK-NEXT:    %[[V3:.*]] = "iterators.constantstream"() {value = {{\[}}[42 : i32, 1337]]} : () -> !iterators.stream<!llvm.struct<(i32, i64)>>
   return
+// CHECK-NEXT:    return
 }
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Iterators/constant-stream.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/constant-stream.mlir
@@ -2,13 +2,13 @@
 // RUN: mlir-proto-opt %s
 
 func.func @main() {
-  %empty = "iterators.constantstream"() { value = [] }
-      : () -> (!iterators.stream<!llvm.struct<(i32)>>)
-  %i32 = "iterators.constantstream"() { value = [[42 : i32]] }
-      : () -> (!iterators.stream<!llvm.struct<(i32)>>)
-  %f32 = "iterators.constantstream"() { value = [[42. : f32]] }
-      : () -> (!iterators.stream<!llvm.struct<(f32)>>)
-  %i32i64 = "iterators.constantstream"() { value = [[42 : i32, 1337 : i64]] }
-      : () -> (!iterators.stream<!llvm.struct<(i32, i64)>>)
+  %empty = "iterators.constantstream"() { value = [] } :
+               () -> (!iterators.stream<!llvm.struct<(i32)>>)
+  %i32 = "iterators.constantstream"() { value = [[42 : i32]] } :
+             () -> (!iterators.stream<!llvm.struct<(i32)>>)
+  %f32 = "iterators.constantstream"() { value = [[42. : f32]] } :
+             () -> (!iterators.stream<!llvm.struct<(f32)>>)
+  %i32i64 = "iterators.constantstream"() { value = [[42 : i32, 1337 : i64]] } :
+                () -> (!iterators.stream<!llvm.struct<(i32, i64)>>)
   return
 }

--- a/experimental/iterators/test/Dialect/Iterators/constant.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/constant.mlir
@@ -1,11 +1,17 @@
-// Test that we can parse and verify tuple literals without errors
-// RUN: mlir-proto-opt %s
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
 
 func.func @main() {
+// CHECK-LABEL: func.func @main() {
   %empty_tuple = "iterators.constanttuple"() { values = [] } : () -> tuple<>
+// CHECK-NEXT:    %[[V0:.*]] = "iterators.constanttuple"() {values = []} : () -> tuple<>
   %one_field_tuple = "iterators.constanttuple"()
       { values = [1 : i32] } : () -> tuple<i32>
+// CHECK-NEXT:    %[[V0:.*]] = "iterators.constanttuple"() {values = [1 : i32]} : () -> tuple<i32>
   %three_field_tuple = "iterators.constanttuple"()
       { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
+// CHECK-NEXT:    %[[V0:.*]] = "iterators.constanttuple"() {values = [1 : i32, 2 : i32, 3 : i32]} : () -> tuple<i32, i32, i32>
   return
+// CHECK-NEXT:    return
 }
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Iterators/constant.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/constant.mlir
@@ -3,7 +3,9 @@
 
 func.func @main() {
   %empty_tuple = "iterators.constanttuple"() { values = [] } : () -> tuple<>
-  %one_field_tuple = "iterators.constanttuple"() { values = [1 : i32] } : () -> tuple<i32>
-  %three_field_tuple = "iterators.constanttuple"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
+  %one_field_tuple = "iterators.constanttuple"()
+      { values = [1 : i32] } : () -> tuple<i32>
+  %three_field_tuple = "iterators.constanttuple"()
+      { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
   return
 }

--- a/experimental/iterators/test/Dialect/Iterators/filter.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/filter.mlir
@@ -1,0 +1,25 @@
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+!i32_struct = !llvm.struct<(i32)>
+
+func.func private @is_positive_struct(%struct : !i32_struct) -> i1 {
+  %i = llvm.extractvalue %struct[0 : index] : !i32_struct
+  %zero = arith.constant 0 : i32
+  %cmp = arith.cmpi "sgt", %i, %zero : i32
+  return %cmp : i1
+}
+
+func.func @main() {
+// CHECK-LABEL: func.func @main() {
+  %input = "iterators.constantstream"() { value = [] } :
+               () -> (!iterators.stream<!i32_struct>)
+// CHECK-NEXT:    %[[V0:.*]] = "iterators.constantstream"{{.*}}
+  %filtered = "iterators.filter"(%input) {predicateRef = @is_positive_struct} :
+                  (!iterators.stream<!i32_struct>) ->
+                      (!iterators.stream<!i32_struct>)
+// CHECK-NEXT:    %[[V1:.*]] = "iterators.filter"(%[[V0]]) {predicateRef = @is_positive_struct} : (!iterators.stream<!llvm.struct<(i32)>>) -> !iterators.stream<!llvm.struct<(i32)>>
+  return
+// CHECK-NEXT:    return
+}
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Iterators/map.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/map.mlir
@@ -1,0 +1,22 @@
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+!i32_struct = !llvm.struct<(i32)>
+
+func.func private @unpack_i32(%input : !i32_struct) -> i32 {
+  %i = llvm.extractvalue %input[0 : index] : !i32_struct
+  return %i : i32
+}
+
+func.func @main() {
+// CHECK-LABEL: func.func @main() {
+  %input = "iterators.constantstream"() { value = [] } :
+               () -> (!iterators.stream<!i32_struct>)
+// CHECK-NEXT:    %[[V0:.*]] = "iterators.constantstream"{{.*}}
+  %unpacked = "iterators.map"(%input) {mapFuncRef = @unpack_i32} :
+                  (!iterators.stream<!i32_struct>) -> (!iterators.stream<i32>)
+// CHECK-NEXT:    %[[V1:.*]] = "iterators.map"(%[[V0]]) {mapFuncRef = @unpack_i32} : (!iterators.stream<!llvm.struct<(i32)>>) -> !iterators.stream<i32>
+  return
+// CHECK-NEXT:    return
+}
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Iterators/reduce.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/reduce.mlir
@@ -1,0 +1,26 @@
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+!i32_struct = !llvm.struct<(i32)>
+
+func.func private @sum_struct(%lhs : !i32_struct, %rhs : !i32_struct) -> !i32_struct {
+  %lhsi = llvm.extractvalue %lhs[0 : index] : !i32_struct
+  %rhsi = llvm.extractvalue %rhs[0 : index] : !i32_struct
+  %i = arith.addi %lhsi, %rhsi : i32
+  %result = llvm.insertvalue %i, %lhs[0 : index] : !i32_struct
+  return %result : !i32_struct
+}
+
+func.func @main() {
+// CHECK-LABEL: func.func @main() {
+  %input = "iterators.constantstream"() { value = [] } :
+               () -> (!iterators.stream<!i32_struct>)
+// CHECK-NEXT:    %[[V0:.*]] = "iterators.constantstream"{{.*}}
+  %reduced = "iterators.reduce"(%input) {reduceFuncRef = @sum_struct} :
+                 (!iterators.stream<!i32_struct>) ->
+                     (!iterators.stream<!i32_struct>)
+// CHECK-NEXT:    %[[V1:.*]] = "iterators.reduce"(%[[V0]]) {reduceFuncRef = @sum_struct} : (!iterators.stream<!llvm.struct<(i32)>>) -> !iterators.stream<!llvm.struct<(i32)>>
+  return
+// CHECK-NEXT:    return
+}
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Iterators/state.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/state.mlir
@@ -9,9 +9,11 @@ func.func @testUndefInsertExtract() {
 // CHECK-NEXT:     %[[V0:.*]] = iterators.undefstate : !iterators.state<i32>
   %value = arith.constant 0 : i32
 // CHECK-NEXT:     %[[V1:.*]] = arith.constant 0 : i32
-  %inserted_state = iterators.insertvalue %value into %initial_state[0] : !iterators.state<i32>
+  %inserted_state = iterators.insertvalue %value into
+                        %initial_state[0] : !iterators.state<i32>
 // CHECK-NEXT:     %[[V2:.*]] = iterators.insertvalue %[[V1]] into %[[V0]][0] : !iterators.state<i32>
-  %extracted_value = iterators.extractvalue %inserted_state[0] : !iterators.state<i32>
+  %extracted_value = iterators.extractvalue %inserted_state[0] :
+                         !iterators.state<i32>
 // CHECK-NEXT:     %[[V3:.*]] = iterators.extractvalue %[[V2]][0] : !iterators.state<i32>
   return
 // CHECK-NEXT:     return

--- a/experimental/iterators/test/Dialect/Iterators/state.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/state.mlir
@@ -1,5 +1,3 @@
-// Test that we can parse and verify ops on iterator state correctly, and that
-// they round-trip through assembly.
 // RUN: mlir-proto-opt %s \
 // RUN: | FileCheck %s
 

--- a/experimental/iterators/test/Dialect/Iterators/stream-to-value.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/stream-to-value.mlir
@@ -1,0 +1,15 @@
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+func.func @main() {
+  // CHECK-LABEL: func.func @main() {
+  %value = arith.constant 42 : i32
+  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 42 : i32
+  %stream = iterators.value_to_stream %value : !iterators.stream<i32>
+  // CHECK-NEXT:   %[[V1:.*]] = iterators.value_to_stream %[[V0]] : !iterators.stream<i32>
+  %result:2 = iterators.stream_to_value %stream : !iterators.stream<i32>
+  // CHECK-NEXT:   %[[V2:result.*]], %[[V3:hasResult.*]] = iterators.stream_to_value %[[V1]] : !iterators.stream<i32>
+  return
+// CHECK-NEXT:    return
+}
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Iterators/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/tabular-view-to-stream.mlir
@@ -1,0 +1,12 @@
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+func.func @main(%input : !tabular.tabular_view<i32>) {
+  // CHECK-LABEL: func.func @main(%{{arg.*}}: !tabular.tabular_view<i32>) {
+  %stream = iterators.tabular_view_to_stream %input
+                to !iterators.stream<!llvm.struct<(i32)>>
+// CHECK-NEXT:    %[[V0:.*]] = iterators.tabular_view_to_stream %[[arg0:.*]] to !iterators.stream<!llvm.struct<(i32)>>
+  return
+// CHECK-NEXT:    return
+}
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Iterators/value-to-stream.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/value-to-stream.mlir
@@ -1,0 +1,13 @@
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+func.func @main() {
+  // CHECK-LABEL: func.func @main() {
+  %value = arith.constant 42 : i32
+  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 42 : i32
+  %stream = iterators.value_to_stream %value : !iterators.stream<i32>
+  // CHECK-NEXT:   %[[V1:.*]] = iterators.value_to_stream %[[V0]] : !iterators.stream<i32>
+  return
+// CHECK-NEXT:    return
+}
+// CHECK-NEXT:  }

--- a/experimental/iterators/test/Dialect/Tabular/view-as-tabular.mlir
+++ b/experimental/iterators/test/Dialect/Tabular/view-as-tabular.mlir
@@ -1,0 +1,16 @@
+// RUN: mlir-proto-opt %s \
+// RUN: | FileCheck %s
+
+func.func @main() {
+  // CHECK-LABEL: func.func @main() {
+  %t1 = arith.constant dense<[0, 1, 2]> : tensor<3xi32>
+  // CHECK-NEXT:    %[[V0:.*]] = arith.constant
+  %m1 = bufferization.to_memref %t1 : memref<3xi32>
+  // CHECK-NEXT:    %[[V1:.*]] = bufferization.to_memref
+  %view = tabular.view_as_tabular %m1
+    : (memref<3xi32>) -> !tabular.tabular_view<i32>
+  // CHECK-NEXT:    %[[V2:.*]] = tabular.view_as_tabular %[[V1]] : (memref<3xi32>) -> !tabular.tabular_view<i32>
+  return
+// CHECK-NEXT:    return
+}
+// CHECK-NEXT:  }


### PR DESCRIPTION
This PR extends (and cleans up) the existing Dialect tests to check for round-trippability (instead of just no errors on parsing) and adds new Dialect tests for those ops that didn't have them yet.