### PR TITLE
[Indexing] Add Python bindings for indexing dialect.

### DIFF
--- a/include/structured-c/Dialects.h
+++ b/include/structured-c/Dialects.h
@@ -17,6 +17,21 @@ extern "C" {
 #endif
 
 //===----------------------------------------------------------------------===//
+// Indexing dialect and types
+//===----------------------------------------------------------------------===//
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Indexing, indexing);
+
+MLIR_CAPI_EXPORTED bool mlirTypeIsAIndexingCustom(MlirType type);
+
+MLIR_CAPI_EXPORTED MlirType mlirIndexingCustomTypeGet(MlirContext ctx,
+                                                      MlirStringRef str);
+
+MLIR_CAPI_EXPORTED bool mlirIsATensorValue(MlirValue value);
+
+MLIR_CAPI_EXPORTED bool mlirIsAnArithValue(MlirValue value);
+
+//===----------------------------------------------------------------------===//
 // Iterators dialect and types
 //===----------------------------------------------------------------------===//
 

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_public_c_api_library(StructuredCAPI
     Passes.cpp
     Transforms.cpp
   LINK_LIBS PUBLIC
+    MLIRIndexing
     MLIRIterators
     MLIRIteratorsToLLVM
     MLIRIteratorsTransforms
@@ -12,4 +13,5 @@ add_mlir_public_c_api_library(StructuredCAPI
     MLIRTupleTransforms
     MLIRPass
     MLIRStatesToLLVM
+    MLIRCAPIIR
 )

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -12,19 +12,48 @@
 #include "mlir/CAPI/IR.h"
 #include "mlir/CAPI/Registration.h"
 #include "mlir/IR/Types.h"
+#include "structured/Dialect/Indexing/IR/Indexing.h"
 #include "structured/Dialect/Iterators/IR/Iterators.h"
 #include "structured/Dialect/Tabular/IR/Tabular.h"
 #include "structured/Dialect/Tuple/IR/Tuple.h"
 #include "llvm/ADT/StringRef.h"
+#include <mlir-c/BuiltinTypes.h>
+#include <mlir/CAPI/Support.h>
+
+using namespace mlir;
+using namespace mlir::indexing;
+using namespace mlir::iterators;
+using namespace mlir::tabular;
+using namespace mlir::tuple;
+
+//===----------------------------------------------------------------------===//
+// Indexing dialect and attributes
+//===----------------------------------------------------------------------===//
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Indexing, indexing, IndexingDialect)
+
+bool mlirTypeIsAIndexingCustom(MlirType type) {
+  return unwrap(type).isa<CustomType>();
+}
+
+MlirType mlirIndexingCustomTypeGet(MlirContext ctx, MlirStringRef str) {
+  return wrap(CustomType::get(unwrap(ctx), unwrap(str)));
+}
+
+bool mlirIsATensorValue(MlirValue value) {
+  return mlirTypeIsATensor(mlirValueGetType(value));
+}
+
+bool mlirIsAnArithValue(MlirValue value) {
+  MlirType type = mlirValueGetType(value);
+  return mlirTypeIsABF16(type) || mlirTypeIsAComplex(type) ||
+         mlirTypeIsAF16(type) || mlirTypeIsAF32(type) || mlirTypeIsAF64(type) ||
+         mlirTypeIsAInteger(type) || mlirTypeIsAIndex(type);
+}
 
 //===----------------------------------------------------------------------===//
 // Iterators dialect and types
 //===----------------------------------------------------------------------===//
