### PR TITLE
[Iterators] Replace UndefStateOp with CreateStateOp for iterator states.

### DIFF
--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -422,23 +422,28 @@ def Iterators_ValueToStreamOp : Iterators_Op<"value_to_stream",
 // Ops related to Iterator bodies.
 //===----------------------------------------------------------------------===//
 
-def Iterators_UndefStateOp : Iterators_Base_Op<"undefstate",
+def Iterators_CreateStateOp : Iterators_Base_Op<"createstate",
     [Pure,
+     TypesMatchWith<"types of provided values much match the field types of "
+                    "the resulting state", "result", "values",
+                    "$_self.cast<StateType>().getFieldTypes()">,
      DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
-  let summary = "Create an undefined iterator state";
+  let summary = "Create an iterator state out of the given values";
+  let arguments = (ins Variadic<AnyType>:$values);
   let results = (outs Iterators_State:$result);
-  let assemblyFormat = "attr-dict `:` qualified(type($result))";
+  let assemblyFormat = "`(` $values `)` attr-dict `:` qualified(type($result))";
   let description = [{
-    Creates an iterator state of the given type with undefined field values.
-    All fields have to be set individually with `insertvalue` before the whole
-    state is fully defined.
+    Create a new iterator state filled with the given values.
 
-    This is similar to `llvm.undef` for `llvm.struct`.
+    This is similar to `complex.create`.
 
     Example:
 
     ```
-    %undef_state = iterators.undefstate : !iterators.state<i32, tensor<?xi32>>
+    %i32 = ...
+    %tensor = ...
+    %state = iterators.createstate(%i32, %tensor) :
+                 !iterators.state<i32, tensor<?xi32>>
     ```
   }];
   let extraClassDefinition = [{

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -178,7 +178,10 @@ def Iterators_State : Iterators_Type<"State", "state"> {
     Example:
 
     ```
-    %undef_state = iterators.undefstate : !iterators.state<i32, tensor<?xi32>>
+    %i32 = ...
+    %tensor = ...
+    %state = iterators.createstate(%i32, %tensor) :
+                 !iterators.state<i32, tensor<?xi32>>
     ```
   }];
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/constant-stream.mlir
@@ -59,7 +59,8 @@ func.func @main() {
   %input = "iterators.constantstream"()
       { value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]] }
       : () -> (!iterators.stream<!element_type>)
-  // CHECK-NEXT:   %[[V0:.*]] = iterators.undefstate : !iterators.state<i32>
+  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 0 : i32
+  // CHECK-NEXT:   %[[V1:.*]] = iterators.createstate(%[[V0]]) : !iterators.state<i32>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/filter.mlir
@@ -53,14 +53,13 @@ func.func private @is_positive_struct(%struct : !element_type) -> i1 {
 // CHECK-NEXT:  }
 
 func.func @main() {
-  // CHECK-LABEL: func.func @main()
+// CHECK-LABEL:  func.func @main()
   %input = "iterators.constantstream"() { value = [] } : () -> (!iterators.stream<!element_type>)
+  // CHECK:        %[[V0:.*]] = iterators.createstate({{.*}}) : [[upstreamStateType:.*]]
   %filter = "iterators.filter"(%input) {predicateRef = @is_positive_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  // CHECK:        %[[V1:.*]] = iterators.undefstate : !iterators.state<!iterators.state<i32>>
-  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V0:.*]] into %[[V1]][0] : !iterators.state<!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V1:.*]] = iterators.createstate(%[[V0]]) : !iterators.state<[[upstreamStateType]]>
   return
   // CHECK-NEXT:   return
 }
 // CHECK-NEXT:   }
-// CHECK-NEXT: }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/map.mlir
@@ -44,15 +44,16 @@ func.func private @double_struct(%struct : !element_type) -> !element_type {
 }
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func.func @main() {
 func.func @main() {
+// CHECK-LABEL:  func.func @main() {
   %input = "iterators.constantstream"()
       { value = [[0 : i32], [1 : i32], [2 : i32], [3 : i32]] }
       : () -> (!iterators.stream<!element_type>)
+  // CHECK:        %[[V0:.*]] = iterators.createstate({{.*}}) : [[upstreamStateType:.*]]
   %reduce = "iterators.map"(%input) {mapFuncRef = @double_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  "iterators.sink"(%reduce) : (!iterators.stream<!element_type>) -> ()
-  // CHECK:        %[[V1:.*]] = iterators.undefstate : !iterators.state<!iterators.state<i32>>
-  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V0:.*]] into %[[V1]][0] : !iterators.state<!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V1:.*]] = iterators.createstate(%[[V0]]) : !iterators.state<[[upstreamStateType]]>
   return
