### PR TITLE
[Iterators] Introduce pass that decomposes iterator states into its constituent values.

### DIFF
--- a/experimental/iterators/benchmarks/inner_product/run.py
+++ b/experimental/iterators/benchmarks/inner_product/run.py
@@ -230,7 +230,8 @@ class IteratorsMethod(Method):
         emit_benchmarking_function('main_bench', main_func)
       pm = PassManager.parse(  # (Comment for better formatting.)
           'convert-iterators-to-llvm,'
-          'convert-states-to-llvm,'
+          'decompose-iterator-states,'
+          'canonicalize,'
           'expand-strided-metadata,'
           'finalize-memref-to-llvm,'
           'convert-scf-to-cf,'

--- a/experimental/iterators/include/iterators-c/Passes.h
+++ b/experimental/iterators/include/iterators-c/Passes.h
@@ -19,6 +19,8 @@ extern "C" {
 
 #include "iterators/Conversion/Passes.capi.h.inc" // IWYU pragma: export
 
+#include "iterators/Dialect/Iterators/Transforms/Passes.capi.h.inc" // IWYU pragma: export
+
 #ifdef __cplusplus
 }
 #endif

--- a/experimental/iterators/include/iterators/Dialect/Iterators/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Iterators)
+mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix Iterators)
+mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix Iterators)
+add_public_tablegen_target(MLIRIteratorsPassIncGen)

--- a/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/DecomposeIteratorStates.h
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/DecomposeIteratorStates.h
@@ -1,0 +1,26 @@
+//===- DecomposeIteratorStates.h - Pass Utilities ---------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ITERATORS_DIALECT_ITERATORS_TRANSFORMS_DECOMPOSEITERATORSTATES_H
+#define ITERATORS_DIALECT_ITERATORS_TRANSFORMS_DECOMPOSEITERATORSTATES_H
+
+namespace mlir {
+class RewritePatternSet;
+class TypeConverter;
+} // namespace mlir
+
+namespace mlir {
+namespace iterators {
+
+void populateDecomposeIteratorStatesPatterns(TypeConverter &typeConverter,
+                                             RewritePatternSet &patterns);
+
+} // namespace iterators
+} // namespace mlir
+
+#endif // ITERATORS_DIALECT_ITERATORS_TRANSFORMS_DECOMPOSEITERATORSTATES_H

--- a/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/Passes.h
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/Passes.h
@@ -1,0 +1,41 @@
+//===- Passes.h - Transform Pass Construction and Registration --*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This header file defines prototypes that expose pass constructors.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ITERATORS_DIALECT_ITERATORS_TRANSFORMS_PASSES_H
+#define ITERATORS_DIALECT_ITERATORS_TRANSFORMS_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+//===----------------------------------------------------------------------===//
+// Construction
+//===----------------------------------------------------------------------===//
+
+/// Generate pass declarations.
+#define GEN_PASS_DECL
+#include "iterators/Dialect/Iterators/Transforms/Passes.h.inc"
+
+/// Creates a pass that decomposes iterator states into individual values.
+std::unique_ptr<Pass> createDecomposeIteratorStatesPass();
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "iterators/Dialect/Iterators/Transforms/Passes.h.inc"
+
+} // namespace mlir
+
+#endif // ITERATORS_DIALECT_ITERATORS_TRANSFORMS_PASSES_H

--- a/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/Passes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/Passes.td
@@ -59,6 +59,8 @@ def DecomposeIteratorStates : Pass<"decompose-iterator-states", "ModuleOp"> {
   }];
   let constructor = "mlir::createDecomposeIteratorStatesPass()";
   let dependentDialects = [
+    "scf::SCFDialect",
+    "func::FuncDialect",
   ];
 }
 

--- a/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/Passes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/Transforms/Passes.td
@@ -1,0 +1,65 @@
+//===-- Passes.td - Transform pass definition file ---------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ITERATORS_TRANSFORMS_PASSES
+#define ITERATORS_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+//===----------------------------------------------------------------------===//
+// IteratorsToLLVM
+//===----------------------------------------------------------------------===//
+
+def DecomposeIteratorStates : Pass<"decompose-iterator-states", "ModuleOp"> {
+  let summary = "Decompose iterator states into their constituent values";
+  let description = [{
+    Iterator state "bundle" values that constitute the current state of
+    iterators, which often includes the state of nested iterators. This pass
+    decomposes these bundles into their constituent values such that the
+    `iterators.state` type is completely eliminated. In particular, the
+    creation, field access, and field updates now simply forward SSA values,
+    which are then carried as individual arguments through `scf` and `func` ops.
+    This decomposition allows further passes to run without knowing anything
+    about iterators, i.e., it makes iterators composable with other passes.
+
+    Example:
+
+    ```mlir
+    func.func @example(%arg : !iterators.state<i1, i32>) -> (!iterators.state<i1, i32>) {
+      %i1 = iterators.extractvalue %arg[0] : !iterators.state<i1, i32>
+      %result = scf.if %i1 -> !iterators.state<i1, i32> {
+        scf.yield %arg : !iterators.state<i1, i32>
+      } else {
+        %true = arith.constant 1 : i1
+        %updated = iterators.insertvalue %true into %arg[0] : !iterators.state<i1, i32>
+        scf.yield %updated : !iterators.state<i1, i32>
+      }
+      return %result : !iterators.state<i1, i32>
+    }
+    ```
+
+    gets decomposed into
+
+    ```mlir
+    func.func @example(%arg0: i1, %arg1: i32) -> (i1, i32) {
+      %true = arith.constant true
+      %0:2 = scf.if %arg0 -> (i1, i32) {
+        scf.yield %arg0, %arg1 : i1, i32
+      } else {
+        scf.yield %true, %arg1 : i1, i32
+      }
+      return %0#0, %0#1 : i1, i32
+    }
+    ```
+  }];
+  let constructor = "mlir::createDecomposeIteratorStatesPass()";
+  let dependentDialects = [
+  ];
+}
+
+#endif // ITERATORS_TRANSFORMS_PASSES