-
-using namespace mlir;
-using namespace mlir::iterators;
-using namespace mlir::tabular;
-using namespace mlir::tuple;
 
 MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Iterators, iterators, IteratorsDialect)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,6 +14,15 @@ declare_mlir_python_sources(StructuredPythonSources.Dialects
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT StructuredPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
+  TD_FILE dialects/IndexingOps.td
+  SOURCES
+  dialects/indexing.py
+  DIALECT_NAME indexing
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT StructuredPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
   TD_FILE dialects/IteratorsOps.td
   SOURCES
   dialects/iterators.py

--- a/python/mlir_structured/dialects/IndexingOps.td
+++ b/python/mlir_structured/dialects/IndexingOps.td
@@ -1,0 +1,13 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYTHON_BINDINGS_INDEXING_OPS
+#define PYTHON_BINDINGS_INDEXING_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "structured/Dialect/Indexing/IR/IndexingOps.td"
+
+#endif // PYTHON_BINDINGS_INDEXING_OPS

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -1,0 +1,112 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+import re
+from typing import Union, Tuple
+
+from . import arith as arith_dialect
+from . import linalg
+from . import tensor as tensor_dialect
+# noinspection PyUnresolvedReferences
+from ._indexing_ops_gen import *
+from .linalg.opdsl.lang.emitter import _BodyBuilder, _is_floating_point_type, _is_integer_type, \
+  _is_index_type, _is_complex_type
+# noinspection PyUnresolvedReferences
+from .._mlir_libs import _mlirStructuredPasses as _cextStructuredPasses
+from .._mlir_libs._structuredDialects.indexing import *
+from ..ir import Value, Type, RankedTensorType, ShapedType, Operation, IndexType
+
+res_val_reg = re.compile(r"(%\w+) =")
+
+_body_builder = _BodyBuilder({}, {}, {})
+
+
+class Scalar(ArithValue):
+
+  def __str__(self):
+    s = res_val_reg.findall(super().__str__())
+    assert len(s) == 1
+    return f"Scalar({s[0]}, {self.type})"
+
+  def __add__(self, other) -> "Scalar":
+    return Scalar(_body_builder._binary_add(self, other))
+
+  def __sub__(self, other) -> "Scalar":
+    return Scalar(_body_builder._binary_sub(self, other))
+
+  def __mul__(self, other) -> "Scalar":
+    return Scalar(_body_builder._binary_mul(self, other))
+
+
+class Tensor(TensorValue):
+
+  def __str__(self):
+    s = res_val_reg.findall(super().__str__())
+    assert len(s) == 1
+    return f"Tensor({s[0]}, {self.type})"
+
+  @property
+  def _shaped_type(self) -> ShapedType:
+    return ShapedType(self.type)
+
+  @property
+  def shape(self) -> list[int]:
+    assert self._shaped_type.has_static_shape, "Only static shapes currently supported."
+    return self._shaped_type.shape
+
+  @property
+  def element_type(self) -> Type:
+    return self._shaped_type.element_type
+
+  @classmethod
+  def empty(cls, shape: Union[list[Union[int, Value]], tuple[Union[int, Value],
+                                                             ...]],
+            el_type: Type) -> "Tensor":
+
+    return cls(tensor_dialect.EmptyOp(shape, el_type).result)
+
+  def __class_getitem__(
+      cls, dim_sizes_el_type: Tuple[Union[list[int], tuple[int, ...]],
+                                    Type]) -> Type:
+    assert (len(dim_sizes_el_type) == 2
+           ), f"wrong dim_sizes_el_type: {dim_sizes_el_type}"
+    dim_sizes, el_type = dim_sizes_el_type
+    assert isinstance(el_type, Type), f"wrong type T args for tensor: {el_type}"
+    static_sizes = []
+    for s in dim_sizes:
+      if isinstance(s, int):
+        static_sizes.append(s)
+      else:
+        static_sizes.append(ShapedType.get_dynamic_size())
+    return RankedTensorType.get(static_sizes, el_type)
+
+  def __getitem__(self, dims: tuple) -> Scalar:
+    dims = list(dims)
+    for i, d in enumerate(dims):
+      if isinstance(d, int):
+        dims[i] = arith_dialect.ConstantOp.create_index(d).result
+
+    return Scalar(tensor_dialect.ExtractOp(self, dims).result)
+
+  @classmethod
+  def __binary_op(cls, op: str, lhs: "Tensor", rhs: "Tensor") -> "Tensor":
+    assert op in {"Add", "Sub", "Mul"}
+    assert lhs.element_type == rhs.element_type
+    assert lhs.shape == rhs.shape
+
+    if _is_floating_point_type(lhs.element_type):
+      return cls(getattr(arith_dialect, f"{op}FOp")(lhs, rhs).result)
+    if _is_integer_type(lhs.element_type) or _is_index_type(lhs.element_type):
+      return cls(getattr(arith_dialect, f"{op}IOp")(lhs, rhs).result)
+    raise NotImplementedError("Unsupported 'add' operands: {lhs}, {rhs}")
+
+  def __add__(self: "Tensor", rhs: "Tensor") -> "Tensor":
+    return self.__binary_op("Add", self, rhs)
+
+  def __sub__(self: "Tensor", rhs: "Tensor") -> "Tensor":
+    return self.__binary_op("Sub", self, rhs)
+
+  def __mul__(self: "Tensor", rhs: "Tensor") -> "Tensor":
+    return self.__binary_op("Mul", self, rhs)

--- a/python/mlir_structured/runtime/util.py
+++ b/python/mlir_structured/runtime/util.py
@@ -1,0 +1,21 @@
+import contextlib
+from typing import Optional
+
+from mlir_structured.ir import Context, Module, InsertionPoint, Location
+
+
+@contextlib.contextmanager
+def mlir_mod_ctx(src: Optional[str] = None,
+                 context: Context = None,
+                 location: Location = None):
+  if context is None:
+    context = Context()
+  if location is None:
+    location = Location.unknown()
+  with context, location:
+    if src is not None:
+      module = Module.parse(src)
+    else:
+      module = Module.create()
+    with InsertionPoint(module.body):
+      yield module

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -1,0 +1,114 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir_structured.dialects import indexing as idx
+from mlir_structured.dialects import func
+from mlir_structured.ir import Context, IntegerType, F32Type
+from mlir_structured.passmanager import PassManager
+from mlir_structured.runtime.util import mlir_mod_ctx
+
+
+def run(f):
+  print("\nTEST:", f.__name__)
+  with Context():
+    idx.register_dialect()
+    f()
+  return f
+
+
+# CHECK-LABEL: TEST: testArithValue
+@run
+def testArithValue():
+  i32 = IntegerType.get_signless(32)
+  with mlir_mod_ctx():
+    ten = idx.Tensor.empty([10, 10], i32)
+    # CHECK: %[[TEN:.*]] = tensor.empty() : tensor<10x10xi32>
+    print(ten.owner)
+    # CHECK: Tensor(%[[TEN]], tensor<10x10xi32>)
+    print(ten)
+
+    v = ten[0, 0]
+    # CHECK: %[[EXTRACTED:.*]] = tensor.extract %[[TEN]][%{{.*}}, %{{.*}}] : tensor<10x10xi32>
+    print(v.owner)
+    # CHECK: Scalar(%[[EXTRACTED]], i32)
+    print(v)
+
+    w = v + v
+    # CHECK: %[[ADDI:.*]] = arith.addi %[[EXTRACTED]], %[[EXTRACTED]] : i32
+    print(w.owner)
+    z = w * w
+    # CHECK: %[[MULI:.*]] = arith.muli %[[ADDI]], %[[ADDI]] : i32
+    print(z.owner)
+
+
+# CHECK-LABEL: TEST: testTensorType
+@run
+def testTensorType():
+  i32 = IntegerType.get_signless(32)
+  with mlir_mod_ctx():
+    tt = idx.Tensor[(10, 10), i32]
+    # CHECK: tensor<10x10xi32>
+    print(tt)
+
+    tt = idx.Tensor[(None, None), i32]
+    # CHECK: tensor<?x?xi32>
+    print(tt)
+
+    tt = idx.IndexTensorType.get([10, 10])
+    # CHECK: tensor<10x10xindex>
+    print(tt)
+
+
+# CHECK-LABEL: TEST: testTensorValue
+@run
+def testTensorValue():
+  i32 = IntegerType.get_signless(32)
+  with mlir_mod_ctx() as module:
+
+    @func.FuncOp.from_py_func()
+    def test_tensor_value():
+      ten = idx.Tensor.empty((10, 10), i32)
+      # CHECK: Tensor(%[[TEN:.*]], tensor<10x10xi32>)
+      print(ten)
+
+      twenty = ten + ten
+      # CHECK: %[[ADD:.*]] = "arith.addi"(%[[TEN]], %[[TEN]]) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x10xi32>
+      print(twenty.owner)
+
+      one_hundred = ten * ten
+      # CHECK: %[[MUL:.*]] = "arith.muli"(%[[TEN]], %[[TEN]]) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x10xi32>
+      print(one_hundred.owner)
+
+      return one_hundred
+
+  # CHECK: module {
+  # CHECK:   func.func @test_tensor_value() -> tensor<10x10xi32> {
+  # CHECK:     %[[TEN]] = tensor.empty() : tensor<10x10xi32>
+  # CHECK:     %[[ADD]] = arith.addi %[[TEN]], %[[TEN]] : tensor<10x10xi32>
+  # CHECK:     %[[MUL]] = arith.muli %[[TEN]], %[[TEN]] : tensor<10x10xi32>
+  # CHECK:     return %[[MUL]] : tensor<10x10xi32>
+  # CHECK:   }
+  # CHECK: }
+  print(module)
+
+  pm = PassManager.parse(
+      'builtin.module(func.func(convert-elementwise-to-linalg))')
+  pm.run(module.operation)
+
+  # CHECK: #map = affine_map<(d0, d1) -> (d0, d1)>
+  # CHECK: module {
+  # CHECK:   func.func @test_tensor_value() -> tensor<10x10xi32> {
+  # CHECK:     %{{.*}} = tensor.empty()
+  # CHECK:     %{{.*}} = linalg.generic
+  # CHECK:     ^bb0(%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i32):
+  # CHECK:       %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
+  # CHECK:       linalg.yield %{{.*}} : i32
+  # CHECK:     } -> tensor<10x10xi32>
+  # CHECK:     %{{.*}} = linalg.generic
+  # CHECK:     ^bb0(%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i32):
+  # CHECK:       %{{.*}} = arith.muli %{{.*}}, %{{.*}} : i32
+  # CHECK:       linalg.yield %{{.*}} : i32
+  # CHECK:     } -> tensor<10x10xi32>
+  # CHECK:     return %{{.*}} : tensor<10x10xi32>
+  # CHECK:   }
+  # CHECK: }
+  print(module)


### PR DESCRIPTION
Finally we arrive at being ready for some of the Python acrobatics. In particular, this PR adds Python bindings for a `mlir_value_subclass(..., TensorValue,...)` (using my recently upstream small [diff](https://reviews.llvm.org/D147758)) which is then used as a wrapper that maps native Python indexing to (currently) `tensor.extract`. The near-term grand plan is to route as much of `tensor.scatter` and `tensor.gather` semantics as possible through this API.

All comments/questions/concerns welcome and appreciated.

cc @kylechard

NB: In the previous PR I added a [short notebook](https://github.com/iree-org/iree-llvm-sandbox/blob/00babefe3abedd66d8a50e8be986c69e95bdcae4/examples/advanced-indexing.ipynb) that explains numpy's advanced indexing and its relation to `tensor.scatter`/`tensor.gather`. I will keep adding to that notebook as our API matures, but since there's no real addition to the API in this PR (I'm counting `tensor.extract` as too small to discuss), there's no change to that notebook here.

Edit: 

@nicolasvasilache @ingomueller-net 

I've added some code that sketches out "tensor-like" semantics on `tensor<...>` via pybinding. One choice I think we should discuss is whether we should map such operations to `linalg` or `arith` (or both). For example, I think it's reasonable that operations on tensors of data (i.e. `tensor<...xf32>`) should be expressed in terms of `linalg` as such:

```python
    ten = idx.Tensor.empty([10, 10], f32)
    twenty = ten + ten
    one_hundred = ten * ten
```

mapping to

```mlir
  %0 = tensor.empty() : tensor<10x10xf32>
  %1 = tensor.empty() : tensor<10x10xf32>
  %2 = linalg.elemwise_binary {cast = #linalg.type_fn<cast_signed>, fun = #linalg.binary_fn<add>} ins(%0, %0 : tensor<10x10xf32>, tensor<10x10xf32>) outs(%1 : tensor<10x10xf32>) -> tensor<10x10xf32>
  %3 = tensor.empty() : tensor<10x10xf32>
  %4 = linalg.elemwise_binary {cast = #linalg.type_fn<cast_signed>, fun = #linalg.binary_fn<mul>} ins(%0, %0 : tensor<10x10xf32>, tensor<10x10xf32>) outs(%3 : tensor<10x10xf32>) -> tensor<10x10xf32>
```

On the other hand it might be useful to map "index tensors" (i.e., tensor of indices) directly to `arith` as such:

```python
    ten = idx.IndexTensor.empty([10, 10])
    twenty = ten + ten
    one_hundred = ten * ten
```

mapping to

```mlir
  %0 = tensor.empty() : tensor<10x10xindex>
  %1 = arith.addi %0, %0 : tensor<10x10xindex>
  %2 = arith.muli %0, %0 : tensor<10x10xindex>
```

My thinking there is that index arithmetic should be treated distinctly/separately from tensor-of-data operations (maybe making constant-folding simpler).