+  // CHECK-NEXT:   return
 }
+// CHECK-NEXT:   }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/reduce.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/reduce.mlir
@@ -54,14 +54,13 @@ func.func private @sum_struct(%lhs : !element_type, %rhs : !element_type) -> !el
 // CHECK-NEXT:  }
 
 func.func @main() {
-  // CHECK-LABEL: func.func @main()
+// CHECK-LABEL:  func.func @main()
   %input = "iterators.constantstream"() { value = [] } : () -> (!iterators.stream<!element_type>)
+  // CHECK:        %[[V0:.*]] = iterators.createstate({{.*}}) : [[upstreamStateType:.*]]
   %reduce = "iterators.reduce"(%input) {reduceFuncRef = @sum_struct}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
-  // CHECK:        %[[V1:.*]] = iterators.undefstate : !iterators.state<!iterators.state<i32>>
-  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V0:.*]] into %[[V1]][0] : !iterators.state<!iterators.state<i32>>
+  // CHECK-NEXT:   %[[V1:.*]] = iterators.createstate(%[[V0]]) : !iterators.state<[[upstreamStateType]]>
   return
   // CHECK-NEXT:   return
 }
 // CHECK-NEXT:   }
-// CHECK-NEXT: }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/stream-to-value.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/stream-to-value.mlir
@@ -8,17 +8,15 @@
 // CHECK-LABEL: func.func private @iterators.value_to_stream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i1, i32>) -> !iterators.state<i1, i32> {
 
 func.func @main() {
-// CHECK-LABEL: func.func @main() {
+// CHECK-LABEL:  func.func @main() {
   %value = arith.constant 42 : i32
-// CHECK-NEXT:    %[[V0:.*]] = arith.constant 42 : i32
   %stream = iterators.value_to_stream %value : !iterators.stream<i32>
-// CHECK-NEXT:    %[[V1:.*]] = iterators.undefstate : !iterators.state<i1, i32>
-// CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[V0]] into %[[V1]][1] : !iterators.state<i1, i32>
+  // CHECK:        %[[V0:.*]] = iterators.createstate({{.*}}) : [[upstreamStateType:.*]]
   %result:2 = iterators.stream_to_value %stream : !iterators.stream<i32>
-// CHECK-NEXT:    %[[V3:.*]] = call @iterators.value_to_stream.open.{{[0-9]+}}(%[[V2]]) : (!iterators.state<i1, i32>) -> !iterators.state<i1, i32>
-// CHECK-NEXT:    %[[V4:.*]]:3 = call @iterators.value_to_stream.next.{{[0-9]+}}(%[[V3]]) : (!iterators.state<i1, i32>) -> (!iterators.state<i1, i32>, i1, i32)
-// CHECK-NEXT:    %[[V5:.*]] = call @iterators.value_to_stream.close.{{[0-9]+}}(%[[V4]]#0) : (!iterators.state<i1, i32>) -> !iterators.state<i1, i32>
+  // CHECK-NEXT:   %[[V1:.*]] = call @iterators.value_to_stream.open.0(%[[V0]]) : ([[upstreamStateType]]) -> [[upstreamStateType]]
+  // CHECK-NEXT:   %[[V2:.*]]:3 = call @iterators.value_to_stream.next.0(%[[V1]]) : ([[upstreamStateType]]) -> ([[upstreamStateType]], i1, i32)
+  // CHECK-NEXT:   %[[V3:.*]] = call @iterators.value_to_stream.close.0(%[[V2]]#0) : ([[upstreamStateType]]) -> [[upstreamStateType]]
   return
-// CHECK-NEXT:    return
+  // CHECK-NEXT:   return
 }
