### PR TITLE
[Indexing] Add `ConcatenateOp`

### DIFF
--- a/include/structured/Dialect/Indexing/IR/Indexing.h
+++ b/include/structured/Dialect/Indexing/IR/Indexing.h
@@ -17,10 +17,6 @@
 
 #include "structured/Dialect/Indexing/IR/IndexingOpsDialect.h.inc"
 
-namespace mlir {
-namespace indexing {} // namespace indexing
-} // namespace mlir
-
 #define GET_TYPEDEF_CLASSES
 
 #include "structured/Dialect/Indexing/IR/IndexingOpsTypes.h.inc"

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -37,4 +37,32 @@ def Indexing_GatherOp : Indexing_Op<"gather", [
   }];
 }
 
+def Indexing_ConcatenateOp : Indexing_Op<"concatenate",
+    [Pure, SameOperandsAndResultElementType,
+     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Concatenate operation";
+  let description = [{
+    Concatenates a variadic number of tensors in `inputs` along `dimension`
+    dimension in the same order as the given arguments and produces a `result`
+    tensor.
+
+    Example:
+    ```mlir
+    %result = indexing.concatenate %input0, %input1, dim = 0
+        : (tensor<3x2xi64>, tensor<1x2xi64>) -> tensor<4x2xi64>
+    ```
+  }];
+
+  let arguments = (ins
+    Variadic<AnyRankedTensor>:$inputs,
+    I64Attr:$dimension
+  );
+
+  let results = (outs AnyRankedTensor);
+
+  let assemblyFormat = [{
+     `(` $inputs `)` `{` `dim` `=` $dimension `}` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
 #endif // STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS

--- a/test/Dialect/Indexing/basic.mlir
+++ b/test/Dialect/Indexing/basic.mlir
@@ -7,6 +7,7 @@
 // CHECK:     %0 = tensor.empty() : tensor<10x10xi32>
 // CHECK:     %1 = tensor.empty() : tensor<1x2x2xi32>
 // CHECK:     %2 = indexing.gather %0[%1] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
+// CHECK:     %3 = indexing.concatenate(%2, %2) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
 // CHECK:     return
 // CHECK:   }
 // CHECK: }
@@ -16,6 +17,7 @@ module {
     %0 = tensor.empty() : tensor<10x10xi32>
     %1 = tensor.empty() : tensor<1x2x2xi32>
     %2 = indexing.gather %0[%1] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
+    %3 = indexing.concatenate (%2, %2) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
     return
   }
 }

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -112,3 +112,24 @@ def testTensorValue():
   # CHECK:   }
   # CHECK: }
   print(module)
+
+
+# CHECK-LABEL: TEST: testConcatOp
+@run
+def testConcatOp():
+  i32 = IntegerType.get_signless(32)
+  with mlir_mod_ctx() as module:
+
+    @func.FuncOp.from_py_func()
+    def test_concat_op():
+      ten = idx.Tensor.empty((10, 10), i32)
+      # CHECK: Tensor(%[[TEN:.*]], tensor<10x10xi32>)
+      print(ten)
+
+      concat_ten_first_dim = idx.ConcatenateOp((ten, ten), 0).result
+      # CHECK: %{{.*}} = "indexing.concatenate"(%[[TEN]], %[[TEN]]) {dimension = 0 : i64} : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<20x10xi32>
+      print(concat_ten_first_dim.owner)
+
+      concat_ten_second_dim = idx.ConcatenateOp((ten, ten), 1).result
+      # CHECK: %{{.*}} = "indexing.concatenate"(%[[TEN]], %[[TEN]]) {dimension = 1 : i64} : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x20xi32>
+      print(concat_ten_second_dim.owner)


### PR DESCRIPTION
This is a wholesale lift/grab from [stablehlo](https://github.com/openxla/stablehlo/blob/main/docs/spec.md#concatenate). Feel free to tell me you want more tests, or more examples in the td description, or to make a suggestion about a different asm.

Stack (bottom to top):

https://github.com/iree-org/iree-llvm-sandbox/pull/702

[here](https://github.com/iree-org/iree-llvm-sandbox/pull/696)