--- a/experimental/iterators/lib/CAPI/CMakeLists.txt
+++ b/experimental/iterators/lib/CAPI/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_mlir_public_c_api_library(IteratorsCAPI
     Dialects.cpp
     Passes.cpp
+    Transforms.cpp
   LINK_LIBS PUBLIC
     MLIRIterators
     MLIRIteratorsToLLVM
+    MLIRIteratorsTransforms
     MLIRTabular
     MLIRTabularToLLVM
     MLIRPass

--- a/experimental/iterators/lib/CAPI/Transforms.cpp
+++ b/experimental/iterators/lib/CAPI/Transforms.cpp
@@ -1,0 +1,27 @@
+//===- Transforms.cpp - C API for Transformations Passes ------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// #include "iterators-c/Passes.h"
+#include "iterators/Dialect/Iterators/Transforms/Passes.h"
+#include "mlir/CAPI/Pass.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+// Must include the declarations as they carry important visibility attributes.
+#include "iterators/Dialect/Iterators/Transforms/Passes.capi.h.inc"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "iterators/Dialect/Iterators/Transforms/Passes.capi.cpp.inc"
+
+#ifdef __cplusplus
+}
+#endif

--- a/experimental/iterators/lib/Dialect/Iterators/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialect/Iterators/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/experimental/iterators/lib/Dialect/Iterators/Transforms/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialect/Iterators/Transforms/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_mlir_dialect_library(MLIRIteratorsTransforms
+  DecomposeIteratorStates.cpp
+
+  DEPENDS
+  MLIRIteratorsPassIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRRewrite
+  MLIRTransformUtils
+)

--- a/experimental/iterators/lib/Dialect/Iterators/Transforms/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialect/Iterators/Transforms/CMakeLists.txt
@@ -5,8 +5,19 @@ add_mlir_dialect_library(MLIRIteratorsTransforms
   MLIRIteratorsPassIncGen
 
   LINK_LIBS PUBLIC
+  MLIRFuncDialect
+  MLIRFuncTransforms
   MLIRIR
+  MLIRIterators
   MLIRPass
   MLIRRewrite
+  MLIRSCFDialect
+  MLIRSCFTransforms
   MLIRTransformUtils
+)
+
+# Make headers from test pass available here.
+target_include_directories(MLIRIteratorsTransforms
+  PRIVATE
+  ${ITERATORS_MAIN_SRC_DIR}/test/lib/Conversion/OneToNTypeConversion/
 )

