### PR TITLE
[Iterators] Introduce Tuple dialect for manipulating tuple values.

### DIFF
--- a/experimental/iterators/include/iterators-c/Dialects.h
+++ b/experimental/iterators/include/iterators-c/Dialects.h
@@ -53,6 +53,12 @@ MLIR_CAPI_EXPORTED MlirType mlirTabularViewTypeGetColumnType(MlirType type,
 /// Returns tuple type that represents one row of the given tabular view.
 MLIR_CAPI_EXPORTED MlirType mlirTabularViewTypeGetRowType(MlirType type);
 
+//===----------------------------------------------------------------------===//
+// Tuple dialect and attributes
+//===----------------------------------------------------------------------===//
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Tuple, tuple);
+
 #ifdef __cplusplus
 }
 #endif

--- a/experimental/iterators/include/iterators/Dialect/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Iterators)
 add_subdirectory(Tabular)
+add_subdirectory(Tuple)

--- a/experimental/iterators/include/iterators/Dialect/Tuple/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/Tuple/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/experimental/iterators/include/iterators/Dialect/Tuple/IR/CMakeLists.txt
+++ b/experimental/iterators/include/iterators/Dialect/Tuple/IR/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_mlir_dialect(TupleOps tuple)
+add_dependencies(MLIRTupleDialect MLIRTupleOpsIncGen)
+
+add_dependencies(mlir-headers
+  MLIRTupleOpsIncGen
+)

--- a/experimental/iterators/include/iterators/Dialect/Tuple/IR/Tuple.h
+++ b/experimental/iterators/include/iterators/Dialect/Tuple/IR/Tuple.h
@@ -1,0 +1,23 @@
+//===-- Tuple.h - Tuple dialect header file ---------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef ITERATORS_DIALECT_TUPLE_IR_TUPLE_H
+#define ITERATORS_DIALECT_TUPLE_IR_TUPLE_H
+
+#include "mlir/IR/Dialect.h"
+#include "mlir/IR/OpImplementation.h"
+
+#include "iterators/Dialect/Tuple/IR/TupleOpsDialect.h.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "iterators/Dialect/Tuple/IR/TupleOpsTypes.h.inc"
+
+#define GET_OP_CLASSES
+#include "iterators/Dialect/Tuple/IR/TupleOps.h.inc"
+
+#endif // ITERATORS_DIALECT_TUPLE_IR_TUPLE_H

--- a/experimental/iterators/include/iterators/Dialect/Tuple/IR/TupleDialect.td
+++ b/experimental/iterators/include/iterators/Dialect/Tuple/IR/TupleDialect.td
@@ -1,0 +1,30 @@
+//===-- TupleDialect.td - Tuple dialect --------------------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TUPLE_IR_TUPLEDIALECT
+#define TUPLE_IR_TUPLEDIALECT
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// Dialect definition.
+//===----------------------------------------------------------------------===//
+
+def Tuple_Dialect : Dialect {
+  let name = "tuple";
+  let cppNamespace = "::mlir::tuple";
+  let summary = "Dialect for generic manipulation of built-in tuples.";
+  let description = [{
+    This dialect contains ops that allow creating tuples as well as accessing
+    and updating elements or slices of them. Potential lowering are a mapping to
+    lower-level tuple-like structures such as structs in LLVM or decomposition
+    into individual elements.
+  }];
+}
+
+#endif // TUPLE_IR_TUPLEDIALECT

