### PR TITLE
[Iterators] Do not canonicalize in pipeline used in python tests.

### DIFF
--- a/experimental/iterators/test/python/dialects/iterators/dialect.py
+++ b/experimental/iterators/test/python/dialects/iterators/dialect.py
@@ -83,7 +83,6 @@ def testEndToEndStandalone():
   pm = PassManager.parse('builtin.module('
                          'convert-iterators-to-llvm,'
                          'decompose-iterator-states,'
-                         'canonicalize,'
                          'convert-func-to-llvm,'
                          'convert-scf-to-cf,'
                          'convert-cf-to-llvm)')
@@ -110,7 +109,6 @@ def testEndToEndWithInput():
   pm = PassManager.parse('builtin.module('
                          'convert-iterators-to-llvm,'
                          'decompose-iterator-states,'
-                         'canonicalize,'
                          'expand-strided-metadata,'
                          'finalize-memref-to-llvm,'
                          'convert-func-to-llvm,'


### PR DESCRIPTION
This is a change I forgot to do in #646.