### PR TITLE
[Triton][NO-MERGE] Add Triton as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "experimental/iterators/third_party/llvm-project"]
 	path = third_party/llvm-project
 	url = https://github.com/llvm/llvm-project.git
+[submodule "third_party/triton"]
+	path = third_party/triton
+	url = git@github.com:openai/triton.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,24 @@ include(AddLLVM)
 include(AddMLIR)
 
 ################################################################################
+# Add Triton as an external project
+################################################################################
+
+list(APPEND LLVM_EXTERNAL_PROJECTS triton)
+list(REMOVE_DUPLICATES LLVM_EXTERNAL_PROJECTS)
+set(LLVM_EXTERNAL_TRITON_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/triton CACHE STRING "" FORCE)
+set(LLVM_EXTERNAL_PROJECTS ${LLVM_EXTERNAL_PROJECTS} CACHE STRING "" FORCE)
+message("-- Applying the patch ${CMAKE_CURRENT_SOURCE_DIR}/triton.patch")
+execute_process(COMMAND
+        git apply --verbose --allow-empty ${CMAKE_CURRENT_SOURCE_DIR}/triton.patch
+        WORKING_DIRECTORY ${LLVM_EXTERNAL_TRITON_SOURCE_DIR}
+        OUTPUT_VARIABLE GIT_APPLY
+        RESULT_VARIABLE GIT_APPLY
+        ERROR_VARIABLE GIT_APPLY)
+message(WARNING "GIT_APPLY ${GIT_APPLY}")
+add_subdirectory(${LLVM_EXTERNAL_TRITON_SOURCE_DIR})
+
+################################################################################
 # Subdirs to recurse into
 ################################################################################
 add_custom_target(structured-all)

--- a/include/structured-c/TritonDialects.h
+++ b/include/structured-c/TritonDialects.h
@@ -1,0 +1,29 @@
+//===- Dialects.h - CAPI for dialects -----------------------------*- C -*-===//
+//
+// This file is licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TRITON_C_DIALECTS_H
+#define TRITON_C_DIALECTS_H
+
+#include "mlir-c/IR.h"
+#include "mlir-c/Support.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//===----------------------------------------------------------------------===//
+// Triton dialect and attributes
+//===----------------------------------------------------------------------===//
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Triton, triton);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // TRITON_C_DIALECTS_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(CAPI)
+add_subdirectory(TritonCAPI)
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
 add_subdirectory(Utils)

--- a/lib/TritonCAPI/CMakeLists.txt
+++ b/lib/TritonCAPI/CMakeLists.txt
@@ -1,0 +1,9 @@
+include_directories(${triton_BINARY_DIR}/include)
+include_directories(${LLVM_EXTERNAL_TRITON_SOURCE_DIR}/include)
+
+add_mlir_public_c_api_library(TritonCAPI
+  Dialects.cpp
+
+  LINK_LIBS PUBLIC
+  TritonIR
+)

