### PR TITLE
[Indexing] Rename gather_dims

### DIFF
--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -18,10 +18,6 @@ include "mlir/Dialect/Tensor/IR/TensorBase.td"
 class Indexing_Op<string mnemonic, list<Trait> traits = []> :
         Op<Indexing_Dialect, mnemonic, traits>;
 
-//===----------------------------------------------------------------------===//
-// Debugging/testing utilities
-//===----------------------------------------------------------------------===//
-
 def Indexing_GatherOp : Indexing_Op<"gather", [
     Pure,
     DeclareOpInterfaceMethods<InferTypeOpInterface>
@@ -31,13 +27,14 @@ def Indexing_GatherOp : Indexing_Op<"gather", [
 
   let arguments = (ins AnyRankedTensor:$source,
                        RankedTensorOf<[AnySignlessIntegerOrIndex]>:$indices,
-                       DenseI64ArrayAttr:$coordinates);
+                       DenseI64ArrayAttr:$gather_dims,
+                       UnitAttr:$unique);
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $source `[` $indices `]` `coordinates` `=` $coordinates attr-dict `:` functional-type(operands, results)
+    $source `[` $indices `]` `gather_dims` `(` $gather_dims `)` (`unique` $unique^)? attr-dict
+        `:` functional-type(operands, results)
   }];
 }
-
 
 #endif // STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS

--- a/lib/Dialect/Indexing/IR/Indexing.cpp
+++ b/lib/Dialect/Indexing/IR/Indexing.cpp
@@ -49,13 +49,13 @@ LogicalResult mlir::indexing::GatherOp::inferReturnTypes(
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
 
-  ArrayRef<int64_t> coordinates =
-      attributes.get("coordinates").cast<mlir::DenseI64ArrayAttr>();
+  ArrayRef<int64_t> gather_dims =
+      attributes.get("gather_dims").cast<mlir::DenseI64ArrayAttr>();
   RankedTensorType expectedResultType = mlir::tensor::GatherOp::inferResultType(
       // source
       operands[0].getType().cast<RankedTensorType>(),
       // indices
-      operands[1].getType().cast<RankedTensorType>(), coordinates,
+      operands[1].getType().cast<RankedTensorType>(), gather_dims,
       /*rankReduced=*/true);
   inferredReturnTypes.assign({expectedResultType});
   return success();

--- a/test/Dialect/Indexing/basic.mlir
+++ b/test/Dialect/Indexing/basic.mlir
@@ -6,7 +6,7 @@
 // CHECK:     %c2_i32 = arith.constant 2 : i32
 // CHECK:     %0 = tensor.empty() : tensor<10x10xi32>
 // CHECK:     %1 = tensor.empty() : tensor<1x2x2xi32>
-// CHECK:     %2 = indexing.gather %0[%1] coordinates = [0, 1] : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
+// CHECK:     %2 = indexing.gather %0[%1] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
 // CHECK:     return
 // CHECK:   }
 // CHECK: }
@@ -15,7 +15,7 @@ module {
     %c2_i32 = arith.constant 2 : i32
     %0 = tensor.empty() : tensor<10x10xi32>
     %1 = tensor.empty() : tensor<1x2x2xi32>
-    %2 = indexing.gather %0[%1] coordinates = [0, 1] : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
+    %2 = indexing.gather %0[%1] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
     return
   }
 }


### PR DESCRIPTION
Stack (bottom to top):

[here](https://github.com/iree-org/iree-llvm-sandbox/pull/702)

Note this is kind of frippery because this op is just a 1-1 duplication of @nicolasvasilache's upstream `tensor.gather`, so in reality soon (if I don't think of any reason not to) I'll just upstream the only addition/delta I've made so far (`inferReturnTypes` as a trait) and get rid of this op entirely.