### PR TITLE
[Iterators] Produce tuples instead of LLVMStructs in TabularViewToStreamOp.

### DIFF
--- a/experimental/iterators/include/iterators/Conversion/Passes.td
+++ b/experimental/iterators/include/iterators/Conversion/Passes.td
@@ -54,7 +54,8 @@ def ConvertIteratorsToLLVM : Pass<"convert-iterators-to-llvm", "ModuleOp"> {
   let dependentDialects = [
     "func::FuncDialect",
     "LLVM::LLVMDialect",
-    "scf::SCFDialect"
+    "scf::SCFDialect",
+    "tuple::TupleDialect"
   ];
 }
 

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -51,11 +51,6 @@ def Iterators_ConstantTupleOp : Iterators_Base_Op<"constanttuple",
   }];
 }
 
-def Iterators_PrintTupleOp : Iterators_Base_Op<"printtuple"> {
-  let summary = "Prints the elements of a tuple";
-  let arguments = (ins Iterators_NestedTupleOfPrintableTypes:$tuple);
-}
-
 def Iterators_PrintOp : Iterators_Base_Op<"print", [
     PredOpTrait<"only one of 'constant' and 'value' may be set",
       CPred<[{($constant.empty() || !llvm::cast<PrintOp>($_op).getValue())}]>>

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsOps.td
@@ -333,33 +333,28 @@ def Iterators_ReduceOp : Iterators_Op<"reduce",
   }];
 }
 