--- a/lib/TritonCAPI/Dialects.cpp
+++ b/lib/TritonCAPI/Dialects.cpp
@@ -1,0 +1,18 @@
+//===- Dialects.cpp - CAPI for dialects -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "structured-c/TritonDialects.h"
+
+#include "mlir-c/IR.h"
+#include "mlir/CAPI/IR.h"
+#include "mlir/CAPI/Registration.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+
+using namespace mlir::triton;
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Triton, triton, TritonDialect)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -45,6 +45,7 @@ declare_mlir_python_extension(StructuredPythonSources.DialectExtension
   StructuredDialects.cpp
   EMBED_CAPI_LINK_LIBS
   StructuredCAPI
+  TritonCAPI
 )
 
 declare_mlir_python_extension(StructuredPythonSources.PassesExtension
@@ -62,6 +63,8 @@ declare_mlir_python_sources(StructuredPythonSources.ExecutionEngine
   SOURCES_GLOB
     runtime/*.py
 )
+
+add_subdirectory(triton)
 
 # ###############################################################################
 # Common CAPI
@@ -96,3 +99,4 @@ add_mlir_python_modules(StructuredPythonModules
 )
 
 add_dependencies(structured-all StructuredPythonModules)
+

--- a/python/StructuredDialects.cpp
+++ b/python/StructuredDialects.cpp
@@ -15,6 +15,7 @@
 #include "mlir-c/IR.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 #include "structured-c/Dialects.h"
+#include "structured-c/TritonDialects.h"
 
 namespace py = pybind11;
 using namespace mlir::python::adaptors;
@@ -111,6 +112,26 @@ PYBIND11_MODULE(_structuredDialects, mainModule) {
       "register_dialect",
       [](MlirContext context, bool doLoad) {
         MlirDialectHandle handle = mlirGetDialectHandle__tuple__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (doLoad) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context") = py::none(), py::arg("load") = true);
+
+  //===--------------------------------------------------------------------===//
+  // Triton dialect.
+  //===--------------------------------------------------------------------===//
+  auto tritonModule = mainModule.def_submodule("triton");
+
+  //
+  // Dialect
+  //
+
+  tritonModule.def(
+      "register_dialect",
+      [](MlirContext context, bool doLoad) {
+        MlirDialectHandle handle = mlirGetDialectHandle__triton__();
         mlirDialectHandleRegisterDialect(handle, context);
         if (doLoad) {
           mlirDialectHandleLoadDialect(handle, context);

--- a/python/mlir_structured/dialects/TritonOps.td
+++ b/python/mlir_structured/dialects/TritonOps.td
@@ -1,0 +1,13 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYTHON_BINDINGS_TRITON_OPS
+#define PYTHON_BINDINGS_TRITON_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "triton/Dialect/Triton/IR/TritonOps.td"
+
+#endif // PYTHON_BINDINGS_TRITON_OPS

--- a/python/mlir_structured/dialects/triton.py
+++ b/python/mlir_structured/dialects/triton.py
@@ -1,0 +1,9 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._tt_ops_gen import *
+from .._mlir_libs._structuredDialects.triton import *
+from .._mlir_libs import _mlirStructuredPasses as _cextStructuredPasses

--- a/python/triton/CMakeLists.txt
+++ b/python/triton/CMakeLists.txt
@@ -1,0 +1,9 @@
+include_directories(${LLVM_EXTERNAL_TRITON_SOURCE_DIR}/include)
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT StructuredPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../mlir_structured"
+  TD_FILE dialects/TritonOps.td
+  SOURCES
+  dialects/triton.py
+  DIALECT_NAME tt
+)

--- a/test/python/dialects/triton/dialect.py
+++ b/test/python/dialects/triton/dialect.py
@@ -1,0 +1,30 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+import ctypes
+
+import pandas as pd
+import numpy as np
+
+from mlir_structured.dialects import triton as tt
+from mlir_structured.dialects import tensor
+from mlir_structured.passmanager import PassManager
+from mlir_structured.execution_engine import ExecutionEngine
+from mlir_structured.ir import Context, Module, IntegerType, RankedTensorType, Location
+
+
+def run(f):
+  print("\nTEST:", f.__name__)
+  with Context(), Location.unknown():
+    tt.register_dialect()
+    f()
+  return f
+
+
+# CHECK-LABEL: TEST: testMakeRangeOp
+@run
+def testMakeRangeOp():
+  i32 = IntegerType.get_signless(32)
+  tensor_type = RankedTensorType.get([10], i32)
+  r = tt.MakeRangeOp(tensor_type, 0, 10)
+  # CHECK: %{{.*}} = "tt.make_range"() {end = 10 : i32, start = 0 : i32} : () -> tensor<10xi32>
+  print(r)

--- a/triton.patch
+++ b/triton.patch
@@ -1,0 +1,697 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 1e79e9cbf..18d8fdedb 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -20,7 +20,7 @@ if(NOT WIN32)
+ endif()
+ 
+ # Options
+-option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" ON)
++option(TRITON_BUILD_TUTORIALS "Build C++ Triton tutorials" OFF)
+ option(TRITON_BUILD_PYTHON_MODULE "Build Python Triton bindings" OFF)
+ 
+ # Ensure Python3 vars are set correctly
+@@ -52,222 +52,222 @@ if(WIN32)
+   set(CMAKE_DL_LIBS dlfcn-win32::dl)
+ endif()
+ 
+-set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden")
++#set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -D__STDC_FORMAT_MACROS  -fPIC -std=gnu++17 -fvisibility=hidden -fvisibility-inlines-hidden")
+ 
+ if(APPLE)
+   set(CMAKE_OSX_DEPLOYMENT_TARGET 11.6)
+ endif()
+ 
+-# #########
+-# LLVM
+-# #########
+-if(NOT MLIR_DIR)
+-  if(NOT LLVM_LIBRARY_DIR)
+-    if(WIN32)
+-      find_package(LLVM 13 REQUIRED COMPONENTS nvptx amdgpu)
+-
+-      include_directories(${LLVM_INCLUDE_DIRS})
+-      separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
+-      add_definitions(${LLVM_DEFINITIONS_LIST})
+-
+-      llvm_map_components_to_libnames(LLVM_LIBRARIES support core
+-        NVPTXInfo nvptxcodegen
+-        AMDGPUInfo AMDGPUcodegen
+-      )
+-    else()
+-      find_package(LLVM 11 REQUIRED COMPONENTS "nvptx;amdgpu")
+-    endif()
+-
+-    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+-
+-    # FindLLVM outputs LLVM_LIBRARY_DIRS but we expect LLVM_LIBRARY_DIR here
+-    set(LLVM_LIBRARY_DIR ${LLVM_LIBRARY_DIRS})
+-
+-    if(APPLE)
+-      set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
+-    endif()
+-
+-  # sometimes we don't want to use llvm-config, since it may have been downloaded for some specific linux distros
+-  else()
+-    set(LLVM_LDFLAGS "-L${LLVM_LIBRARY_DIR}")
+-    set(LLVM_LIBRARIES
+-      libLLVMNVPTXCodeGen.a
+-      libLLVMNVPTXDesc.a
+-      libLLVMNVPTXInfo.a
+-      libLLVMAMDGPUDisassembler.a
+-      libLLVMMCDisassembler.a
+-      libLLVMAMDGPUCodeGen.a
+-      libLLVMMIRParser.a
+-      libLLVMGlobalISel.a
+-      libLLVMSelectionDAG.a
+-      libLLVMipo.a
+-      libLLVMInstrumentation.a
+-      libLLVMVectorize.a
+-      libLLVMLinker.a
+-      libLLVMIRReader.a
+-      libLLVMAsmParser.a
+-      libLLVMFrontendOpenMP.a
+-      libLLVMAsmPrinter.a
+-      libLLVMDebugInfoDWARF.a
+-      libLLVMCodeGen.a
+-      libLLVMTarget.a
+-      libLLVMScalarOpts.a
+-      libLLVMInstCombine.a
+-      libLLVMAggressiveInstCombine.a
+-      libLLVMTransformUtils.a
+-      libLLVMBitWriter.a
+-      libLLVMAnalysis.a
+-      libLLVMProfileData.a
+-      libLLVMObject.a
+-      libLLVMTextAPI.a
+-      libLLVMBitReader.a
+-      libLLVMAMDGPUAsmParser.a
+-      libLLVMMCParser.a
+-      libLLVMAMDGPUDesc.a
+-      libLLVMAMDGPUUtils.a
+-      libLLVMMC.a
+-      libLLVMDebugInfoCodeView.a
+-      libLLVMDebugInfoMSF.a
+-      libLLVMCore.a
+-      libLLVMRemarks.a
+-      libLLVMBitstreamReader.a
+-      libLLVMBinaryFormat.a
+-      libLLVMAMDGPUInfo.a
+-      libLLVMSupport.a
+-      libLLVMDemangle.a
+-      libLLVMPasses.a
+-      libLLVMAnalysis.a
+-      libLLVMTransformUtils.a
+-      libLLVMScalarOpts.a
+-      libLLVMTransformUtils.a
+-      libLLVMipo.a
+-      libLLVMObjCARCOpts.a
+-      libLLVMCoroutines.a
+-      libLLVMAnalysis.a
+-    )
+-  endif()
+-
+-  set(MLIR_DIR ${LLVM_LIBRARY_DIR}/cmake/mlir)
+-endif()
+-
+-# Python module
+-if(TRITON_BUILD_PYTHON_MODULE)
+-  message(STATUS "Adding Python module")
+-  set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
+-  set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc)
+-  include_directories("." ${PYTHON_SRC_PATH})
+-
+-  if(PYTHON_INCLUDE_DIRS)
+-    include_directories(${PYTHON_INCLUDE_DIRS})
+-  else()
+-    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
+-    include_directories(${Python3_INCLUDE_DIRS})
+-    link_directories(${Python3_LIBRARY_DIRS})
+-    link_libraries(${Python3_LIBRARIES})
+-    add_link_options(${Python3_LINK_OPTIONS})
+-  endif()
+-endif()
+-
+-# # Triton
+-# file(GLOB_RECURSE LIBTRITON_SRC lib/*.cc)
+-# if (WIN32 AND TRITON_BUILD_PYTHON_MODULE)
+-# Python3_add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
+-# set_target_properties(triton PROPERTIES SUFFIX ".pyd")
+-# set_target_properties(triton PROPERTIES PREFIX "lib")
+-# else()
+-# add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
+-# endif()
+-
+-# MLIR
+-find_package(MLIR REQUIRED CONFIG PATHS ${MLIR_DIR})
+-
+-list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
+-list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+-
+-include(TableGen) # required by AddMLIR
+-include(AddLLVM)
+-include(AddMLIR)
+-
+-# Disable warnings that show up in external code (gtest;pybind11)
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default")
+-
++### #########
++### LLVM
++### #########
++##if(0)
++##  if(0)
++##    if(WIN32)
++##      find_package(LLVM 13 REQUIRED COMPONENTS nvptx amdgpu)
++##
++##      include_directories(${LLVM_INCLUDE_DIRS})
++##      separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
++##      add_definitions(${LLVM_DEFINITIONS_LIST})
++##
++##      llvm_map_components_to_libnames(LLVM_LIBRARIES support core
++##        NVPTXInfo nvptxcodegen
++##        AMDGPUInfo AMDGPUcodegen
++##      )
++##    else()
++##      find_package(LLVM 11 REQUIRED COMPONENTS "nvptx;amdgpu")
++##    endif()
++##
++##    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
++##
++##    # FindLLVM outputs LLVM_LIBRARY_DIRS but we expect LLVM_LIBRARY_DIR here
++##    set(LLVM_LIBRARY_DIR ${LLVM_LIBRARY_DIRS})
++##
++##    if(APPLE)
++##      set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
++##    endif()
++##
++##  # sometimes we don't want to use llvm-config, since it may have been downloaded for some specific linux distros
++##  else()
++##    set(LLVM_LDFLAGS "-L${LLVM_LIBRARY_DIR}")
++##    set(LLVM_LIBRARIES
++##      libLLVMNVPTXCodeGen.a
++##      libLLVMNVPTXDesc.a
++##      libLLVMNVPTXInfo.a
++##      libLLVMAMDGPUDisassembler.a
++##      libLLVMMCDisassembler.a
++##      libLLVMAMDGPUCodeGen.a
++##      libLLVMMIRParser.a
++##      libLLVMGlobalISel.a
++##      libLLVMSelectionDAG.a
++##      libLLVMipo.a
++##      libLLVMInstrumentation.a
++##      libLLVMVectorize.a
++##      libLLVMLinker.a
++##      libLLVMIRReader.a
++##      libLLVMAsmParser.a
++##      libLLVMFrontendOpenMP.a
++##      libLLVMAsmPrinter.a
++##      libLLVMDebugInfoDWARF.a
++##      libLLVMCodeGen.a
++##      libLLVMTarget.a
++##      libLLVMScalarOpts.a
++##      libLLVMInstCombine.a
++##      libLLVMAggressiveInstCombine.a
++##      libLLVMTransformUtils.a
++##      libLLVMBitWriter.a
++##      libLLVMAnalysis.a
++##      libLLVMProfileData.a
++##      libLLVMObject.a
++##      libLLVMTextAPI.a
++##      libLLVMBitReader.a
++##      libLLVMAMDGPUAsmParser.a
++##      libLLVMMCParser.a
++##      libLLVMAMDGPUDesc.a
++##      libLLVMAMDGPUUtils.a
++##      libLLVMMC.a
++##      libLLVMDebugInfoCodeView.a
++##      libLLVMDebugInfoMSF.a
++##      libLLVMCore.a
++##      libLLVMRemarks.a
++##      libLLVMBitstreamReader.a
++##      libLLVMBinaryFormat.a
++##      libLLVMAMDGPUInfo.a
++##      libLLVMSupport.a
++##      libLLVMDemangle.a
++##      libLLVMPasses.a
++##      libLLVMAnalysis.a
++##      libLLVMTransformUtils.a
++##      libLLVMScalarOpts.a
++##      libLLVMTransformUtils.a
++##      libLLVMipo.a
++##      libLLVMObjCARCOpts.a
++##      libLLVMCoroutines.a
++##      libLLVMAnalysis.a
++##    )
++##  endif()
++##
++##  set(MLIR_DIR ${LLVM_LIBRARY_DIR}/cmake/mlir)
++##endif()
++##
++### Python module
++##if(TRITON_BUILD_PYTHON_MODULE)
++##  message(STATUS "Adding Python module")
++##  set(PYTHON_SRC_PATH ${CMAKE_CURRENT_SOURCE_DIR}/python/src)
++##  set(PYTHON_SRC ${PYTHON_SRC_PATH}/main.cc ${PYTHON_SRC_PATH}/triton.cc)
++##  include_directories("." ${PYTHON_SRC_PATH})
++##
++##  if(PYTHON_INCLUDE_DIRS)
++##    include_directories(${PYTHON_INCLUDE_DIRS})
++##  else()
++##    find_package(Python3 REQUIRED COMPONENTS Development Interpreter)
++##    include_directories(${Python3_INCLUDE_DIRS})
++##    link_directories(${Python3_LIBRARY_DIRS})
++##    link_libraries(${Python3_LIBRARIES})
++##    add_link_options(${Python3_LINK_OPTIONS})
++##  endif()
++##endif()
++#
++## # Triton
++## file(GLOB_RECURSE LIBTRITON_SRC lib/*.cc)
++## if (WIN32 AND TRITON_BUILD_PYTHON_MODULE)
++## Python3_add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
++## set_target_properties(triton PROPERTIES SUFFIX ".pyd")
++## set_target_properties(triton PROPERTIES PREFIX "lib")
++## else()
++## add_library(triton SHARED ${LIBTRITON_SRC} ${PYTHON_SRC})
++## endif()
++#
++## MLIR
++##find_package(MLIR REQUIRED CONFIG PATHS ${MLIR_DIR})
++##
++##list(APPEND CMAKE_MODULE_PATH "${MLIR_CMAKE_DIR}")
++##list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
++##
++##include(TableGen) # required by AddMLIR
++##include(AddLLVM)
++##include(AddMLIR)
++#
++## Disable warnings that show up in external code (gtest;pybind11)
++##set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wno-covered-switch-default")
++#
+ include_directories(${MLIR_INCLUDE_DIRS})
+ include_directories(${LLVM_INCLUDE_DIRS})
+ include_directories(${PROJECT_SOURCE_DIR}/include)
+ include_directories(${PROJECT_BINARY_DIR}/include) # Tablegen'd files
+ 
+ # link_directories(${LLVM_LIBRARY_DIR})
+-add_subdirectory(include)
+ add_subdirectory(lib)
+-add_subdirectory(bin)
+-
+-# find_package(PythonLibs REQUIRED)
+-set(TRITON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
+-set(TRITON_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+-
+-get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+-get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
+-
+-if(TRITON_BUILD_PYTHON_MODULE)
+-  add_library(triton SHARED ${PYTHON_SRC})
+-  set(TRITON_LIBRARIES
+-    TritonAnalysis
+-    TritonTransforms
+-    TritonGPUTransforms
+-    TritonLLVMIR
+-    TritonPTX
+-    TritonHSACO
+-    ${dialect_libs}
+-    ${conversion_libs}
+-
+-    # optimizations
+-    MLIRPass
+-    MLIRTransforms
+-    MLIRLLVMDialect
+-    MLIRSupport
+-    MLIRTargetLLVMIRExport
+-    MLIRExecutionEngine
+-    MLIRMathToLLVM
+-    MLIRNVVMToLLVMIRTranslation
+-    MLIRROCDLToLLVMIRTranslation
+-    MLIRIR
+-  )
+-
+-  if(WIN32)
+-    target_link_libraries(triton PRIVATE ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS}
+-      ${TRITON_LIBRARIES}
+-    )
+-  elseif(APPLE)
+-    target_link_libraries(triton ${LLVM_LIBRARIES} z
+-      ${TRITON_LIBRARIES}
+-    )
+-  else()
+-    target_link_libraries(triton ${LLVM_LIBRARIES} z
+-      ${TRITON_LIBRARIES}
+-    )
+-    # TODO: Figure out which target is sufficient to fix errors; triton is
+-    # apparently not enough
+-    link_libraries(stdc++fs)
+-  endif()
+-
+-  target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
+-endif()
+-
+-if(UNIX AND NOT APPLE)
+-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
+-endif()
+-
+-if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)
+-  set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+-
+-  # Check if the platform is MacOS
+-  if(APPLE)
+-    set(PYTHON_LDFLAGS "-undefined dynamic_lookup -flto")
+-  endif()
+-
+-  target_link_libraries(triton ${CUTLASS_LIBRARIES} ${PYTHON_LDFLAGS})
+-endif()
+-
+-add_subdirectory(test)
+-
+-add_subdirectory(unittest)
++add_subdirectory(include)
++#add_subdirectory(bin)
++#
++## find_package(PythonLibs REQUIRED)
++#set(TRITON_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
++#set(TRITON_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}")
++#
++#get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
++#get_property(conversion_libs GLOBAL PROPERTY MLIR_CONVERSION_LIBS)
++#
++##if(TRITON_BUILD_PYTHON_MODULE)
++##  add_library(triton SHARED ${PYTHON_SRC})
++##  set(TRITON_LIBRARIES
++##    TritonAnalysis
++##    TritonTransforms
++##    TritonGPUTransforms
++##    TritonLLVMIR
++##    TritonPTX
++##    TritonHSACO
++##    ${dialect_libs}
++##    ${conversion_libs}
++##
++##    # optimizations
++##    MLIRPass
++##    MLIRTransforms
++##    MLIRLLVMDialect
++##    MLIRSupport
++##    MLIRTargetLLVMIRExport
++##    MLIRExecutionEngine
++##    MLIRMathToLLVM
++##    MLIRNVVMToLLVMIRTranslation
++##    MLIRROCDLToLLVMIRTranslation
++##    MLIRIR
++##  )
++##
++##  if(WIN32)
++##    target_link_libraries(triton PRIVATE ${LLVM_LIBRARIES} ${CMAKE_DL_LIBS}
++##      ${TRITON_LIBRARIES}
++##    )
++##  elseif(APPLE)
++##    target_link_libraries(triton ${LLVM_LIBRARIES} z
++##      ${TRITON_LIBRARIES}
++##    )
++##  else()
++##    target_link_libraries(triton ${LLVM_LIBRARIES} z
++##      ${TRITON_LIBRARIES}
++##    )
++##    # TODO: Figure out which target is sufficient to fix errors; triton is
++##    # apparently not enough
++##    link_libraries(stdc++fs)
++##  endif()
++##
++##  target_link_options(triton PRIVATE ${LLVM_LDFLAGS})
++##endif()
++##
++##if(UNIX AND NOT APPLE)
++##  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,--exclude-libs,ALL")
++##endif()
++##
++##if(TRITON_BUILD_PYTHON_MODULE AND NOT WIN32)
++##  set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
++##
++##  # Check if the platform is MacOS
++##  if(APPLE)
++##    set(PYTHON_LDFLAGS "-undefined dynamic_lookup -flto")
++##  endif()
++##
++##  target_link_libraries(triton ${CUTLASS_LIBRARIES} ${PYTHON_LDFLAGS})
++##endif()
++##
++##add_subdirectory(test)
++##
++##add_subdirectory(unittest)
+diff --git a/include/triton/CMakeLists.txt b/include/triton/CMakeLists.txt
+index 629c08af6..265b8ea5b 100644
+--- a/include/triton/CMakeLists.txt
++++ b/include/triton/CMakeLists.txt
+@@ -1,2 +1,2 @@
+-add_subdirectory(Conversion)
++#add_subdirectory(Conversion)
+ add_subdirectory(Dialect)
+diff --git a/include/triton/Dialect/CMakeLists.txt b/include/triton/Dialect/CMakeLists.txt
+index 27cb65ce5..d3586a2fd 100644
+--- a/include/triton/Dialect/CMakeLists.txt
++++ b/include/triton/Dialect/CMakeLists.txt
+@@ -1,2 +1,2 @@
+ add_subdirectory(Triton)
+-add_subdirectory(TritonGPU)
++#add_subdirectory(TritonGPU)
+diff --git a/lib/CMakeLists.txt b/lib/CMakeLists.txt
+index ab1d31a76..e01dfe541 100644
+--- a/lib/CMakeLists.txt
++++ b/lib/CMakeLists.txt
+@@ -1,5 +1,5 @@
+ # add_subdirectory(codegen)
+-add_subdirectory(Analysis)
+-add_subdirectory(Conversion)
++#add_subdirectory(Analysis)
++#add_subdirectory(Conversion)
+ add_subdirectory(Dialect)
+-add_subdirectory(Target)
++#add_subdirectory(Target)
+diff --git a/lib/Dialect/CMakeLists.txt b/lib/Dialect/CMakeLists.txt
+index 27cb65ce5..d3586a2fd 100644
+--- a/lib/Dialect/CMakeLists.txt
++++ b/lib/Dialect/CMakeLists.txt
+@@ -1,2 +1,2 @@
+ add_subdirectory(Triton)
+-add_subdirectory(TritonGPU)
++#add_subdirectory(TritonGPU)
+diff --git a/lib/Dialect/Triton/CMakeLists.txt b/lib/Dialect/Triton/CMakeLists.txt
+index 9f57627c3..218c20c88 100644
+--- a/lib/Dialect/Triton/CMakeLists.txt
++++ b/lib/Dialect/Triton/CMakeLists.txt
+@@ -1,2 +1,2 @@
+ add_subdirectory(IR)
+-add_subdirectory(Transforms)
++#add_subdirectory(Transforms)
+diff --git a/lib/Dialect/Triton/IR/CMakeLists.txt b/lib/Dialect/Triton/IR/CMakeLists.txt
+index 9488db8d8..9f2764352 100644
+--- a/lib/Dialect/Triton/IR/CMakeLists.txt
++++ b/lib/Dialect/Triton/IR/CMakeLists.txt
+@@ -12,4 +12,5 @@ add_mlir_dialect_library(TritonIR
+   MLIRIR
+   MLIRArithDialect
+   MLIRSCFDialect
++  MLIRMathDialect
+ )
+diff --git a/lib/Dialect/Triton/IR/Ops.cpp b/lib/Dialect/Triton/IR/Ops.cpp
+index 3d97b4e98..0ba5623d6 100644
+--- a/lib/Dialect/Triton/IR/Ops.cpp
++++ b/lib/Dialect/Triton/IR/Ops.cpp
+@@ -706,5 +706,94 @@ LogicalResult triton::ReturnOp::verify() {
+   return success();
+ }
+ 
++// load(ptr, splat(1), ...)        -> load(ptr, ...)
++// load(ptr, splat(0), other, ...) -> other
++struct CanonicalizeMaskedLoadPattern
++    : public mlir::OpRewritePattern<triton::LoadOp> {
++  CanonicalizeMaskedLoadPattern(mlir::MLIRContext *context)
++      : OpRewritePattern<triton::LoadOp>(context, 1) {}
++
++  mlir::LogicalResult
++  matchAndRewrite(triton::LoadOp loadOp,
++                  mlir::PatternRewriter &rewriter) const override {
++    auto mask = loadOp.getMask();
++    if (!mask)
++      return mlir::failure();
++
++    auto constantMask =
++        llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
++    if (!constantMask)
++      return mlir::failure();
++
++    auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
++    if (!splatMask)
++      return mlir::failure();
++
++    if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
++      // mask = splat(1)
++      rewriter.replaceOpWithNewOp<triton::LoadOp>(
++          loadOp, loadOp.getType(), loadOp.getPtr(), Value(), Value(),
++          loadOp.getBoundaryCheckAttr(), loadOp.getPaddingAttr(),
++          loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
++    } else {
++      // mask = splat(0)
++
++      // If there's no "other", the value is "undef".  Perhaps we want to
++      // optimize it in the future.x
++      auto otherVal = loadOp.getOther();
++      if (!otherVal)
++        return mlir::failure();
++      rewriter.replaceOp(loadOp, otherVal);
++    }
++    return mlir::success();
++  }
++};
++
++void LoadOp::getCanonicalizationPatterns(RewritePatternSet &results,
++                                         MLIRContext *context) {
++  results.add<CanonicalizeMaskedLoadPattern>(context);
++}
++
++// store(ptr, value, splat(1), ...) -> store(ptr, value, ...)
++// store(ptr, value, splat(0), ...) -> [none]
++struct CanonicalizeMaskedStorePattern
++    : public mlir::OpRewritePattern<triton::StoreOp> {
++  CanonicalizeMaskedStorePattern(mlir::MLIRContext *context)
++      : OpRewritePattern<triton::StoreOp>(context, 1) {}
++
++  mlir::LogicalResult
++  matchAndRewrite(triton::StoreOp storeOp,
++                  mlir::PatternRewriter &rewriter) const override {
++    auto mask = storeOp.getMask();
++    if (!mask)
++      return mlir::failure();
++
++    auto constantMask =
++        llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
++    if (!constantMask)
++      return mlir::failure();
++
++    auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
++    if (!splatMask)
++      return mlir::failure();
++
++    if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
++      // mask = splat(1)
++      rewriter.replaceOpWithNewOp<triton::StoreOp>(
++          storeOp, storeOp.getPtr(), storeOp.getValue(), storeOp.getCache(),
++          storeOp.getEvict());
++    } else {
++      // mask = splat(0)
++      rewriter.eraseOp(storeOp);
++    }
++    return mlir::success();
++  }
++};
++
++void StoreOp::getCanonicalizationPatterns(RewritePatternSet &results,
++                                          MLIRContext *context) {
++  results.add<CanonicalizeMaskedStorePattern>(context);
++}
++
+ } // namespace triton
+ } // namespace mlir
+diff --git a/lib/Dialect/Triton/Transforms/Combine.cpp b/lib/Dialect/Triton/Transforms/Combine.cpp
+index 850182366..d9c4356a9 100644
+--- a/lib/Dialect/Triton/Transforms/Combine.cpp
++++ b/lib/Dialect/Triton/Transforms/Combine.cpp
+@@ -101,95 +101,6 @@ public:
+   }
+ };
+ 
+-// load(ptr, splat(1), ...)        -> load(ptr, ...)
+-// load(ptr, splat(0), other, ...) -> other
+-struct CanonicalizeMaskedLoadPattern
+-    : public mlir::OpRewritePattern<triton::LoadOp> {
+-  CanonicalizeMaskedLoadPattern(mlir::MLIRContext *context)
+-      : OpRewritePattern<triton::LoadOp>(context, 1) {}
+-
+-  mlir::LogicalResult
+-  matchAndRewrite(triton::LoadOp loadOp,
+-                  mlir::PatternRewriter &rewriter) const override {
+-    auto mask = loadOp.getMask();
+-    if (!mask)
+-      return mlir::failure();
+-
+-    auto constantMask =
+-        llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
+-    if (!constantMask)
+-      return mlir::failure();
+-
+-    auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
+-    if (!splatMask)
+-      return mlir::failure();
+-
+-    if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
+-      // mask = splat(1)
+-      rewriter.replaceOpWithNewOp<triton::LoadOp>(
+-          loadOp, loadOp.getType(), loadOp.getPtr(), Value(), Value(),
+-          loadOp.getBoundaryCheckAttr(), loadOp.getPaddingAttr(),
+-          loadOp.getCache(), loadOp.getEvict(), loadOp.getIsVolatile());
+-    } else {
+-      // mask = splat(0)
+-
+-      // If there's no "other", the value is "undef".  Perhaps we want to
+-      // optimize it in the future.x
+-      auto otherVal = loadOp.getOther();
+-      if (!otherVal)
+-        return mlir::failure();
+-      rewriter.replaceOp(loadOp, otherVal);
+-    }
+-    return mlir::success();
+-  }
+-};
+-
+-void triton::LoadOp::getCanonicalizationPatterns(RewritePatternSet &results,
+-                                                 MLIRContext *context) {
+-  results.add<CanonicalizeMaskedLoadPattern>(context);
+-}
+-
+-// store(ptr, value, splat(1), ...) -> store(ptr, value, ...)
+-// store(ptr, value, splat(0), ...) -> [none]
+-struct CanonicalizeMaskedStorePattern
+-    : public mlir::OpRewritePattern<triton::StoreOp> {
+-  CanonicalizeMaskedStorePattern(mlir::MLIRContext *context)
+-      : OpRewritePattern<triton::StoreOp>(context, 1) {}
+-
+-  mlir::LogicalResult
+-  matchAndRewrite(triton::StoreOp storeOp,
+-                  mlir::PatternRewriter &rewriter) const override {
+-    auto mask = storeOp.getMask();
+-    if (!mask)
+-      return mlir::failure();
+-
+-    auto constantMask =
+-        llvm::dyn_cast_or_null<arith::ConstantOp>(mask.getDefiningOp());
+-    if (!constantMask)
+-      return mlir::failure();
+-
+-    auto splatMask = constantMask.getValue().dyn_cast<SplatElementsAttr>();
+-    if (!splatMask)
+-      return mlir::failure();
+-
+-    if (splatMask.getSplatValue<IntegerAttr>().getValue() == true) {
+-      // mask = splat(1)
+-      rewriter.replaceOpWithNewOp<triton::StoreOp>(
+-          storeOp, storeOp.getPtr(), storeOp.getValue(), storeOp.getCache(),
+-          storeOp.getEvict());
+-    } else {
+-      // mask = splat(0)
+-      rewriter.eraseOp(storeOp);
+-    }
+-    return mlir::success();
+-  }
+-};
+-
+-void triton::StoreOp::getCanonicalizationPatterns(RewritePatternSet &results,
+-                                                  MLIRContext *context) {
+-  results.add<CanonicalizeMaskedStorePattern>(context);
+-}
+-
+ #define GEN_PASS_CLASSES
+ #include "triton/Dialect/Triton/Transforms/Passes.h.inc"
+ 


### PR DESCRIPTION
This is a POC of adding Triton as a submodule and generating the Python bindings for the `Triton` dialect. Because of their very unconventional CMake it's actually not completely straightforward (requires a patch) but ultimately doable. Incidentally this is I think a pretty killer feature of MLIR: free Python bindings...

<p align="center">
  <img src="https://user-images.githubusercontent.com/5657668/233546015-365b1e20-cf81-45d3-98c2-366b9d387a3d.png">
</p>