--- a/experimental/iterators/include/iterators/Dialect/Tuple/IR/TupleOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Tuple/IR/TupleOps.td
@@ -1,0 +1,83 @@
+//===-- TupleOps.td - Tuple operations definitions ---------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TUPLE_IR_TUPLEOPS
+#define TUPLE_IR_TUPLEOPS
+
+include "iterators/Dialect/Tuple/IR/TupleDialect.td"
+include "mlir/IR/OpAsmInterface.td"
+include "mlir/IR/OpBase.td"
+
+class Tuple_Op<string mnemonic, list<Trait> traits = []> :
+    Op<Tuple_Dialect, mnemonic, traits> {
+}
+
+def Tuple_FromElementsOp : Tuple_Op<"from_elements", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+    ]> {
+  let summary = "Builds a tuple from the given elements";
+  let description = [{
+    Returns a `tuple` with the elements assembled from the operands, i.e., the
+    elements of the returned `tuple` consist of the values provided as operands.
+
+    Example:
+
+    ```mlir
+    %0 = arith.constant 42 : i32
+    %tuple = tuple.from_elements %0, %0 : tuple<i32, i32>  // contains (42, 42)
+    ```
+  }];
+  let arguments = (ins Variadic<AnyType>:$elements);
+  let results = (outs AnyTuple:$tuple);
+  let assemblyFormat = [{
+    $elements attr-dict `:` qualified(type($tuple))
+    custom<TupleElementTypes>(type($elements), ref(type($tuple)))
+  }];
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    void $cppClass::getAsmResultNames(
+        llvm::function_ref<void(mlir::Value, llvm::StringRef)> setNameFn) {
+      setNameFn(getResult(), "tuple");
+    }
+  }];
+}
+
+def Tuple_ToElementsOp : Tuple_Op<"to_elements", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>
+    ]> {
+  let summary = "Produces all elements of a given tuple";
+  let description = [{
+    Produces one result value for each field of the provided tuple. Note that
+    this does not "flatten" the tuple, i.e., a tuple-typed element produces
+    exactly one result value, which may itself have zero, one, or more elements.
+
+    Example:
+
+    ```mlir
+    %0 = ...
+    %first_element, %second_element = tuple.to_elements %0 : tuple<i32, tuple<>>
+    // %first_element is a i32, %second_element is a tuple<>
+    ```
+  }];
+  let arguments = (ins AnyTuple:$tuple);
+  let results = (outs Variadic<AnyType>:$elements);
+  let assemblyFormat = [{
+    $tuple attr-dict `:` qualified(type($tuple))
+    custom<TupleElementTypes>(type($elements), ref(type($tuple)))
+  }];
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    void $cppClass::getAsmResultNames(
+        llvm::function_ref<void(mlir::Value, llvm::StringRef)> setNameFn) {
+      if (getNumResults() > 0)
+        setNameFn(getResult(0), "elements");
+    }
+  }];
+}
+
+#endif // TUPLE_IR_TUPLEOPS

--- a/experimental/iterators/lib/CAPI/CMakeLists.txt
+++ b/experimental/iterators/lib/CAPI/CMakeLists.txt
@@ -8,6 +8,7 @@ add_mlir_public_c_api_library(IteratorsCAPI
     MLIRIteratorsTransforms
     MLIRTabular
     MLIRTabularToLLVM
+    MLIRTupleDialect
     MLIRPass
     MLIRStatesToLLVM
 )

--- a/experimental/iterators/lib/CAPI/Dialects.cpp
+++ b/experimental/iterators/lib/CAPI/Dialects.cpp
@@ -10,6 +10,7 @@
 
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
 #include "iterators/Dialect/Tabular/IR/Tabular.h"
+#include "iterators/Dialect/Tuple/IR/Tuple.h"
 #include "mlir-c/IR.h"
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
@@ -22,6 +23,7 @@
 
 using namespace mlir;
 using namespace mlir::iterators;
+using namespace mlir::tuple;
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Iterators, iterators, IteratorsDialect)
 
@@ -68,3 +70,9 @@ MlirType mlirTabularViewTypeGetColumnType(MlirType type, intptr_t pos) {
 MlirType mlirTabularViewTypeGetRowType(MlirType type) {
   return wrap(unwrap(type).cast<TabularViewType>().getRowType());
 }
+
+//===----------------------------------------------------------------------===//
+// Tuple dialect and attributes
+//===----------------------------------------------------------------------===//
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Tuple, tuple, TupleDialect)