-// CHECK-NEXT:  }
+// CHECK-NEXT:   }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
@@ -35,11 +35,12 @@
 // CHECK-NEXT:  }
 
 func.func @main(%input : !tabular.tabular_view<i32>) {
-  // CHECK-LABEL: func.func @main(%{{arg.*}}: !llvm.struct<(i64, ptr<i32>)>) {
+// CHECK-LABEL:  func.func @main(
+// CHECK-SAME:      %[[arg0:.*]]: [[tabularViewType:.*]]) {
   %stream = iterators.tabular_view_to_stream %input
                 to !iterators.stream<!llvm.struct<(i32)>>
-  // CHECK-NEXT:    %[[V1:.*]] = iterators.undefstate : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
-  // CHECK-NEXT:    %[[V2:.*]] = iterators.insertvalue %[[arg:.*]] into %[[V1]][1] : !iterators.state<i64, !llvm.struct<(i64, ptr<i32>)>>
+  // CHECK-NEXT:   %[[V1:.*]] = arith.constant 0 : i64
+  // CHECK-NEXT:   %[[V2:.*]] = iterators.createstate(%[[V1]], %[[arg0]]) : !iterators.state<i64, [[tabularViewType]]>
   return
   // CHECK-NEXT:   return
 }

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/value-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/value-to-stream.mlir
@@ -20,13 +20,13 @@
 // CHECK-NEXT:  }
 
 func.func @main() {
-// CHECK-LABEL:  func.func @main() {
+// CHECK-LABEL:   func.func @main() {
   %value = arith.constant 42 : i32
-  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 42 : i32
+  // CHECK-NEXT:    %[[V0:.*]] = arith.constant 42 : i32
   %stream = iterators.value_to_stream %value : !iterators.stream<i32>
-  // CHECK-NEXT:   %[[V1:.*]] = iterators.undefstate : !iterators.state<i1, i32>
-  // CHECK-NEXT:   %[[V2:.*]] = iterators.insertvalue %[[V0]] into %[[V1]][1] : !iterators.state<i1, i32>
+  // CHECK-NEXT:    %[[V1:.*]] = arith.constant false
+  // CHECK-NEXT:    %[[V2:.*]] = iterators.createstate(%[[V1]], %[[V0]]) : !iterators.state<i1, i32>
   return
-  // CHECK-NEXT:   return
+  // CHECK-NEXT:    return
 }
-// CHECK-NEXT:   }
+// CHECK-NEXT:    }

