### PR TITLE
CI: Update ninja dependency

### DIFF
--- a/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
+++ b/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
@@ -22,12 +22,12 @@ jobs:
         python-version: 3.9
 
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: sandbox
 
     - name: Install Ninja
-      uses: llvm/actions/install-ninja@55d844821959226fab4911f96f37071c1d4c3268
+      uses: lukka/get-cmake@latest
 
     - name: Install doxygen
       run: |


### PR DESCRIPTION
This is something I did for a couple of other repos recently, so let me mention it here as well:

It seems that the llvm action to install Ninja (and also checkout v2) uses deprecated nodes (visibile [here](https://github.com/iree-org/iree-llvm-sandbox/actions/runs/3628671385)). This updates to a properly configured action. Alternatively, one could probably also update the llvm action and close this PR...

I just did it for a single CI workflow, the others would obviously have to be updated as well, if you decide to use this.