--- a/experimental/iterators/lib/Dialect/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialect/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Iterators)
 add_subdirectory(Tabular)
+add_subdirectory(Tuple)

--- a/experimental/iterators/lib/Dialect/Tuple/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialect/Tuple/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/experimental/iterators/lib/Dialect/Tuple/IR/CMakeLists.txt
+++ b/experimental/iterators/lib/Dialect/Tuple/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_mlir_library(MLIRTupleDialect
+  Tuple.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+
+  DEPENDS
+  MLIRTupleOpsIncGen
+)

--- a/experimental/iterators/lib/Dialect/Tuple/IR/Tuple.cpp
+++ b/experimental/iterators/lib/Dialect/Tuple/IR/Tuple.cpp
@@ -1,0 +1,73 @@
+//===-- Tuple.cpp - Tuple dialect -------------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Dialect/Tuple/IR/Tuple.h"
+
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/InliningUtils.h"
+
+using namespace mlir;
+using namespace mlir::tuple;
+
+//===----------------------------------------------------------------------===//
+// Tuple dialect.
+//===----------------------------------------------------------------------===//
+
+#include "iterators/Dialect/Tuple/IR/TupleOpsDialect.cpp.inc"
+
+namespace {
+/// This class defines the interface for handling inlining for tuple dialect
+/// operations.
+struct TupleInlinerInterface : public DialectInlinerInterface {
+  using DialectInlinerInterface::DialectInlinerInterface;
+
+  /// All Tuple dialect ops can be inlined.
+  bool isLegalToInline(Operation *, Region *, bool, IRMapping &) const final {
+    return true;
+  }
+};
+} // namespace
+
+void TupleDialect::initialize() {
+#define GET_OP_LIST
+  addOperations<
+#include "iterators/Dialect/Tuple/IR/TupleOps.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "iterators/Dialect/Tuple/IR/TupleOpsTypes.cpp.inc"
+      >();
+  addInterfaces<TupleInlinerInterface>();
+}
+
+//===----------------------------------------------------------------------===//
+// Tuple operations.
+//===----------------------------------------------------------------------===//
+
+static ParseResult parseTupleElementTypes(AsmParser &parser,
+                                          SmallVectorImpl<Type> &elementsTypes,
+                                          Type type) {
+  assert(type.isa<TupleType>());
+  auto tupleType = type.cast<TupleType>();
+  elementsTypes.append(tupleType.begin(), tupleType.end());
+  return success();
+}
+
+static void printTupleElementTypes(AsmPrinter &printer, Operation *op,
+                                   TypeRange elementsTypes, Type tupleType) {}
+
+#define GET_OP_CLASSES
+#include "iterators/Dialect/Tuple/IR/TupleOps.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// Tuple types.
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "iterators/Dialect/Tuple/IR/TupleOpsTypes.cpp.inc"