--- a/experimental/iterators/test/Conversion/StatesToLLVM/state.mlir
+++ b/experimental/iterators/test/Conversion/StatesToLLVM/state.mlir
@@ -2,66 +2,80 @@
 // RUN: | FileCheck --enable-var-scope %s
 
 func.func @testUndefInsertExtract() {
-// CHECK-LABEL: func.func @testUndefInsertExtract() {
-  %initial_state = iterators.undefstate : !iterators.state<i32>
-// CHECK-NEXT:     %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+// CHECK-LABEL:  func.func @testUndefInsertExtract() {
   %value = arith.constant 0 : i32
-// CHECK-NEXT:     %[[V1:.*]] = arith.constant 0 : i32
+  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 0 : i32
+  %initial_state = iterators.createstate(%value) : !iterators.state<i32>
+  // CHECK-NEXT:   %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0]], %[[V1]][0] : !llvm.struct<(i32)>
   %inserted_state = iterators.insertvalue %value into %initial_state[0] : !iterators.state<i32>
-// CHECK-NEXT:     %[[V2:.*]] = llvm.insertvalue %[[V1]], %[[V0]][0] : !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V3:.*]] = llvm.insertvalue %[[V0]], %[[V2]][0] : !llvm.struct<(i32)>
   %extracted_value = iterators.extractvalue %inserted_state[0] : !iterators.state<i32>
-// CHECK-NEXT:     %[[V3:.*]] = llvm.extractvalue %[[V2]][0] : !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V4:.*]] = llvm.extractvalue %[[V3]][0] : !llvm.struct<(i32)>
   return
-// CHECK-NEXT:     return
+  // CHECK-NEXT:   return
 }
 // CHECK-NEXT:   }
 
 func.func @testNestedType() {
-// CHECK-LABEL: func.func @testNestedType() {
-  %outer_state = iterators.undefstate : !iterators.state<i32, !iterators.state<i32>>
-// CHECK-NEXT:     %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<(i32, struct<(i32)>)>
-  %inner_state = iterators.extractvalue %outer_state[1] : !iterators.state<i32, !iterators.state<i32>>
-// CHECK-NEXT:     %[[V1:.*]] = llvm.extractvalue %[[V0]][1] : !llvm.struct<(i32, struct<(i32)>)>
+// CHECK-LABEL:  func.func @testNestedType() {
+  %value = arith.constant 0 : i32
+  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 0 : i32
+  %inner_state = iterators.createstate(%value) : !iterators.state<i32>
+  // CHECK-NEXT:   %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0]], %[[V1]][0] : !llvm.struct<(i32)>
+  %outer_state = iterators.createstate(%value, %inner_state) : !iterators.state<i32, !iterators.state<i32>>
+  // CHECK-NEXT:   %[[V3:.*]] = llvm.mlir.undef : !llvm.struct<(i32, struct<(i32)>)>
+  // CHECK-NEXT:   %[[V4:.*]] = llvm.insertvalue %[[V0]], %[[V3]][0] : !llvm.struct<(i32, struct<(i32)>)>
+  // CHECK-NEXT:   %[[V5:.*]] = llvm.insertvalue %[[V2]], %[[V4]][1] : !llvm.struct<(i32, struct<(i32)>)>
+  %extracted_inner_state = iterators.extractvalue %outer_state[1] : !iterators.state<i32, !iterators.state<i32>>
+  // CHECK-NEXT:   %[[V6:.*]] = llvm.extractvalue %[[V5]][1] : !llvm.struct<(i32, struct<(i32)>)>
   return
-// CHECK-NEXT:     return
+  // CHECK-NEXT:   return
 }
 // CHECK-NEXT:   }
 
 func.func @testFuncReturn(%state: !iterators.state<i32>) -> !iterators.state<i32> {
-// CHECK-LABEL: func.func @testFuncReturn(%{{.*}}: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
+// CHECK-LABEL:  func.func @testFuncReturn(%{{.*}}: !llvm.struct<(i32)>) -> !llvm.struct<(i32)> {
   return %state : !iterators.state<i32>
-// CHECK-NEXT:     return %[[V0:.*]] : !llvm.struct<(i32)>
+  // CHECK-NEXT:   return %[[V0:.*]] : !llvm.struct<(i32)>
 }
 // CHECK-NEXT:   }
 
 func.func @testCall() {
-// CHECK-LABEL: func.func @testCall() {
-  %state = iterators.undefstate : !iterators.state<i32>
-// CHECK-NEXT:     %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+// CHECK-LABEL:  func.func @testCall() {
+  %value = arith.constant 0 : i32
+  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 0 : i32
+  %state = iterators.createstate(%value) : !iterators.state<i32>
+  // CHECK-NEXT:   %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0]], %[[V1]][0] : !llvm.struct<(i32)>
   func.call @testFuncReturn(%state) : (!iterators.state<i32>) -> !iterators.state<i32>
-// CHECK-NEXT:     %[[V1:.*]] = call @testFuncReturn(%[[V0]]) : (!llvm.struct<(i32)>) -> !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V3:.*]] = call @testFuncReturn(%[[V2]]) : (!llvm.struct<(i32)>) -> !llvm.struct<(i32)>
   return
-// CHECK-NEXT:     return
+  // CHECK-NEXT:   return
 }
 // CHECK-NEXT:   }
 
 func.func @testScf() {
 // CHECK-LABEL: func.func @testScf() {
-  %state = iterators.undefstate : !iterators.state<i32>
-// CHECK-NEXT:     %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+  %value  = arith.constant 0 : i32
+  // CHECK-NEXT:   %[[V0:.*]] = arith.constant 0 : i32
+  %state = iterators.createstate(%value) : !iterators.state<i32>
+  // CHECK-NEXT:   %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V2:.*]] = llvm.insertvalue %[[V0]], %[[V1]][0] : !llvm.struct<(i32)>
   %cmp = arith.constant true
-// CHECK-NEXT:     %[[V1:.*]] = arith.constant true
+  // CHECK-NEXT:   %[[V3:.*]] = arith.constant true
   %a = scf.if %cmp -> !iterators.state<i32> {
-// CHECK-NEXT:     %[[V2:.*]] = scf.if %[[V1]] -> (!llvm.struct<(i32)>) {
-    scf.yield %state :  !iterators.state<i32>
-// CHECK-NEXT:       scf.yield %[[V0]] : !llvm.struct<(i32)>
+  // CHECK-NEXT:   %[[V4:.*]] = scf.if %[[V3]] -> (!llvm.struct<(i32)>) {
+  scf.yield %state :  !iterators.state<i32>
+  // CHECK-NEXT:     scf.yield %[[V2]] : !llvm.struct<(i32)>
   } else {
-// CHECK-NEXT:     } else {
-    scf.yield %state :  !iterators.state<i32>
-// CHECK-NEXT:       scf.yield %[[V0]] : !llvm.struct<(i32)>
+  // CHECK-NEXT:   } else {
+  scf.yield %state :  !iterators.state<i32>
+  // CHECK-NEXT:     scf.yield %[[V2]] : !llvm.struct<(i32)>
   }
-// CHECK-NEXT:     }
+  // CHECK-NEXT:   }
   return
-// CHECK-NEXT:     return
+  // CHECK-NEXT:   return
 }
 // CHECK-NEXT:   }

