### PR TITLE
[CI] Update Github actions for git checkout and ninja.

### DIFF
--- a/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
+++ b/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: 3.9
 
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: sandbox
 

--- a/.github/workflows/buildAndTestIreeDialects.yml
+++ b/.github/workflows/buildAndTestIreeDialects.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: 3.9
 
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: sandbox
         submodules: recursive

--- a/.github/workflows/buildAndTestIterators.yml
+++ b/.github/workflows/buildAndTestIterators.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: 3.9
 
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: sandbox
         submodules: recursive

--- a/.github/workflows/testSQLDialect.yml
+++ b/.github/workflows/testSQLDialect.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: "3.10"
 
     - name: Checkout project
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: sandbox
 


### PR DESCRIPTION
This fixes the following warning that has appeared a few weeks ago during CI:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

Both the official `checkout` action and the [`llvm/install-ninja`](https://github.com/llvm/actions/tree/main/install-ninja) action have had new version coming out doing the requested upgrade for Node, so using the latest version, respectively, makes the warning go away.

This replaces #626.