--- a/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
+++ b/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
@@ -10,8 +10,13 @@
 
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
 #include "iterators/Dialect/Iterators/Transforms/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Func/Transforms/OneToNFuncConversions.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/OneToNTypeConversion.h"
 
 namespace mlir {
 #define GEN_PASS_CLASSES
@@ -22,19 +27,222 @@ namespace mlir {
 using namespace mlir;
 using namespace mlir::iterators;
 
+class DecomposeStatesTypeConverter : public OneToNTypeConverter {
+public:
+  DecomposeStatesTypeConverter() {
+    addConversion([](Type type) { return type; });
+    addConversion([&](StateType type, SmallVectorImpl<Type> &results) {
+      return decomposeStateType(type, results);
+    });
+  }
+
+private:
+  /// Maps a StateType to the types of its fields.
+  Optional<LogicalResult> decomposeStateType(StateType type,
+                                             SmallVectorImpl<Type> &results) {
+    for (Type fieldType : type.getFieldTypes()) {
+      if (failed(convertTypes(fieldType, results)))
+        return failure();
+    }
+    return success();
+  }
+};
+
+class DecomposeCreateStateOp : public OneToNOpConversionPattern<CreateStateOp> {
+public:
+  using OneToNOpConversionPattern<CreateStateOp>::OneToNOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(CreateStateOp op, OneToNPatternRewriter &rewriter,
+                  const OneToNTypeMapping & /*operandMapping*/,
+                  const OneToNTypeMapping &resultMapping,
+                  const ValueRange convertedOperands) const override {
+    // Simply replace the current op with the converted operands.
+    rewriter.replaceOp(op, convertedOperands, resultMapping);
+    return success();
+  }
+};
+
+class DecomposeInsertValueOp : public OneToNOpConversionPattern<InsertValueOp> {
+public:
+  using OneToNOpConversionPattern<InsertValueOp>::OneToNOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(InsertValueOp op, OneToNPatternRewriter &rewriter,
+                  const OneToNTypeMapping &operandMapping,
+                  const OneToNTypeMapping &resultMapping,
+                  const ValueRange convertedOperands) const override {
+    // Construct conversion mapping for field types.
+    auto stateType = op.getState().getType().cast<StateType>();
+    TypeRange originalFieldTypes = stateType.getFieldTypes();
+    OneToNTypeMapping fieldMapping(originalFieldTypes);
+    if (failed(typeConverter->convertSignatureArgs(originalFieldTypes,
+                                                   fieldMapping)))
+      return failure();
+
+    // Extract converted operands.
+    ValueRange convertedState =
+        operandMapping.getConvertedValues(convertedOperands, 0);
+    ValueRange convertedValue =
+        operandMapping.getConvertedValues(convertedOperands, 1);
+
+    // Compose new state fields from unchanged and inserted ones.
+    size_t index = op.getIndex().getZExtValue();
+    SmallVector<Value> updatedState;
+    for (size_t i = 0; i < stateType.getFieldTypes().size(); i++) {
+      ValueRange field = fieldMapping.getConvertedValues(convertedState, i);
+      if (index == i) {
+        assert(field.getTypes() == ValueRange{convertedValue}.getTypes());
+        updatedState.append(convertedValue.begin(), convertedValue.end());
+      } else {
+        updatedState.append(field.begin(), field.end());
+      }
+    }
+
+    // Replace original op with new state fields.
+    rewriter.replaceOp(op, updatedState, resultMapping);
+    return success();
+  }
+};
+
+class DecomposeExtractValueOp
+    : public OneToNOpConversionPattern<ExtractValueOp> {
+public:
+  using OneToNOpConversionPattern<ExtractValueOp>::OneToNOpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(ExtractValueOp op, OneToNPatternRewriter &rewriter,
+                  const OneToNTypeMapping &operandMapping,
+                  const OneToNTypeMapping &resultMapping,
+                  const ValueRange convertedOperands) const override {
+    // Construct conversion mapping for field types.
+    auto stateType = op.getState().getType().cast<StateType>();
+    TypeRange originalFieldTypes = stateType.getFieldTypes();
+    OneToNTypeMapping fieldMapping(originalFieldTypes);
+    if (failed(typeConverter->convertSignatureArgs(originalFieldTypes,
+                                                   fieldMapping)))
+      return failure();
+
+    // Extract converted operands.
+    ValueRange convertedState =
+        operandMapping.getConvertedValues(convertedOperands, 0);
+
+    // Return extracted value.
+    size_t index = op.getIndex().getZExtValue();
+    ValueRange extractedValue =
+        fieldMapping.getConvertedValues(convertedState, index);
+
+    // Replace original op with extracted field value.
+    rewriter.replaceOp(op, extractedValue, resultMapping);
+    return success();
+  }
+};
+
 void iterators::populateDecomposeIteratorStatesPatterns(
     TypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<
       // clang-format off
+      DecomposeExtractValueOp,
+      DecomposeInsertValueOp,
+      DecomposeCreateStateOp
       // clang-format on
       >(typeConverter, patterns.getContext());
 }
 
+static std::optional<Value> buildCreateStateOp(OpBuilder &builder,
+                                               TypeConverter &typeConverter,
+                                               Type type, ValueRange inputs,
+                                               Location loc) {
+  auto stateType = type.dyn_cast<StateType>();
+  if (!stateType)
+    return {};
+
+  SmallVector<Value> operands;
+  operands.reserve(stateType.getFieldTypes().size());
+  ValueRange::iterator inputsIt = inputs.begin();
+  for (Type fieldType : stateType.getFieldTypes()) {
+    Value operand;
+    if (fieldType.isa<StateType>()) {
+      SmallVector<Type> nestedFieldTypes;
+      if (failed(typeConverter.convertType(fieldType, nestedFieldTypes)))
+        return {};
+      ValueRange nestedFields{inputsIt, inputsIt + nestedFieldTypes.size()};
+      std::optional<Value> createdState = buildCreateStateOp(
+          builder, typeConverter, fieldType, nestedFields, loc);
+      if (!createdState.has_value() || !createdState.value())
+        return {};
+      operand = createdState.value();
+    } else {
+      operand = *inputsIt;
+    }
+    operands.push_back(operand);
+  }
+  auto createStateOp = builder.create<CreateStateOp>(loc, type, operands);
+  assert(createStateOp->getNumResults() == 1);
+  return createStateOp->getResult(0);
+}
+
+std::optional<SmallVector<Value>>
+buildExtractValueOps(OpBuilder &builder, TypeConverter &typeConverter,
+                     TypeRange resultTypes, Value input, Location loc) {
+  auto stateType = input.getType().dyn_cast<StateType>();
+  if (!stateType)
+    return {};
+
+  SmallVector<Value> extractedValues;
+  for (auto [idx, fieldType] : llvm::enumerate(stateType.getFieldTypes())) {
+    Value extractedValue =
+        builder.create<ExtractValueOp>(loc, input, builder.getIndexAttr(idx));
+
+    // If the value isn't a nested state, we can take it as is.
+    if (!fieldType.isa<StateType>()) {
+      extractedValues.push_back(extractedValue);
+      continue;
+    }
+
+    // For states, we recurse to extract the nested fields.
+    SmallVector<Type> nestedResultTypes;
+    if (failed(typeConverter.convertType(extractedValue.getType(),
+                                         nestedResultTypes)))
+      return {};
+    std::optional<SmallVector<Value>> maybeResults = buildExtractValueOps(
+        builder, typeConverter, nestedResultTypes, extractedValue, loc);
+    if (!maybeResults)
+      return {};
+
+    extractedValues.append(*maybeResults);
+  }
+
+  return extractedValues;
+}
 struct DecomposeIteratorStatesPass
     : public DecomposeIteratorStatesBase<DecomposeIteratorStatesPass> {
   void runOnOperation() override {
     ModuleOp module = getOperation();
     MLIRContext *context = &getContext();
+
+    DecomposeStatesTypeConverter typeConverter;
+    auto buildCreateStateOpHelper = [&](OpBuilder &builder, Type type,
+                                        ValueRange inputs, Location loc) {
+      return buildCreateStateOp(builder, typeConverter, type, inputs, loc);
+    };
+    typeConverter.addArgumentMaterialization(buildCreateStateOpHelper);
+    typeConverter.addSourceMaterialization(buildCreateStateOpHelper);
+    auto buildExtractValueOpsHelper = [&](OpBuilder &builder,
+                                          TypeRange resultTypes, Value input,
+                                          Location loc) {
+      return buildExtractValueOps(builder, typeConverter, resultTypes, input,
+                                  loc);
+    };
+    typeConverter.addTargetMaterialization(buildExtractValueOpsHelper);
+
+    RewritePatternSet patterns(context);
+    populateDecomposeIteratorStatesPatterns(typeConverter, patterns);
+    populateFuncTypeConversionPatterns(typeConverter, patterns);
+    scf::populateSCFStructuralOneToNTypeConversions(typeConverter, patterns);
+    if (failed(applyPartialOneToNConversion(module, typeConverter,
+                                            std::move(patterns))))
+      return signalPassFailure();
   };
 };
 

--- a/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
+++ b/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
@@ -27,6 +27,8 @@ namespace mlir {
 using namespace mlir;
 using namespace mlir::iterators;
 
+namespace {
+
 class DecomposeStatesTypeConverter : public OneToNTypeConverter {
 public:
   DecomposeStatesTypeConverter() {
@@ -130,6 +132,8 @@ public:
   }
 };
 
+} // namespace
+
 void iterators::populateDecomposeIteratorStatesPatterns(
     TypeConverter &typeConverter, RewritePatternSet &patterns) {
   patterns.add<
@@ -199,7 +203,7 @@ static std::optional<Value> buildCreateStateOp(OpBuilder &builder,
 /// however, is a problem with the overall design of the current lowering and
 /// not specific to state decomposition. If/when that is fixed, the problem here
 /// will either go away comletely or be fixed as a consequence.
-std::optional<SmallVector<Value>>
+static std::optional<SmallVector<Value>>
 buildExtractValueOps(OpBuilder &builder, TypeConverter &typeConverter,
                      TypeRange resultTypes, Value input, Location loc) {
   auto stateType = input.getType().dyn_cast<StateType>();
@@ -232,6 +236,9 @@ buildExtractValueOps(OpBuilder &builder, TypeConverter &typeConverter,
 
   return extractedValues;
 }
+
+namespace {
+
 struct DecomposeIteratorStatesPass
     : public DecomposeIteratorStatesBase<DecomposeIteratorStatesPass> {
   void runOnOperation() override {
@@ -262,6 +269,8 @@ struct DecomposeIteratorStatesPass
       return signalPassFailure();
   };
 };
+
+} // namespace
 
 std::unique_ptr<Pass> mlir::createDecomposeIteratorStatesPass() {
   return std::make_unique<DecomposeIteratorStatesPass>();

--- a/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
+++ b/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
@@ -141,6 +141,19 @@ void iterators::populateDecomposeIteratorStatesPatterns(
       >(typeConverter, patterns.getContext());
 }
 
+/// Creates IR that builds `CreateStateOp`s to assemble an iterator state of the
+/// given, portentially recursive state type from the given range of value. This
+/// is meant to be used as argument and source materializations for iterator
+/// state decomposition.
+///
+/// The implementation of this function is recursive, which should be avoided in
+/// the LLVM code base. On the one side, the recursion is bounded by the nesting
+/// depth of the iterator state types, which might make this an acceptable
+/// exception. On the other side, the nesting depth of the states currently
+/// depends on the length of SSA use-def chains, which may be large. That,
+/// however, is a problem with the overall design of the current lowering and
+/// not specific to state decomposition. If/when that is fixed, the problem here
+/// will either go away comletely or be fixed as a consequence.
 static std::optional<Value> buildCreateStateOp(OpBuilder &builder,
                                                TypeConverter &typeConverter,
                                                Type type, ValueRange inputs,
@@ -174,6 +187,18 @@ static std::optional<Value> buildCreateStateOp(OpBuilder &builder,
   return createStateOp->getResult(0);
 }
 
+/// Creates IR that builds `ExtractValueOp`s to extract the (potentially nested)
+/// constituent values from the given iterator state. This is meant to be used
+/// as target materializations for iterator state decomposition.
+///
+/// The implementation of this function is recursive, which should be avoided in
+/// the LLVM code base. On the one side, the recursion is bounded by the nesting
+/// depth of the iterator state types, which might make this an acceptable
+/// exception. On the other side, the nesting depth of the states currently
+/// depends on the length of SSA use-def chains, which may be large. That,
+/// however, is a problem with the overall design of the current lowering and
+/// not specific to state decomposition. If/when that is fixed, the problem here
+/// will either go away comletely or be fixed as a consequence.
 std::optional<SmallVector<Value>>
 buildExtractValueOps(OpBuilder &builder, TypeConverter &typeConverter,
                      TypeRange resultTypes, Value input, Location loc) {

--- a/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
+++ b/experimental/iterators/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
@@ -1,0 +1,43 @@
+//===- DecomposeIteratorStates.cpp - Pass Implementation --------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Dialect/Iterators/Transforms/DecomposeIteratorStates.h"
+
+#include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Dialect/Iterators/Transforms/Passes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+#define GEN_PASS_CLASSES
+#include "iterators/Dialect/Iterators/Transforms/Passes.h.inc"
+} // namespace mlir
+
+// using namespace iterators;
+using namespace mlir;
+using namespace mlir::iterators;
+
+void iterators::populateDecomposeIteratorStatesPatterns(
+    TypeConverter &typeConverter, RewritePatternSet &patterns) {
+  patterns.add<
+      // clang-format off
+      // clang-format on
+      >(typeConverter, patterns.getContext());
+}
+
+struct DecomposeIteratorStatesPass
+    : public DecomposeIteratorStatesBase<DecomposeIteratorStatesPass> {
+  void runOnOperation() override {
+    ModuleOp module = getOperation();
+    MLIRContext *context = &getContext();
+  };
+};
+
+std::unique_ptr<Pass> mlir::createDecomposeIteratorStatesPass() {
+  return std::make_unique<DecomposeIteratorStatesPass>();
+}

--- a/experimental/iterators/python/IteratorsPasses.cpp
+++ b/experimental/iterators/python/IteratorsPasses.cpp
@@ -19,4 +19,5 @@ PYBIND11_MODULE(_mlirIteratorsPasses, m) {
 
   // Register all Iterators passes on load.
   mlirRegisterIteratorsConversionPasses();
+  mlirRegisterIteratorsPasses();
 }

--- a/experimental/iterators/test/Dialect/Iterators/Transforms/DecomposeIteratorStates/state.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/Transforms/DecomposeIteratorStates/state.mlir
@@ -1,0 +1,149 @@
+// RUN: iterators-opt %s -decompose-iterator-states \
+// RUN: | FileCheck --enable-var-scope %s
+
+// CHECK-LABEL: func.func @testCreateInsertExtractFlat() -> (i32, i32) {
+// CHECK-NEXT:    %[[V0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    return %[[V0]], %[[V0]] : i32, i32
+// CHECK-NEXT:  }
+func.func @testCreateInsertExtractFlat() -> (i32, i32) {
+  %value = arith.constant 0 : i32
+  %created_state = iterators.createstate(%value) : !iterators.state<i32>
+  %extracted_value_0 = iterators.extractvalue %created_state[0] : !iterators.state<i32>
+  %inserted_state = iterators.insertvalue %value into %created_state[0] : !iterators.state<i32>
+  %extracted_value_1 = iterators.extractvalue %inserted_state[0] : !iterators.state<i32>
+  return %extracted_value_0, %extracted_value_1 : i32, i32
+}
+
+// CHECK-LABEL: func.func @testCreateInsertExtractNested() -> (i32, i32, i32, i32) {
+// CHECK-NEXT:    %[[V0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    return %[[V0]], %[[V0]], %[[V0]], %[[V0]] : i32, i32, i32, i32
+// CHECK-NEXT:  }
+func.func @testCreateInsertExtractNested() -> (i32, i32, i32, i32) {
+  // Create nested states.
+  %value = arith.constant 0 : i32
+  %created_inner_state = iterators.createstate(%value) : !iterators.state<i32>
+  %created_outer_state = iterators.createstate(%value, %created_inner_state) : !iterators.state<i32, !iterators.state<i32>>
+  // Extract from created state.
+  %extracted_value_0 = iterators.extractvalue %created_outer_state[0] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_inner_state_0 = iterators.extractvalue %created_outer_state[1] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_value_1 = iterators.extractvalue %extracted_inner_state_0[0] : !iterators.state<i32>
+  // Update states and then extract again.
+  %inserted_inner_state = iterators.insertvalue %value into %created_inner_state[0] : !iterators.state<i32>
+  %inserted_outer_state_0 = iterators.insertvalue %value into %created_outer_state[0] : !iterators.state<i32, !iterators.state<i32>>
+  %inserted_outer_state_1 = iterators.insertvalue %inserted_inner_state into %inserted_outer_state_0[1] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_value_2 = iterators.extractvalue %inserted_outer_state_1[0] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_inner_state_1 = iterators.extractvalue %inserted_outer_state_1[1] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_value_3 = iterators.extractvalue %extracted_inner_state_1[0] : !iterators.state<i32>
+  return %extracted_value_0, %extracted_value_1, %extracted_value_2, %extracted_value_3 : i32, i32, i32, i32
+}
+
+// CHECK-LABEL: func.func @testSCFIfNested(
+// CHECK-SAME:        %[[arg0:.*]]: i1) -> (i32, i32) {
+// CHECK-NEXT:    %[[V1:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:    %[[V0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %[[V3:.*]]:2 = scf.if %[[arg0]] -> (i32, i32) {
+// CHECK-NEXT:      scf.yield %[[V1]], %[[V1]] : i32, i32
+// CHECK-NEXT:    } else {
+// CHECK-NEXT:      scf.yield %[[V0]], %[[V0]] : i32, i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[V3]]#0, %[[V3]]#1 : i32, i32
+// CHECK-NEXT:  }
+func.func @testSCFIfNested(%do_insert : i1) -> (i32, i32) {
+  // Create nested state.
+  %init_value = arith.constant 0 : i32
+  %created_inner_state = iterators.createstate(%init_value) : !iterators.state<i32>
+  %created_outer_state = iterators.createstate(%init_value, %created_inner_state) : !iterators.state<i32, !iterators.state<i32>>
+  // Possibly insert new values.
+  %updated_outer_state = scf.if %do_insert -> !iterators.state<i32, !iterators.state<i32>> {
+    %insert_value = arith.constant 1 : i32
+    %inserted_inner_state = iterators.insertvalue %insert_value into %created_inner_state[0] : !iterators.state<i32>
+    %inserted_outer_state = iterators.createstate(%insert_value, %inserted_inner_state) : !iterators.state<i32, !iterators.state<i32>>
+    scf.yield %inserted_outer_state : !iterators.state<i32, !iterators.state<i32>>
+  } else {
+    scf.yield %created_outer_state : !iterators.state<i32, !iterators.state<i32>>
+  }
+  // Extract possibly overwritten values.
+  %extracted_value_0 = iterators.extractvalue %updated_outer_state[0] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_inner_state = iterators.extractvalue %updated_outer_state[1] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_value_1 = iterators.extractvalue %extracted_inner_state[0] : !iterators.state<i32>
+  return %extracted_value_0, %extracted_value_1 : i32, i32
+}
+
+// CHECK-LABEL: func.func @testSCFWhileNested(
+// CHECK-SAME:        %[[arg0:.*]]: i32) -> (i32, i32) {
+// CHECK-NEXT:    %[[V0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %[[V1:.*]]:2 = scf.while (%[[arg1:.*]] = %[[V0]], %[[arg2:.*]] = %[[V0]]) : (i32, i32) -> (i32, i32) {
+// CHECK-NEXT:      %[[V2:.*]] = arith.cmpi eq, %[[arg0]], %[[arg1]] : i32
+// CHECK-NEXT:      scf.condition(%[[V2]]) %[[arg1]], %[[arg2]] : i32, i32
+// CHECK-NEXT:    } do {
+// CHECK-NEXT:    ^bb0(%[[arg3:.*]]: i32, %[[arg4:.*]]: i32):
+// CHECK-NEXT:      scf.yield %[[arg3]], %[[V0]] : i32, i32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return %[[V1]]#0, %[[V1]]#1 : i32, i32
+// CHECK-NEXT:  }
+func.func @testSCFWhileNested(%arg : i32) -> (i32, i32) {
+  // Create nested state.
+  %init_value = arith.constant 0 : i32
+  %created_inner_state = iterators.createstate(%init_value) : !iterators.state<i32>
+  %created_outer_state = iterators.createstate(%init_value, %created_inner_state) : !iterators.state<i32, !iterators.state<i32>>
+  // Do dummy update of state in a loop.
+  %processed_outer_state = scf.while (%state = %created_outer_state) : (!iterators.state<i32, !iterators.state<i32>>) -> !iterators.state<i32, !iterators.state<i32>> {
+    %extracted_value = iterators.extractvalue %state[0] : !iterators.state<i32, !iterators.state<i32>>
+    %cmp = arith.cmpi "eq", %arg, %extracted_value : i32
+    scf.condition (%cmp) %state : !iterators.state<i32, !iterators.state<i32>>
+  } do {
+  ^bb0(%state : !iterators.state<i32, !iterators.state<i32>>):
+    %updated_state = iterators.insertvalue %created_inner_state into %state[1] : !iterators.state<i32, !iterators.state<i32>>
+    scf.yield %updated_state : !iterators.state<i32, !iterators.state<i32>>
+  }
+  // Extract nested values.
+  %extracted_value_0 = iterators.extractvalue %processed_outer_state[0] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_inner_state = iterators.extractvalue %processed_outer_state[1] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_value_1 = iterators.extractvalue %extracted_inner_state[0] : !iterators.state<i32>
+  return %extracted_value_0, %extracted_value_1 : i32, i32
+}
+
+// CHECK-LABEL: func.func private @testFuncFunc(
+// CHECK-SAME:        i32, i32) -> (i32, i32)
+func.func private @testFuncFunc(%arg : !iterators.state<i32, !iterators.state<i32>>) -> (!iterators.state<i32, !iterators.state<i32>>)
+
+// CHECK-LABEL: func.func @testFuncBlock(
+// CHECK-SAME:        %[[arg0:.*]]: i32, %[[arg1:.*]]: i32) -> (i32, i32) {
+// CHECK-NEXT:    return %[[arg0]], %[[arg1]] : i32, i32
+// CHECK-NEXT:  }
+func.func @testFuncBlock(%arg : !iterators.state<i32, !iterators.state<i32>>) -> (i32, i32) {
+  %extracted_value_0 = iterators.extractvalue %arg[0] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_inner_state = iterators.extractvalue %arg[1] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_value_1 = iterators.extractvalue %extracted_inner_state[0] : !iterators.state<i32>
+  return %extracted_value_0, %extracted_value_1 : i32, i32
+}
+
+// CHECK-LABEL: func.func @testFuncCall(
+// CHECK-SAME:        %[[arg0:.*]]: i32) -> (i32, i32) {
+// CHECK-NEXT:    %[[V0:.*]]:2 = call @testFuncFunc(%[[arg0]], %[[arg0]]) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:    return %[[V0]]#0, %[[V0]]#1 : i32, i32
+// CHECK-NEXT:  }
+func.func @testFuncCall(%arg : i32) -> (i32, i32) {
+  // Create nested state.
+  %created_inner_state = iterators.createstate(%arg) : !iterators.state<i32>
+  %created_outer_state = iterators.createstate(%arg, %created_inner_state) : !iterators.state<i32, !iterators.state<i32>>
+  // Pass it to function call.
+  %call_result = func.call @testFuncFunc(%created_outer_state) : (!iterators.state<i32, !iterators.state<i32>>) -> !iterators.state<i32, !iterators.state<i32>>
+  // Extract values from call result.
+  %extracted_value_0 = iterators.extractvalue %call_result[0] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_inner_state = iterators.extractvalue %call_result[1] : !iterators.state<i32, !iterators.state<i32>>
+  %extracted_value_1 = iterators.extractvalue %extracted_inner_state[0] : !iterators.state<i32>
+  return %extracted_value_0, %extracted_value_1 : i32, i32
+}
+
+// CHECK-LABEL: func.func @testFuncReturn(
+// CHECK-SAME:        %arg0: i32) -> (i32, i32) {
+// CHECK-NEXT:    return %arg0, %arg0 : i32, i32
+// CHECK-NEXT:  }
+func.func @testFuncReturn(%arg : i32) -> !iterators.state<i32, !iterators.state<i32>> {
+  // Create nested state.
+  %created_inner_state = iterators.createstate(%arg) : !iterators.state<i32>
+  %created_outer_state = iterators.createstate(%arg, %created_inner_state) : !iterators.state<i32, !iterators.state<i32>>
+  // Return from function.
+  return %created_outer_state : !iterators.state<i32, !iterators.state<i32>>
+}

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/constant-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/constant-stream.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/constant-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/constant-stream.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/filter.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/map.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/reduce.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/stream-to-value.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/stream-to-value.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/stream-to-value.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/stream-to-value.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/symbol-collision-resolution.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/symbol-collision-resolution.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/symbol-collision-resolution.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/symbol-collision-resolution.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
@@ -1,7 +1,7 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-tabular-to-llvm \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -arith-bufferize -cse \
 // RUN:   -expand-strided-metadata \
 // RUN:   -finalize-memref-to-llvm \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
@@ -1,7 +1,7 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-tabular-to-llvm \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -arith-bufferize -cse \
 // RUN:   -expand-strided-metadata \
 // RUN:   -finalize-memref-to-llvm \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tpch-q6.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tpch-q6.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tpch-q6.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tpch-q6.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/value-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/value-to-stream.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -decompose-iterator-states -canonicalize \
+// RUN:   -decompose-iterator-states \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/value-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/value-to-stream.mlir
@@ -1,6 +1,6 @@
 // RUN: iterators-opt %s \
 // RUN:   -convert-iterators-to-llvm \
-// RUN:   -convert-states-to-llvm \
+// RUN:   -decompose-iterator-states -canonicalize \
 // RUN:   -convert-func-to-llvm \
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \

--- a/experimental/iterators/test/python/dialects/iterators/dialect.py
+++ b/experimental/iterators/test/python/dialects/iterators/dialect.py
@@ -82,7 +82,8 @@ def testEndToEndStandalone():
       ''')
   pm = PassManager.parse('builtin.module('
                          'convert-iterators-to-llvm,'
-                         'convert-states-to-llvm,'
+                         'decompose-iterator-states,'
+                         'canonicalize,'
                          'convert-func-to-llvm,'
                          'convert-scf-to-cf,'
                          'convert-cf-to-llvm)')
@@ -108,7 +109,8 @@ def testEndToEndWithInput():
       ''')
   pm = PassManager.parse('builtin.module('
                          'convert-iterators-to-llvm,'
-                         'convert-states-to-llvm,'
+                         'decompose-iterator-states,'
+                         'canonicalize,'
                          'expand-strided-metadata,'
                          'finalize-memref-to-llvm,'
                          'convert-func-to-llvm,'

--- a/experimental/iterators/tools/iterators-lsp-server/CMakeLists.txt
+++ b/experimental/iterators/tools/iterators-lsp-server/CMakeLists.txt
@@ -15,11 +15,15 @@ list(APPEND conversion_libs
   MLIRTabularToLLVM
   MLIRStatesToLLVM
   )
+set(iterators_transform_libs
+  MLIRIteratorsTransforms
+  )
 
 target_link_libraries(iterators-lsp-server
   PRIVATE
   ${dialect_libs}
   ${conversion_libs}
+  ${iterators_transform_libs}
   MLIRLspServerLib
   MLIRSupport
   MLIRIR

--- a/experimental/iterators/tools/iterators-lsp-server/iterators-lsp-server.cpp
+++ b/experimental/iterators/tools/iterators-lsp-server/iterators-lsp-server.cpp
@@ -16,6 +16,7 @@
 
 #include "iterators/Conversion/Passes.h"
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Dialect/Iterators/Transforms/Passes.h"
 #include "iterators/Dialect/Tabular/IR/Tabular.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/InitAllDialects.h"
@@ -37,6 +38,7 @@ static void registerIteratorDialects(DialectRegistry &registry) {
 int main(int argc, char **argv) {
   registerAllPasses();
   registerIteratorsConversionPasses();
+  registerIteratorsPasses();
 
   DialectRegistry registry;
   registerAllDialects(registry);

--- a/experimental/iterators/tools/iterators-opt/CMakeLists.txt
+++ b/experimental/iterators/tools/iterators-opt/CMakeLists.txt
@@ -15,10 +15,12 @@ list(APPEND conversion_libs
   MLIRTabularToLLVM
   MLIRStatesToLLVM
   )
+set(iterators_transform_libs
+  MLIRIteratorsTransforms
+  )
 
 target_link_libraries(iterators-opt
   PRIVATE
-
   ${dialect_libs}
   ${conversion_libs}
   MLIRAffineAnalysis

--- a/experimental/iterators/tools/iterators-opt/iterators-opt.cpp
+++ b/experimental/iterators/tools/iterators-opt/iterators-opt.cpp
@@ -13,6 +13,7 @@
 
 #include "iterators/Conversion/Passes.h"
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
+#include "iterators/Dialect/Iterators/Transforms/Passes.h"
 #include "iterators/Dialect/Tabular/IR/Tabular.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/InitAllDialects.h"
@@ -38,6 +39,7 @@ int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
   registerAllPasses();
   registerIteratorsConversionPasses();
+  registerIteratorsPasses();
 
   DialectRegistry registry;
   registerAllDialects(registry);


### PR DESCRIPTION
~~This PR depends on and, therefore, includes #650 and #655. I might also factor out the update of LLVM into a different PR before landing.~~

This PR implements a pass that decomposes iterator states into its constituent values instead of lowering them to (nested) LLVM structs. The problem with the previous approach is that it only supports storing LLVM types in the state, which includes many interesting things such as `tensor`s or `memref`s. By decomposing the state into individual fields, other passes can run on this fields without knowing anything about iterators (or LLVM structs) and, thus, makes iterators composable with other dialects.

- [x] Move boilerplate changes to first commit.
- [x] Remove forward declarations of `populate*`, which are now in a different compilation unit.