### PR TITLE
[Iterators] Fix getOrCreateGlobalString for single-element Twines.

### DIFF
--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -102,12 +102,14 @@ static Value getOrCreateGlobalString(OpBuilder &builder, Twine name,
   Type i64 = b.getI64Type();
 
   // Determine name of global.
-  llvm::SmallString<64> candidateName;
-  name.toStringRef(candidateName);
+  llvm::SmallString<64> candidateNameStorage;
+  StringRef candidateName = name.toStringRef(candidateNameStorage);
   if (makeUnique) {
     int64_t uniqueNumber = 0;
     while (module.lookupSymbol(candidateName)) {
-      (name + "." + Twine(uniqueNumber)).toStringRef(candidateName);
+      candidateNameStorage.clear();
+      candidateName =
+          (name + "." + Twine(uniqueNumber)).toStringRef(candidateNameStorage);
       uniqueNumber++;
     }
   }


### PR DESCRIPTION
I had previously misunderstood (and hence misused) Twine::ToStringRef. It fills the given SmallString *only if* the Twine isn't made from a single element. I was using that SmallString blindly, which breaks in the single-element case. Now, I differentiate between the SmallString as storage and a StringRef that points to the value.