--- a/experimental/iterators/python/CMakeLists.txt
+++ b/experimental/iterators/python/CMakeLists.txt
@@ -29,6 +29,15 @@ declare_mlir_dialect_python_bindings(
   DIALECT_NAME tabular
 )
 
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT IteratorsPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_iterators"
+  TD_FILE dialects/TupleOps.td
+  SOURCES
+  dialects/tuple.py
+  DIALECT_NAME tuple
+)
+
 declare_mlir_python_extension(IteratorsPythonSources.DialectExtension
   MODULE_NAME _iteratorsDialects
   ADD_TO_PARENT IteratorsPythonSources

--- a/experimental/iterators/python/IteratorsDialects.cpp
+++ b/experimental/iterators/python/IteratorsDialects.cpp
@@ -12,6 +12,7 @@
 #include <initializer_list>
 
 #include "iterators-c/Dialects.h"
+#include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/IR.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 
@@ -96,4 +97,24 @@ PYBIND11_MODULE(_iteratorsDialects, mainModule) {
       .def("get_column_type", mlirTabularViewTypeGetColumnType, py::arg("pos"))
       .def("get_num_column_types", mlirTabularViewTypeGetNumColumnTypes)
       .def("get_row_type", mlirTabularViewTypeGetRowType);
+
+  //===--------------------------------------------------------------------===//
+  // Tuple dialect.
+  //===--------------------------------------------------------------------===//
+  auto tupleModule = mainModule.def_submodule("tuple");
+
+  //
+  // Dialect
+  //
+
+  tupleModule.def(
+      "register_dialect",
+      [](MlirContext context, bool doLoad) {
+        MlirDialectHandle handle = mlirGetDialectHandle__tuple__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (doLoad) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context") = py::none(), py::arg("load") = true);
 }

--- a/experimental/iterators/python/mlir_iterators/dialects/TupleOps.td
+++ b/experimental/iterators/python/mlir_iterators/dialects/TupleOps.td
@@ -1,0 +1,13 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYTHON_BINDINGS_TUPLE_OPS
+#define PYTHON_BINDINGS_TUPLE_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "iterators/Dialect/Tuple/IR/TupleOps.td"
+
+#endif // PYTHON_BINDINGS_TUPLE_OPS

--- a/experimental/iterators/python/mlir_iterators/dialects/tuple.py
+++ b/experimental/iterators/python/mlir_iterators/dialects/tuple.py
@@ -1,0 +1,9 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._tuple_ops_gen import *
+from .._mlir_libs._iteratorsDialects.tuple import *
+from .._mlir_libs import _mlirIteratorsPasses as _cextIteratorsPasses

--- a/experimental/iterators/test/Dialect/Tuple/from-elements.mlir
+++ b/experimental/iterators/test/Dialect/Tuple/from-elements.mlir
@@ -1,0 +1,18 @@
+// RUN: iterators-opt %s | iterators-opt | FileCheck %s
+
+// CHECK-LABEL: func.func @from_elements_i32(
+// CHECK-SAME:                               %[[ARG0:.*]]: i32) -> tuple<i32> {
+// CHECK-NEXT:    %[[V0:tuple.*]] = tuple.from_elements %[[ARG0]] : tuple<i32>
+// CHECK-NEXT:    return %[[V0]] : tuple<i32>
+func.func @from_elements_i32(%arg0 : i32) -> tuple<i32> {
+  %tuple = tuple.from_elements %arg0 : tuple<i32>
+  return %tuple : tuple<i32>
+}
+
+// CHECK-LABEL: func.func @from_elements_empty() -> tuple<> {
+// CHECK-NEXT:    %[[V0:tuple.*]] = tuple.from_elements : tuple<>
+// CHECK-NEXT:    return %[[V0]] : tuple<>
+func.func @from_elements_empty() -> tuple<> {
+  %tuple = tuple.from_elements : tuple<>
+  return %tuple : tuple<>
+}

--- a/experimental/iterators/test/Dialect/Tuple/to-elements.mlir
+++ b/experimental/iterators/test/Dialect/Tuple/to-elements.mlir
@@ -1,0 +1,19 @@
+// RUN: iterators-opt %s | iterators-opt | FileCheck %s
+
+// CHECK-LABEL: func.func @to_elements_i32(
+// CHECK-SAME:                             %[[ARG0:.*]]: tuple<i32>) -> i32 {
+// CHECK-NEXT:    %[[V0:elements.*]] = tuple.to_elements %[[ARG0]] : tuple<i32>
+// CHECK-NEXT:    return %[[V0]] : i32
+func.func @to_elements_i32(%arg0 : tuple<i32>) -> i32 {
+  %elements = tuple.to_elements %arg0 : tuple<i32>
+  return %elements : i32
+}
+
+// CHECK-LABEL: func.func @to_elements_empty(
+// CHECK-SAME:                               %[[ARG0:.*]]: tuple<>) {
+// CHECK-NEXT:    tuple.to_elements %[[ARG0]] : tuple<>
+// CHECK-NEXT:    return
+func.func @to_elements_empty(%arg0 : tuple<>) {
+  tuple.to_elements %arg0 : tuple<>
+  return
+}

--- a/experimental/iterators/test/python/dialects/tuple/dialect.py
+++ b/experimental/iterators/test/python/dialects/tuple/dialect.py
@@ -1,0 +1,24 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir_iterators.dialects import tuple as tup
+from mlir_iterators.ir import (
+    Context,
+    Location,
+    Module,
+)
+
+
+def run(f):
+  print("\nTEST:", f.__name__)
+  with Context(), Location.unknown():
+    tup.register_dialect()
+    f()
+  return f
+
+
+# CHECK-LABEL: TEST: testParse
+@run
+def testParse():
+  mod = Module.parse('tuple.from_elements : tuple<>')
+  # CHECK:      %tuple = tuple.from_elements  : tuple<>
+  print(mod)

--- a/experimental/iterators/tools/iterators-lsp-server/CMakeLists.txt
+++ b/experimental/iterators/tools/iterators-lsp-server/CMakeLists.txt
@@ -9,6 +9,7 @@ add_dependencies(iterators-tools iterators-lsp-server)
 list(APPEND dialect_libs
   MLIRIterators
   MLIRTabular
+  MLIRTupleDialect
   )
 list(APPEND conversion_libs
   MLIRIteratorsToLLVM

--- a/experimental/iterators/tools/iterators-lsp-server/iterators-lsp-server.cpp
+++ b/experimental/iterators/tools/iterators-lsp-server/iterators-lsp-server.cpp
@@ -18,6 +18,7 @@
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
 #include "iterators/Dialect/Iterators/Transforms/Passes.h"
 #include "iterators/Dialect/Tabular/IR/Tabular.h"
+#include "iterators/Dialect/Tuple/IR/Tuple.h"
 #include "mlir/IR/DialectRegistry.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
@@ -30,7 +31,8 @@ static void registerIteratorDialects(DialectRegistry &registry) {
   registry.insert<
       // clang-format off
       mlir::iterators::IteratorsDialect,
-      mlir::iterators::TabularDialect
+      mlir::iterators::TabularDialect,
+      mlir::tuple::TupleDialect
       // clang-format on
       >();
 }

--- a/experimental/iterators/tools/iterators-opt/CMakeLists.txt
+++ b/experimental/iterators/tools/iterators-opt/CMakeLists.txt
@@ -9,6 +9,7 @@ add_dependencies(iterators-tools iterators-opt)
 list(APPEND dialect_libs
   MLIRIterators
   MLIRTabular
+  MLIRTupleDialect
   )
 list(APPEND conversion_libs
   MLIRIteratorsToLLVM

--- a/experimental/iterators/tools/iterators-opt/iterators-opt.cpp
+++ b/experimental/iterators/tools/iterators-opt/iterators-opt.cpp
@@ -15,6 +15,7 @@
 #include "iterators/Dialect/Iterators/IR/Iterators.h"
 #include "iterators/Dialect/Iterators/Transforms/Passes.h"
 #include "iterators/Dialect/Tabular/IR/Tabular.h"
+#include "iterators/Dialect/Tuple/IR/Tuple.h"
 #include "mlir/IR/Dialect.h"
 #include "mlir/InitAllDialects.h"
 #include "mlir/InitAllPasses.h"
@@ -30,7 +31,8 @@ static void registerIteratorDialects(DialectRegistry &registry) {
   registry.insert<
       // clang-format off
       mlir::iterators::IteratorsDialect,
-      mlir::iterators::TabularDialect
+      mlir::iterators::TabularDialect,
+      mlir::tuple::TupleDialect
       // clang-format on
       >();
 }


### PR DESCRIPTION
This commit introduces a dialect around the builtin tuple type for manipulating tuple values similar to how the complex and tensor dialects provide ops for dealing with values of those types. We will use this dialect as a data type for iterators that return "several values". We currently do that using LLVM structs, which maily limits the types we can use as elements but also composes badly with other passes like bufferization.

- [x] Write description of dialect, ops, and attributes.