-def Iterators_TabularViewToStreamOp : Iterators_Op<"tabular_view_to_stream",
-    [TypesMatchWith<"element type of input stream must match result type",
-                    "result", "input",
-                    "TabularViewType::get("
-                    "    $_self.getContext(),"
-                    "    $_self.cast<StreamType>().getElementType()"
-                    "          .cast<LLVM::LLVMStructType>().getBody())">,
-     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
-  // TODO(ingomueller): Get rid of the LLVM dependency after designing a row
-  //                    type or similar.
-  let summary = "Extracts the tuples from a tabular view as LLVM structs";
+def Iterators_TabularViewToStreamOp : Iterators_Op<"tabular_view_to_stream", [
+    TypesMatchWith<"element type of input stream must match result type",
+                   "result", "input",
+                   "TabularViewType::get("
+                   "    $_self.getContext(),"
+                   "    $_self.cast<StreamType>().getElementType()"
+                   "          .cast<TupleType>().getTypes())">,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getAsmResultNames"]>]> {
+  let summary = "Extracts the tuples from a tabular view one at a time";
   let description = [{
-    Produces a stream of LLVM structs from a given `tabular_view` (i.e., "scans"
-    the given `tabular_view`). Each LLVM struct represents one row, and the op
+    Produces a stream of built-in tuples from a given `tabular_view` (i.e.,
+    "scans" the given `tabular_view`). Each tuple represents one row, and the op
     produces all rows in ascending order.
-
-    The current dependency on LLVM is not elegant and only a temporary solution
-    before we get a more high-level `row` type or similar.
 
     Example:
     ```mlir
     %fromtabview = iterators.tabular_view_to_stream %view
-                       to !iterators.stream<!llvm.struct<(!t1, ..., !tn)>>
+                       to !iterators.stream<tuple!t1, ..., !tn>>
     ```
   }];
   let arguments = (ins Tabular_TabularView:$input);
-  let results = (outs Iterators_StreamOfLLVMStructOfNumerics:$result);
+  let results = (outs Iterators_StreamOfPrintableTuples:$result);
   let assemblyFormat = "$input attr-dict `to` type($result)";
   let extraClassDefinition = [{
     /// Implement OpAsmOpInterface.

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -230,6 +230,10 @@ class Iterators_StreamOf<Type elementType>
 def Iterators_StreamOfLLVMStructOfNumerics
   : Iterators_StreamOf<Iterators_LLVMStructOfNumerics>;
 
+/// An Iterators stream of tuples of printable types.
+def Iterators_StreamOfPrintableTuples
+  : Iterators_StreamOf<Iterators_TupleOfPrintableTypes>;
+
 /// An Iterators stream of printable elements.
 def Iterators_StreamOfPrintableElements
   : Iterators_StreamOf<Iterators_PrintableType>;

--- a/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
+++ b/experimental/iterators/include/iterators/Dialect/Iterators/IR/IteratorsTypes.td
@@ -181,18 +181,24 @@ def Iterators_HomogeneouslyTypedLLVMNumericArrayArrayAttr
           "and where the inner arrays consist of numeric values">
       ]>;
 
-/// Any printable type.
-def Iterators_PrintableType : AnyTypeOf<[
+/// Printable type that can occur as a (nested) element type of printable tuples.
+def Iterators_PrintableElementType : AnyTypeOf<[
     Iterators_PrintableNumericType,
     Iterators_NestedLLVMStructOfNumerics
   ]>;
 
 /// A tuple consisting only of printable types.
-def Iterators_TupleOfPrintableTypes : TupleOf<[Iterators_PrintableType]>;
+def Iterators_TupleOfPrintableTypes : TupleOf<[Iterators_PrintableElementType]>;
 
 /// A potentially nested tuple consisting only of printable types.
 def Iterators_NestedTupleOfPrintableTypes
-  : NestedTupleOf<[Iterators_PrintableType]>;
+  : NestedTupleOf<[Iterators_PrintableElementType]>;
+
+/// Any printable type.
+def Iterators_PrintableType : AnyTypeOf<[
+    Iterators_PrintableElementType,
+    Iterators_NestedTupleOfPrintableTypes
+  ]>;
 
 //===----------------------------------------------------------------------===//
 // Streams (i.e., the data types passed between iterators).

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
@@ -15,4 +15,5 @@ add_mlir_conversion_library(MLIRIteratorsToLLVM
   MLIRSCFDialect
   MLIRTabularToLLVM
   MLIRTransforms
+  MLIRTupleDialect
 )

--- a/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
+++ b/experimental/iterators/lib/Conversion/IteratorsToLLVM/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_conversion_library(MLIRIteratorsToLLVM
   MLIRPass
   MLIRSCFDialect
   MLIRTabularToLLVM
+  MLIRTupleDialect
   MLIRTransforms
   MLIRTupleDialect
 )

--- a/experimental/iterators/lib/Conversion/PassDetail.h
+++ b/experimental/iterators/lib/Conversion/PassDetail.h
@@ -9,6 +9,7 @@
 #ifndef LIB_CONVERSION_PASSDETAIL_H
 #define LIB_CONVERSION_PASSDETAIL_H
 
+#include "iterators/Dialect/Tuple/IR/Tuple.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/printconstant.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/printconstant.mlir
@@ -7,28 +7,24 @@
 // CHECK-NEXT:   func.func @main() {
 func.func @main() {
   %empty_tuple = "iterators.constanttuple"() { values = [] } : () -> tuple<>
-  // CHECK-NEXT:     %[[V0:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S0:.*]]", ()>
+  // CHECK-NEXT:     %[[V0:.*]] = tuple.from_elements  : tuple<>
 
   %one_field_tuple = "iterators.constanttuple"() { values = [1 : i32] } : () -> tuple<i32>
-  // CHECK-NEXT:     %[[V1:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S1:.*]]", (i32)>
   // CHECK-NEXT:     %[[V2:.*]] = arith.constant 1 : i32
-  // CHECK-NEXT:     %[[V3:.*]] = llvm.insertvalue %[[V2]], %[[V1]][0] : !llvm.struct<"tuple[[S1]]", (i32)>
+  // CHECK-NEXT:     %[[V3:.*]] = tuple.from_elements %[[V2]] : tuple<i32>
 
-  "iterators.printtuple"(%one_field_tuple) : (tuple<i32>) -> ()
+  iterators.print(%one_field_tuple) : tuple<i32>
   // CHECK-DAG:      %[[V4:.*]] = llvm.mlir.addressof @iterators.frmt_spec{{(\.[0-9]+)?}} : !llvm.ptr
   // CHECK-DAG:      %[[V6:.*]] = llvm.getelementptr %[[V4]][0] : (!llvm.ptr) -> !llvm.ptr, i8
-  // CHECK-DAG:      %[[V7:.*]] = llvm.extractvalue %[[V3]][0] : !llvm.struct<"tuple[[S1]]", (i32)>
+  // CHECK-DAG:      %[[V7:.*]] = tuple.to_elements %[[V3]] : tuple<i32>
   // CHECK-DAG:      %[[Vb:.*]] = arith.extui %[[V7]] : i32 to i64
   // CHECK-NEXT:     %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[Vb]]) : (!llvm.ptr, i64) -> i32
 
   %three_field_tuple = "iterators.constanttuple"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
-  // CHECK-NEXT:     %[[V4:.*]] = llvm.mlir.undef : !llvm.struct<"tuple[[S2:.*]]", (i32, i32, i32)>
-  // CHECK-NEXT:     %[[V5:.*]] = arith.constant 1 : i32
-  // CHECK-NEXT:     %[[V6:.*]] = llvm.insertvalue %[[V5]], %[[V4]][0] : !llvm.struct<"tuple[[S2]]", (i32, i32, i32)>
-  // CHECK-NEXT:     %[[V7:.*]] = arith.constant 2 : i32
-  // CHECK-NEXT:     %[[V8:.*]] = llvm.insertvalue %[[V7]], %[[V6]][1] : !llvm.struct<"tuple[[S2]]", (i32, i32, i32)>
-  // CHECK-NEXT:     %[[V9:.*]] = arith.constant 3 : i32
-  // CHECK-NEXT:     %[[Va:.*]] = llvm.insertvalue %[[V9]], %[[V8]][2] : !llvm.struct<"tuple[[S2]]", (i32, i32, i32)>
+  // CHECK-DAG:      %[[V5:.*]] = arith.constant 1 : i32
+  // CHECK-DAG:      %[[V1:.*]] = arith.constant 2 : i32
+  // CHECK-DAG:      %[[V9:.*]] = arith.constant 3 : i32
+  // CHECK-NEXT:     %[[Va:.*]] = tuple.from_elements %[[V5]], %[[V1]], %[[V9]] : tuple<i32, i32, i32>
 
   return
   // CHECK-NEXT:     return

--- a/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Conversion/IteratorsToLLVM/tabular-view-to-stream.mlir
@@ -6,26 +6,26 @@
 // CHECK-NEXT:    return %[[arg0:.*]] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>
 // CHECK-NEXT:  }
 
-// CHECK-LABEL: func private @iterators.tabular_view_to_stream.next.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr)>>) -> (!iterators.state<i64, !llvm.struct<(i64, ptr)>>, i1, !llvm.struct<(i32)>)
+// CHECK-LABEL: func private @iterators.tabular_view_to_stream.next.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr)>>) -> (!iterators.state<i64, !llvm.struct<(i64, ptr)>>, i1, tuple<i32>)
 // CHECK-NEXT:    %[[V0:.*]] = iterators.extractvalue %[[arg0:.*]][0] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>
 // CHECK-NEXT:    %[[V1:.*]] = iterators.extractvalue %[[arg0]][1] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>
 // CHECK-NEXT:    %[[V2:.*]] = llvm.extractvalue %[[V1]][0] : !llvm.struct<(i64, ptr)>
 // CHECK-NEXT:    %[[V3:.*]] = arith.cmpi slt, %[[V0]], %[[V2]] : i64
-// CHECK-NEXT:    %[[V4:.*]]:2 = scf.if %[[V3]] -> (!iterators.state<i64, !llvm.struct<(i64, ptr)>>, !llvm.struct<(i32)>) {
+// CHECK-NEXT:    %[[V4:.*]]:2 = scf.if %[[V3]] -> (!iterators.state<i64, !llvm.struct<(i64, ptr)>>, tuple<i32>) {
 // CHECK-NEXT:      %[[C1:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[V5:.*]] = arith.addi %[[V0]], %[[C1]] : i64
 // CHECK-NEXT:      %[[V6:.*]] = iterators.insertvalue %[[V5]] into %[[arg0]][0] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>
-// CHECK-NEXT:      %[[V7:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
 // CHECK-NEXT:      %[[V8:.*]] = llvm.extractvalue %[[V1]][1] : !llvm.struct<(i64, ptr)>
 // CHECK-NEXT:      %[[V9:.*]] = llvm.getelementptr %[[V8]][%[[V0]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
 // CHECK-NEXT:      %[[Va:.*]] = llvm.load %[[V9]] : !llvm.ptr -> i32
-// CHECK-NEXT:      %[[Vb:.*]] = llvm.insertvalue %[[Va]], %[[V7]][0] : !llvm.struct<(i32)>
-// CHECK-NEXT:      scf.yield %[[V6]], %[[Vb]] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>, !llvm.struct<(i32)>
+// CHECK-NEXT:      %[[Vb:.*]] = tuple.from_elements %[[Va]] : tuple<i32>
+// CHECK-NEXT:      scf.yield %[[V6]], %[[Vb]] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>, tuple<i32>
 // CHECK-NEXT:    } else {
-// CHECK-NEXT:      %[[V5:.*]] = llvm.mlir.undef : !llvm.struct<(i32)>
-// CHECK-NEXT:      scf.yield %[[arg0]], %[[V5]] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>, !llvm.struct<(i32)>
+// CHECK-NEXT:      %[[V5:.*]] = llvm.mlir.undef : i32
+// CHECK-NEXT:      %[[V7:.*]] = tuple.from_elements %[[V5]] : tuple<i32>
+// CHECK-NEXT:      scf.yield %[[arg0]], %[[V7]] : !iterators.state<i64, !llvm.struct<(i64, ptr)>>, tuple<i32>
 // CHECK-NEXT:    }
-// CHECK-NEXT:    return %[[V4]]#0, %[[V3]], %[[V4]]#1 : !iterators.state<i64, !llvm.struct<(i64, ptr)>>, i1, !llvm.struct<(i32)>
+// CHECK-NEXT:    return %[[V4]]#0, %[[V3]], %[[V4]]#1 : !iterators.state<i64, !llvm.struct<(i64, ptr)>>, i1, tuple<i32>
 // CHECK-NEXT:  }
 
 // CHECK-LABEL: func private @iterators.tabular_view_to_stream.open.{{[0-9]+}}(%{{.*}}: !iterators.state<i64, !llvm.struct<(i64, ptr)>>) -> !iterators.state<i64, !llvm.struct<(i64, ptr)>>
@@ -38,7 +38,7 @@ func.func @main(%input : !tabular.tabular_view<i32>) {
 // CHECK-LABEL:  func.func @main(
 // CHECK-SAME:      %[[arg0:.*]]: [[tabularViewType:.*]]) {
   %stream = iterators.tabular_view_to_stream %input
-                to !iterators.stream<!llvm.struct<(i32)>>
+                to !iterators.stream<tuple<i32>>
   // CHECK-NEXT:   %[[V1:.*]] = arith.constant 0 : i64
   // CHECK-NEXT:   %[[V2:.*]] = iterators.createstate(%[[V1]], %[[arg0]]) : !iterators.state<i64, [[tabularViewType]]>
   return

--- a/experimental/iterators/test/Dialect/Iterators/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Dialect/Iterators/tabular-view-to-stream.mlir
@@ -4,8 +4,8 @@
 func.func @main(%input : !tabular.tabular_view<i32>) {
   // CHECK-LABEL: func.func @main(%{{arg.*}}: !tabular.tabular_view<i32>) {
   %stream = iterators.tabular_view_to_stream %input
-                to !iterators.stream<!llvm.struct<(i32)>>
-// CHECK-NEXT:    %[[V0:fromtabview.*]] = iterators.tabular_view_to_stream %[[arg0:.*]] to !iterators.stream<!llvm.struct<(i32)>>
+                to !iterators.stream<tuple<i32>>
+// CHECK-NEXT:    %[[V0:fromtabview.*]] = iterators.tabular_view_to_stream %[[arg0:.*]] to !iterators.stream<tuple<i32>>
   return
 // CHECK-NEXT:    return
 }

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/print.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/print.mlir
@@ -1,9 +1,12 @@
-// RUN: iterators-opt %s -convert-iterators-to-llvm -cse -convert-func-to-llvm | \
+// RUN: iterators-opt %s \
+// RUN:   -convert-iterators-to-llvm \
+// RUN:   -decompose-tuples \
+// RUN:   -cse -convert-func-to-llvm | \
 // RUN: mlir-cpu-runner -e main -entry-point-result=void \
 // RUN: | FileCheck %s
 
 func.func @print_empty_tuple(%tuple : tuple<>) -> () {
-  "iterators.printtuple"(%tuple) : (tuple<>) -> ()
+  iterators.print(%tuple) : tuple<>
   return
 }
 
@@ -30,24 +33,24 @@ func.func @main() {
   iterators.print()
 
   %empty_tuple = "iterators.constanttuple"() { values = [] } : () -> tuple<>
-  "iterators.printtuple"(%empty_tuple) : (tuple<>) -> ()
+  iterators.print(%empty_tuple) : tuple<>
   // CHECK:      ()
 
   func.call @print_empty_tuple(%empty_tuple) : (tuple<>) -> ()
   // CHECK-NEXT: ()
 
   %one_field_tuple = "iterators.constanttuple"() { values = [1 : i32] } : () -> tuple<i32>
-  "iterators.printtuple"(%one_field_tuple) : (tuple<i32>) -> ()
+  iterators.print(%one_field_tuple) : tuple<i32>
   // CHECK-NEXT: (1)
 
   %three_field_tuple = "iterators.constanttuple"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
-  "iterators.printtuple"(%three_field_tuple) : (tuple<i32, i32, i32>) -> ()
+  iterators.print(%three_field_tuple) : tuple<i32, i32, i32>
   // CHECK-NEXT: (1, 2, 3)
 
   %mixed_field_tuple = "iterators.constanttuple"()
       { values = [1 : i1, 2 : i8, 3 : i16, 4 : i32, 5 : i64, 8.5 : f16, 8.25 : f32, 8.125 : f64] }
       : () -> tuple<i1, i8, i16, i32, i64, f16, f32, f64>
-  "iterators.printtuple"(%mixed_field_tuple) : (tuple<i1, i8, i16, i32, i64, f16, f32, f64>) -> ()
+  iterators.print(%mixed_field_tuple) : tuple<i1, i8, i16, i32, i64, f16, f32, f64>
   // CHECK-NEXT: (1, 2, 3, 4, 5, 8.5, 8.25, 8.125)
 
   %i1 = arith.constant false

--- a/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
+++ b/experimental/iterators/test/Integration/Dialect/Iterators/CPU/tabular-view-to-stream.mlir
@@ -2,6 +2,7 @@
 // RUN:   -convert-tabular-to-llvm \
 // RUN:   -convert-iterators-to-llvm \
 // RUN:   -decompose-iterator-states \
+// RUN:   -decompose-tuples \
 // RUN:   -arith-bufferize -cse \
 // RUN:   -expand-strided-metadata \
 // RUN:   -finalize-memref-to-llvm \
@@ -10,8 +11,6 @@
 // RUN:   -convert-scf-to-cf -convert-cf-to-llvm \
 // RUN: | mlir-cpu-runner -e main -entry-point-result=void \
 // RUN: | FileCheck %s
-
-!struct_type = !llvm.struct<(i32,i64)>
 
 func.func @single_block() {
   iterators.print("single_block")
@@ -22,8 +21,8 @@ func.func @single_block() {
   %view = "tabular.view_as_tabular"(%m1, %m2)
     : (memref<3xi32>, memref<3xi64>) -> !tabular.tabular_view<i32,i64>
   %stream = iterators.tabular_view_to_stream %view
-    to !iterators.stream<!struct_type>
-  "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
+    to !iterators.stream<tuple<i32, i64>>
+  "iterators.sink"(%stream) : (!iterators.stream<tuple<i32, i64>>) -> ()
   // CHECK-LABEL: single_block
   // CHECK-NEXT:  (0, 3)
   // CHECK-NEXT:  (1, 4)
@@ -34,8 +33,8 @@ func.func @single_block() {
 
 func.func @query(%view : !tabular.tabular_view<i32,i64>) {
   %stream = iterators.tabular_view_to_stream %view
-    to !iterators.stream<!struct_type>
-  "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
+    to !iterators.stream<tuple<i32, i64>>
+  "iterators.sink"(%stream) : (!iterators.stream<tuple<i32, i64>>) -> ()
   return
 }
 

--- a/experimental/iterators/test/python/dialects/iterators/dialect.py
+++ b/experimental/iterators/test/python/dialects/iterators/dialect.py
@@ -97,18 +97,18 @@ def testEndToEndStandalone():
 def testEndToEndWithInput():
   # Set up module that reads data from the outside.
   mod = Module.parse('''
-      !struct_type = !llvm.struct<(i32,i64)>
-      func.func @main(%input: !tabular.tabular_view<i32,i64>)
+      func.func @main(%input: !tabular.tabular_view<i32, i64>)
           attributes { llvm.emit_c_interface } {
         %stream = iterators.tabular_view_to_stream %input
-          to !iterators.stream<!struct_type>
-        "iterators.sink"(%stream) : (!iterators.stream<!struct_type>) -> ()
+          to !iterators.stream<tuple<i32, i64>>
+        "iterators.sink"(%stream) : (!iterators.stream<tuple<i32, i64>>) -> ()
         return
       }
       ''')
   pm = PassManager.parse('builtin.module('
                          'convert-iterators-to-llvm,'
                          'decompose-iterator-states,'
+                         'decompose-tuples,'
                          'expand-strided-metadata,'
                          'finalize-memref-to-llvm,'
                          'convert-func-to-llvm,'


### PR DESCRIPTION
This PR depends on and therefor include #670.