### PR TITLE
Iterators: Allow inlining of all ops of the iterators dialect.

### DIFF
--- a/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
+++ b/experimental/iterators/lib/Dialects/Iterators/IR/Iterators.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMTypes.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
@@ -23,6 +24,19 @@ using namespace mlir::iterators;
 
 #include "iterators/Dialect/Iterators/IR/IteratorsOpsDialect.cpp.inc"
 
+namespace {
+/// This class defines the interface for handling inlining for iterators
+/// dialect operations.
+struct IteratorsInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  /// All iterators dialect ops can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
 void IteratorsDialect::initialize() {
 #define GET_OP_LIST
   addOperations<
@@ -32,6 +46,7 @@ void IteratorsDialect::initialize() {
 #define GET_TYPEDEF_LIST
 #include "iterators/Dialect/Iterators/IR/IteratorsOpsTypes.cpp.inc"
       >();
+  addInterfaces<IteratorsInlinerInterface>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/experimental/iterators/test/Dialect/Iterators/inlining.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/inlining.mlir
@@ -1,0 +1,16 @@
+// RUN: iterators-opt %s -inline | FileCheck %s
+
+// CHECK-LABEL: func.func @test_inline() -> i32 {
+// CHECK-NEXT: %[[V0:.*]] = iterators.undefstate : !iterators.state<i32>
+// CHECK-NEXT: %[[RES:.*]] = iterators.extractvalue %[[V0]][0] : !iterators.state<i32>
+// CHECK-NEXT: return %[[RES]] : i32
+func.func @test_inline() -> i32 {
+  %0 = call @inner_func_inlinable() : () -> i32
+  return %0 : i32
+}
+
+func.func @inner_func_inlinable() -> i32 {
+  %0 = iterators.undefstate : !iterators.state<i32>
+  %1 = iterators.extractvalue %0[0] : !iterators.state<i32>
+  return %1 : i32
+}


### PR DESCRIPTION
This PR configures the Iterators dialect such that the MLIR inliner is allowed to inline regions containing ops from this dialect into their call sites. (Note that this needs to happen *in addition to* allowing the callable to be inlined, which may be from a different dialect.)

This is a necessary step for using MLIR's inliner to inline the `open`/`next`/`close` functions into each other, which, in turn, allows to do other passes (such as bufferization) to be done of fused iterators rather than having to work through function boundaries.