--- a/experimental/iterators/test/Dialect/Iterators/inlining.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/inlining.mlir
@@ -1,8 +1,9 @@
 // RUN: iterators-opt %s -inline | FileCheck %s
 
 // CHECK-LABEL: func.func @test_inline() -> i32 {
-// CHECK-NEXT: %[[V0:.*]] = iterators.undefstate : !iterators.state<i32>
-// CHECK-NEXT: %[[RES:.*]] = iterators.extractvalue %[[V0]][0] : !iterators.state<i32>
+// CHECK-NEXT: %[[V0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT: %[[V1:.*]] = iterators.createstate(%[[V0]]) : !iterators.state<i32>
+// CHECK-NEXT: %[[RES:.*]] = iterators.extractvalue %[[V1]][0] : !iterators.state<i32>
 // CHECK-NEXT: return %[[RES]] : i32
 func.func @test_inline() -> i32 {
   %0 = call @inner_func_inlinable() : () -> i32
@@ -10,7 +11,8 @@ func.func @test_inline() -> i32 {
 }
 
 func.func @inner_func_inlinable() -> i32 {
-  %0 = iterators.undefstate : !iterators.state<i32>
-  %1 = iterators.extractvalue %0[0] : !iterators.state<i32>
-  return %1 : i32
+  %0 = arith.constant 0 : i32
+  %1 = iterators.createstate(%0) : !iterators.state<i32>
+  %2 = iterators.extractvalue %1[0] : !iterators.state<i32>
+  return %2 : i32
 }

--- a/experimental/iterators/test/Dialect/Iterators/state.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/state.mlir
@@ -3,10 +3,10 @@
 
 func.func @testUndefInsertExtract() {
 // CHECK-LABEL: func.func @testUndefInsertExtract() {
-  %initial_state = iterators.undefstate : !iterators.state<i32>
-// CHECK-NEXT:     %[[V0:state.*]] = iterators.undefstate : !iterators.state<i32>
   %value = arith.constant 0 : i32
 // CHECK-NEXT:     %[[V1:.*]] = arith.constant 0 : i32
+  %initial_state = iterators.createstate(%value) : !iterators.state<i32>
+// CHECK-NEXT:     %[[V0:state.*]] = iterators.createstate(%[[V1]]) : !iterators.state<i32>
   %inserted_state = iterators.insertvalue %value into
                         %initial_state[0] : !iterators.state<i32>
 // CHECK-NEXT:     %[[V2:state.*]] = iterators.insertvalue %[[V1]] into %[[V0]][0] : !iterators.state<i32>


### PR DESCRIPTION
The previous design was inspired from LLVM's structs and their way to create an undef struct and then insert values. The downside of this design is that it introduces the need to deal with undef states, which gets complex if we want to allow arbitrary field types. By forcing the existence of SSA values for all fields as arguments of a 'create' op, we eliminate the possibility of undef states and push that issue up to the user. Note that this means, in particular, that individual field values can still be set to undef by creating a state with undef values if so desired.