### PR TITLE
[Indexing] Refactor `mlir_value_subclass`es

### DIFF
--- a/python/StructuredDialects.cpp
+++ b/python/StructuredDialects.cpp
@@ -140,10 +140,6 @@ PYBIND11_MODULE(_structuredDialects, mainModule) {
   // Types
   //
 
-  (void)mlir_value_subclass(indexingModule, "TensorValue", [](MlirValue value) {
-    return mlirIsATensorValue(value);
-  });
-
   mlir_type_subclass(indexingModule, "IndexTensorType",
                      [](MlirType type) {
                        return mlirTypeIsATensor(type) &&
@@ -161,4 +157,6 @@ PYBIND11_MODULE(_structuredDialects, mainModule) {
           py::arg("cls"), py::arg("value"), py::arg("context") = py::none());
 
   (void)mlir_value_subclass(indexingModule, "ScalarValue", mlirIsAScalarValue);
+  (void)mlir_value_subclass(indexingModule, "TensorValue", mlirIsATensorValue);
+
 }

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -3,116 +3,369 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-import re
-from typing import Union, Tuple
+import operator
+from copy import deepcopy
+from functools import cached_property, lru_cache, partialmethod
+from typing import Optional, Tuple, Union
 
-from . import arith as arith_dialect
-from . import tensor as tensor_dialect
-# noinspection PyUnresolvedReferences
+import numpy as np
+
+from . import arith, tensor
+from ._arith_ops_ext import _is_integer_like_type
 from ._indexing_ops_gen import *
-from .linalg.opdsl.lang.emitter import _BodyBuilder, _is_floating_point_type, _is_integer_type, \
-  _is_index_type, _is_complex_type
-# noinspection PyUnresolvedReferences
-from .._mlir_libs import _mlirStructuredPasses as _cextStructuredPasses
+from ._ods_common import get_op_result_or_value
+from .linalg.opdsl.lang.emitter import _is_floating_point_type
 from .._mlir_libs._structuredDialects.indexing import *
-from ..ir import Value, Type, RankedTensorType, ShapedType, Operation, IndexType
+from ..ir import (
+    DenseElementsAttr,
+    F16Type,
+    F32Type,
+    F64Type,
+    IndexType,
+    IntegerType,
+    OpView,
+    Operation,
+    RankedTensorType,
+    ShapedType,
+    Type,
+    Value,
+)
 
-res_val_reg = re.compile(r"(%\w+) =")
 
-_body_builder = _BodyBuilder({}, {}, {})
+def infer_mlir_type(
+    py_val: Union[int, float, bool, np.ndarray]
+) -> Union[IntegerType, F64Type, RankedTensorType]:
+  """Infer MLIR type (`ir.Type`) from supported python values.
 
-# The classes in this file implement syntactic sugar for creating MLIR corresponding to arithmetic operations
-# on `tensor`s (MLIR Value whose type is `tensor<...>`) and `scalar`s (`f*` floats, `i*` integers, and `index`).
-#
-# The implementation uses the Python operator overloading mechanism to overload various "dunder" methods (`__add__`, `__mul__`, etc.)
-# to dispatch to the corresponding MLIR builders (`arith.AddFOp`, `arith.MulFOp`, etc.) through their Python bindings.
-# The classes also provide some convenience factory methods and properties for accessing metadata (data type, shape, etc.).
+  Note ints and floats are mapped to 64-bit types.
+
+  Args:
+    py_val: Python value that's either a numerical value or numpy array.
+
+  Returns:
+    MLIR type corresponding to py_val.
+  """
+  if isinstance(py_val, bool):
+    return IntegerType.get_signless(1)
+  elif isinstance(py_val, int):
+    return IntegerType.get_signless(64)
+  elif isinstance(py_val, float):
+    return F64Type.get()
+  elif isinstance(py_val, np.ndarray):
+    dtype = {
+        np.int8: IntegerType.get_signless(8),
+        np.int16: IntegerType.get_signless(16),
+        np.int32: IntegerType.get_signless(32),
+        np.int64: IntegerType.get_signless(64),
+        np.uintp: IndexType.get(),
+        np.float16: F16Type.get(),
+        np.float32: F32Type.get(),
+        np.float64: F64Type.get(),
+    }[py_val.dtype.type]
+    return RankedTensorType.get(py_val.shape, dtype)
+  else:
+    raise NotImplementedError(
+        f"Unsupported Python value {py_val=} with type {type(py_val)}")
 
 
-class Scalar(ScalarValue):
+def constant(
+    value: Union[int, float, bool, np.ndarray],
+    type: Optional[Type] = None,
+    index: Optional[bool] = None,
+) -> arith.ConstantOp:
+  """Instantiate arith.constant with value `value`.
 
+  Args:
+    value: Python value that determines the value attribute of the
+      arith.constant op.
+    type: Optional MLIR type that type of the value attribute of the
+      arith.constant op; if omitted the type of the value attribute
+      will be inferred from the value.
+    index: Whether the MLIR type should be an index type; if passed the
+      type argument will be ignored.
+
+  Returns:
+    ir.OpView instance that corresponds to instantiated arith.constant op.
+  """
+  if index is not None and index:
+    type = IndexType.get()
+  if type is None:
+    type = infer_mlir_type(value)
+  assert type is not None
+
+  if isinstance(value, np.ndarray):
+    value = DenseElementsAttr.get(
+        value,
+        type=type,
+    )
+
+  return arith.ConstantOp(type, value)
+
+
+class ArithValueMeta(type(Value)):
+  """Metaclass that orchestrates the Python object protocol
+  (i.e., calling __new__ and __init__) for Indexing dialect extension values
+  (created using `mlir_value_subclass`).
+
+  The purpose/benefit of handling the `__new__` and `__init__` calls
+  explicitly/manually is we can then wrap arbitrary Python objects; e.g.
+  all three of the following wrappers are equivalent:
+
+  ```
+  s1 = Scalar(arith.ConstantOp(f64, 0.0).result)
+  s2 = Scalar(arith.ConstantOp(f64, 0.0))
+  s3 = Scalar(0.0)
+  ```
+
+  In general the Python object protocol for an object instance is determined
+  by `__call__` of the object class's metaclass, thus here we overload
+  `__call__` and branch on what we're wrapping there.
+
+  Why not just overload __new__ and be done with it? Because then we can't
+  choose what get's passed to __init__: by default (i.e., without overloading
+  __call__ here) the same arguments are passed to both __new__ and __init__.
+
+  Note, this class inherits from `type(Value)` (i.e., the metaclass of
+  `ir.Value`) rather than `type` or `abc.ABCMeta` or something like this because
+  the metaclass of a derived class must be a (non-strict) subclass of the
+  metaclasses of all its bases and so all the extension classes
+  (`ScalarValue`, `TensorValue`), which are derived classes of `ir.Value` must
+  have metaclasses that inherit from the metaclass of `ir.Value`. Without this
+  hierarchy Python will throw `TypeError: metaclass conflict`.
+  """
+
+  def __call__(cls, *args, **kwargs):
+    """Orchestrate the Python object protocol for Indexing dialect extension
+    values in order to handle wrapper arbitrary Python objects.
+
+    Args:
+      *args: Position arguments to the class constructor. Note, currently,
+        only one positional arg is supported (so constructing something like a
+        tuple type from element objects isn't supported).
+      **kwargs: Keyword arguments to the class constructor. Note, currently,
+        we only look for `dtype` (an `ir.Type`) and `index` (a `bool`) and
+        `fold`, which determines whether binary operations on constant
+        instances will be folded (i.e., evaluated at runtime).
+
+    Returns:
+      A fully constructed and initialized instance of the class.
+    """
+    if len(args) != 1:
+      raise ValueError("Only one non-kw arg supported.")
+    arg = args[0]
+    arg_copy = None
+    fold = None
+    if isinstance(arg, (OpView, Operation, Value)):
+      # wrap an already created Value (or op the produces a Value)
+      if isinstance(arg, (Operation, OpView)):
+        assert len(arg.results) == 1
+      val = get_op_result_or_value(arg)
+    elif isinstance(arg, (int, float, bool, np.ndarray)):
+      # wrap a Python value, effectively a scalar or tensor literal
+      dtype = kwargs.get("dtype")
+      if dtype is not None and not isinstance(dtype, Type):
+        raise ValueError(f"{dtype=} is expected to be an ir.Type.")
+      index = kwargs.get("index")
+      if index is not None and not isinstance(index, bool):
+        raise ValueError(f"{index=} is expected to be a bool.")
+      fold = kwargs.get("fold")
+      if fold is not None and not isinstance(fold, bool):
+        raise ValueError(f"{fold=} is expected to be a bool.")
+
+      # If we're wrapping a numpy array (effectively a tensor literal),
+      # then we want to make sure no one else has access to that memory.from
+      # Otherwise the array will get funneled down to DenseElementsAttr.get,
+      # which by default (through the Python buffer protocol) does not copy;
+      # see mlir/lib/Bindings/Python/IRAttributes.cpp#L556
+      arg_copy = deepcopy(arg)
+      val = constant(arg, dtype, index).result
+    else:
+      raise NotImplementedError(
+          f"{cls.__name__} doesn't support wrapping {arg}.")
+
+    # The mlir_value_subclass mechanism works through __new__
+    # (see mlir/Bindings/Python/PybindAdaptors.h#L502)
+    # So we have to pass the wrapped Value to the __new__ of the subclass
+    cls_obj = cls.__new__(cls, val)
+    # We also have to pass it to __init__ because that is required by
+    # the Python object protocol; first an object is new'ed and then
+    # it is init'ed. Note we pass arg_copy here in case a subclass wants to
+    # inspect the literal.
+    cls.__init__(cls_obj, val, arg_copy, fold=fold)
+    return cls_obj
+
+
+class ArithValue(metaclass=ArithValueMeta):
+  """Mixin class for functionality shared by mlir_value_subclasses that support
+  arithmetic operations.
+
+  Note, since we bind the ArithValueMeta here, it is here that the __new__ and
+  __init__ must be defined. To be precise, the callchain, starting from
+  ArithValueMeta is:
+
+  ArithValueMeta.__call__ -> mlir_value_subclass.__new__ ->
+                        (mlir_value_subclass.__init__ == ArithValue.__init__) ->
+                        Value.__init__
+  """
+
+  def __init__(
+      self,
+      val,
+      arg: Optional[Union[int, float, bool, np.ndarray]] = None,
+      fold: Optional[bool] = None,
+  ):
+    self.__arg = arg
+    self._fold = fold if fold is not None else True
+    super().__init__(val)
+
+  @lru_cache(maxsize=1)
+  def is_constant(self) -> bool:
+    return isinstance(self.owner.opview, arith.ConstantOp)
+
+  @lru_cache(maxsize=1)
   def __str__(self):
-    s = res_val_reg.findall(super().__str__())
-    assert len(s) == 1
-    return f"Scalar({s[0]}, {self.type})"
+    if self.is_constant():
+      v = str(self.literal_value)
+      v = f"{v[:10]}..." if len(v) > 10 else v
+      return f"{self.__class__.__name__}({self.get_name()}, {self.type}, {v})"
+    else:
+      return f"{self.__class__.__name__}({self.get_name()}, {self.type})"
 
-  def __add__(self, other) -> "Scalar":
-    return Scalar(_body_builder._binary_add(self, other))
+  @lru_cache(maxsize=1)
+  def __repr__(self):
+    return str(self)
 
-  def __sub__(self, other) -> "Scalar":
-    return Scalar(_body_builder._binary_sub(self, other))
+  def __binary_op(self, other: "ArithValue", op: str) -> "ArithValue":
+    """Generic for handling infix binary operator dispatch.
 
-  def __mul__(self, other) -> "Scalar":
-    return Scalar(_body_builder._binary_mul(self, other))
+    Args:
+      self: E.g. Scalar or Tensor below.
+      other: Scalar or Tensor with type matching self.
+      op: Binary operator, currently only add, sub, mul
+        supported.
+
+    Returns:
+      Result of binary operation. If constant folding is possible and
+      performed then this will be a handle to an arith.constant op and
+      otherwise to an arith(add|sub|mul) op.
+    """
+    assert op in {"add", "sub", "mul"}
+    if self.type != other.type:
+      raise ValueError(f"{self=} {other=} must have the same type.")
+
+    if self.is_constant() and other.is_constant() and self._fold:
+      # if both operands are constants (results of an arith.constant op)
+      # then both have a literal value (i.e. Python value).
+      lhs, rhs = self.literal_value, other.literal_value
+      # if we're folding constants (self._fold = True) then we just carry out
+      # the corresponding operation on the literal values; e.g., operator.add.
+      # note this is the same as op = operator.__dict__[op].
+      op = operator.attrgetter(op)(operator)
+    else:
+      op = op.capitalize()
+      lhs, rhs = self, other
+      if _is_floating_point_type(self.dtype):
+        op = getattr(arith, f"{op}FOp")
+      elif _is_integer_like_type(self.dtype):
+        op = getattr(arith, f"{op}IOp")
+      else:
+        raise NotImplementedError(f"Unsupported '{op}' operands: {lhs}, {rhs}")
+    return self.__class__(op(lhs, rhs))
+
+  # partialmethod differs from partial in that it also binds the object instance
+  # to the first arg (i.e., self)
+  __add__ = partialmethod(__binary_op, op="add")
+  __sub__ = partialmethod(__binary_op, op="sub")
+  __mul__ = partialmethod(__binary_op, op="mul")
 
 
-class Tensor(TensorValue):
+class Scalar(ArithValue, ScalarValue):
+  """Decorator for mlir_value_subclass ScalarValue that adds convenience methods
+  for getting dtype and (possibly) the stored literal value.
 
-  def __str__(self):
-    s = res_val_reg.findall(super().__str__())
-    assert len(s) == 1
-    return f"Tensor({s[0]}, {self.type})"
+  Note, order matters in the superclasses above; ArithValue is first so that
+  e.g. __init__, and __str__ from ArithValue are used instead of
+  from ScalarValue.
+  """
 
-  @property
+  @cached_property
+  def dtype(self) -> Type:
+    return self.type
+
+  @cached_property
+  def literal_value(self) -> Union[int, float, bool]:
+    if not self.is_constant():
+      raise ValueError("Can't build literal from non-constant Scalar")
+    return self.owner.opview.literal_value
+
+
+class Tensor(ArithValue, TensorValue):
+  """Decorator for mlir_value_subclass TensorValue that adds convenience methods
+  for getting dtype, shape and (possibly) the stored literal value.
+
+  Note, order matters in the superclasses above; ArithValue is first so that
+  e.g. __init__, and __str__ from ArithValue are used instead of
+  from TensorValue.
+  """
+
+  @cached_property
+  def literal_value(self) -> np.ndarray:
+    if not self.is_constant():
+      raise ValueError("Can't build literal from non-constant Tensor")
+    return np.array(DenseElementsAttr(self.owner.opview.value), copy=False)
+
+  @cached_property
   def _shaped_type(self) -> ShapedType:
     return ShapedType(self.type)
 
-  @property
-  def shape(self) -> list[int]:
-    assert self._shaped_type.has_static_shape, "Only static shapes currently supported."
-    return self._shaped_type.shape
+  @cached_property
+  def shape(self) -> Tuple[int, ...]:
+    if not self._shaped_type.has_static_shape:
+      raise ValueError("Only static shapes currently supported.")
+    return tuple(self._shaped_type.shape)
 
-  @property
-  def element_type(self) -> Type:
+  @cached_property
+  def dtype(self) -> Type:
     return self._shaped_type.element_type
 
   @classmethod
-  def empty(cls, shape: Union[list[Union[int, Value]], tuple[Union[int, Value],
-                                                             ...]],
-            el_type: Type) -> "Tensor":
+  def empty(
+      cls,
+      shape: Union[list[Union[int, Value]], tuple[Union[int, Value], ...]],
+      el_type: Type,
+  ) -> "Tensor":
 
-    return cls(tensor_dialect.EmptyOp(shape, el_type).result)
+    return cls(tensor.EmptyOp(shape, el_type).result)
 
   def __class_getitem__(
-      cls, dim_sizes_el_type: Tuple[Union[list[int], tuple[int, ...]],
-                                    Type]) -> Type:
-    assert (len(dim_sizes_el_type) == 2
-           ), f"wrong dim_sizes_el_type: {dim_sizes_el_type}"
-    dim_sizes, el_type = dim_sizes_el_type
-    assert isinstance(el_type, Type), f"wrong type T args for tensor: {el_type}"
+      cls, dim_sizes_dtype: Tuple[Union[list[int], tuple[int, ...]],
+                                  Type]) -> Type:
+    """A convenience method for creating RankedTensorType.
+
+    Args:
+      dim_sizes_dtype: A tuple of both the shape of the type and the dtype.
+
+    Returns:
+      An instance of RankedTensorType.
+    """
+    if len(dim_sizes_dtype) != 2:
+      raise ValueError(
+          f"Wrong type of argument to {cls.__name__}: {dim_sizes_dtype=}")
+    dim_sizes, dtype = dim_sizes_dtype
+    if not isinstance(dtype, Type):
+      raise ValueError(f"{dtype=} is not {Type=}")
     static_sizes = []
     for s in dim_sizes:
       if isinstance(s, int):
         static_sizes.append(s)
       else:
         static_sizes.append(ShapedType.get_dynamic_size())
-    return RankedTensorType.get(static_sizes, el_type)
+    return RankedTensorType.get(static_sizes, dtype)
 
   def __getitem__(self, dims: tuple) -> Scalar:
     dims = list(dims)
     for i, d in enumerate(dims):
       if isinstance(d, int):
-        dims[i] = arith_dialect.ConstantOp.create_index(d).result
+        dims[i] = arith.ConstantOp.create_index(d).result
 
-    return Scalar(tensor_dialect.ExtractOp(self, dims).result)
-
-  @classmethod
-  def __binary_op(cls, op: str, lhs: "Tensor", rhs: "Tensor") -> "Tensor":
-    assert op in {"Add", "Sub", "Mul"}
-    assert lhs.element_type == rhs.element_type
-    assert lhs.shape == rhs.shape
-
-    if _is_floating_point_type(lhs.element_type):
-      return cls(getattr(arith_dialect, f"{op}FOp")(lhs, rhs).result)
-    if _is_integer_type(lhs.element_type) or _is_index_type(lhs.element_type):
-      return cls(getattr(arith_dialect, f"{op}IOp")(lhs, rhs).result)
-    raise NotImplementedError(f"Unsupported '{op}' operands: {lhs}, {rhs}")
-
-  def __add__(self: "Tensor", rhs: "Tensor") -> "Tensor":
-    return self.__binary_op("Add", self, rhs)
-
-  def __sub__(self: "Tensor", rhs: "Tensor") -> "Tensor":
-    return self.__binary_op("Sub", self, rhs)
-
-  def __mul__(self: "Tensor", rhs: "Tensor") -> "Tensor":
-    return self.__binary_op("Mul", self, rhs)
+    return Scalar(tensor.ExtractOp(self, dims))

--- a/python/mlir_structured/runtime/util.py
+++ b/python/mlir_structured/runtime/util.py
@@ -1,13 +1,18 @@
 import contextlib
 from typing import Optional
 
-from mlir_structured.ir import Context, Module, InsertionPoint, Location
+from mlir_structured.ir import (
+    Context,
+    Module,
+    InsertionPoint,
+    Location,
+)
 
 
 @contextlib.contextmanager
 def mlir_mod_ctx(src: Optional[str] = None,
-                 context: Context = None,
-                 location: Location = None):
+                 context: Optional[Context] = None,
+                 location: Optional[Location] = None):
   if context is None:
     context = Context()
   if location is None:

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -1,8 +1,11 @@
 # RUN: %PYTHON %s | FileCheck %s
+from random import random
 
-from mlir_structured.dialects import indexing as idx
-from mlir_structured.dialects import func
-from mlir_structured.ir import Context, IntegerType, F32Type
+import numpy as np
+
+from mlir_structured.dialects import func, arith, indexing
+from mlir_structured.dialects.indexing import Scalar, Tensor, IndexTensorType
+from mlir_structured.ir import Context, IntegerType, F64Type
 from mlir_structured.passmanager import PassManager
 from mlir_structured.runtime.util import mlir_mod_ctx
 
@@ -10,34 +13,93 @@ from mlir_structured.runtime.util import mlir_mod_ctx
 def run(f):
   print("\nTEST:", f.__name__)
   with Context():
-    idx.register_dialect()
+    indexing.register_dialect()
     f()
   return f
 
 
-# CHECK-LABEL: TEST: testArithValue
+# CHECK-LABEL: TEST: testScalarValue
 @run
-def testArithValue():
+def testScalarValue():
+  f64 = F64Type.get()
   i32 = IntegerType.get_signless(32)
-  with mlir_mod_ctx():
-    ten = idx.Tensor.empty([10, 10], i32)
-    # CHECK: %[[TEN:.*]] = tensor.empty() : tensor<10x10xi32>
-    print(ten.owner)
-    # CHECK: Tensor(%[[TEN]], tensor<10x10xi32>)
-    print(ten)
+  with mlir_mod_ctx() as module:
+    zero_f64 = Scalar(arith.ConstantOp(f64, 0.0).result)
+    # CHECK: Scalar(%{{.*}}, f64, 0.0)
+    print(zero_f64)
+    # CHECK: True
+    print(zero_f64.is_constant())
+    # CHECK: 0.0
+    print(zero_f64.literal_value)
 
-    v = ten[0, 0]
-    # CHECK: %[[EXTRACTED:.*]] = tensor.extract %[[TEN]][%{{.*}}, %{{.*}}] : tensor<10x10xi32>
-    print(v.owner)
-    # CHECK: Scalar(%[[EXTRACTED]], i32)
-    print(v)
+    zero_f64 = Scalar(arith.ConstantOp(f64, 0.0))
+    # CHECK: Scalar(%{{.*}}, f64, 0.0)
+    print(zero_f64)
+    # CHECK: True
+    print(zero_f64.is_constant())
+    # CHECK: 0.0
+    print(zero_f64.literal_value)
 
-    w = v + v
-    # CHECK: %[[ADDI:.*]] = arith.addi %[[EXTRACTED]], %[[EXTRACTED]] : i32
-    print(w.owner)
-    z = w * w
-    # CHECK: %[[MULI:.*]] = arith.muli %[[ADDI]], %[[ADDI]] : i32
-    print(z.owner)
+    zero_f64 = Scalar(0.0)
+    # CHECK: Scalar(%{{.*}}, f64, 0.0)
+    print(zero_f64)
+    # CHECK: True
+    print(zero_f64.is_constant())
+    # CHECK: 0.0
+    print(zero_f64.literal_value)
+
+    zero_i64 = Scalar(0)
+    # CHECK: Scalar(%{{.*}}, i64, 0)
+    print(zero_i64)
+    # CHECK: True
+    print(zero_i64.is_constant())
+    # CHECK: 0
+    print(zero_i64.literal_value)
+
+    zero_i32 = Scalar(0, dtype=i32)
+    # CHECK: Scalar(%{{.*}}, i32, 0)
+    print(zero_i32)
+    # CHECK: True
+    print(zero_i32.is_constant())
+    # CHECK: 0
+    print(zero_i32.literal_value)
+
+    zero_index = Scalar(0, index=True)
+    # CHECK: Scalar(%{{.*}}, index, 0)
+    print(zero_index)
+    # CHECK: True
+    print(zero_index.is_constant())
+    # CHECK: 0
+    print(zero_index.literal_value)
+
+    one_f64 = Scalar(1.0)
+    two_f64 = Scalar(2.0)
+
+    three_f64 = one_f64 + two_f64
+    # CHECK: %{{.*}} = arith.constant 3.000000e+00 : f64
+    print(three_f64.owner)
+
+    x, y = random(), random()
+    x_f64, y_f64 = Scalar(x), Scalar(y)
+
+    z_f64 = x_f64 + y_f64
+    # CHECK: True
+    print(z_f64.literal_value == x + y)
+    # CHECK: True
+    print(zero_f64.is_constant())
+
+    no_fold_one_f64 = Scalar(1.0, fold=False)
+    # CHECK: Scalar(%[[NF1:.*]], f64, 1.0)
+    print(no_fold_one_f64)
+    no_fold_two_f64 = Scalar(2.0, fold=False)
+    # CHECK: Scalar(%[[NF2:.*]], f64, 2.0)
+    print(no_fold_two_f64)
+
+    no_fold_three_f64 = no_fold_one_f64 + no_fold_two_f64
+    # CHECK: %{{.*}} = arith.addf %[[NF1]], %[[NF2]] : f64
+    print(no_fold_three_f64.owner)
+    # CHECK: False
+    print(no_fold_three_f64.is_constant())
 
 
 # CHECK-LABEL: TEST: testTensorType
@@ -45,15 +107,15 @@ def testArithValue():
 def testTensorType():
   i32 = IntegerType.get_signless(32)
   with mlir_mod_ctx():
-    tt = idx.Tensor[(10, 10), i32]
+    tt = Tensor[(10, 10), i32]
     # CHECK: tensor<10x10xi32>
     print(tt)
 
-    tt = idx.Tensor[(None, None), i32]
+    tt = Tensor[(None, None), i32]
     # CHECK: tensor<?x?xi32>
     print(tt)
 
-    tt = idx.IndexTensorType.get([10, 10])
+    tt = IndexTensorType.get([10, 10])
     # CHECK: tensor<10x10xindex>
     print(tt)
 
@@ -64,72 +126,115 @@ def testTensorValue():
   i32 = IntegerType.get_signless(32)
   with mlir_mod_ctx() as module:
 
-    @func.FuncOp.from_py_func()
-    def test_tensor_value():
-      ten = idx.Tensor.empty((10, 10), i32)
-      # CHECK: Tensor(%[[TEN:.*]], tensor<10x10xi32>)
-      print(ten)
+    ten = Tensor.empty((10, 10), i32)
+    # CHECK: Tensor(%[[TEN:.*]], tensor<10x10xi32>)
+    print(repr(ten))
+    # CHECK: %[[TEN]] = tensor.empty() : tensor<10x10xi32>
+    print(ten.owner)
+    # CHECK: (10, 10)
+    print(ten.shape)
+    # CHECK: i32
+    print(ten.dtype)
+    # CHECK: False
+    print(ten.is_constant())
+    try:
+      print(ten.literal_value)
+    except ValueError as e:
+      # CHECK: Can't build literal from non-constant Tensor
+      print(e)
 
-      sum_ten = ten + ten
-      # CHECK: %[[ADD:.*]] = "arith.addi"(%[[TEN]], %[[TEN]]) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x10xi32>
-      print(sum_ten.owner)
+    sum_ten_1 = ten + ten
+    # CHECK: %[[ADD:.*]] = arith.addi %[[TEN]], %[[TEN]] : tensor<10x10xi32>
+    print(sum_ten_1.owner)
 
-      prod_ten = ten * ten
-      # CHECK: %[[MUL:.*]] = "arith.muli"(%[[TEN]], %[[TEN]]) : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x10xi32>
-      print(prod_ten.owner)
+    prod_ten = ten * ten
+    # CHECK: %[[MUL:.*]] = arith.muli %[[TEN]], %[[TEN]] : tensor<10x10xi32>
+    print(prod_ten.owner)
 
-      return prod_ten
+    x = np.random.random((10, 10))
+    ten_x = Tensor(x)
+    # CHECK: Tensor(%[[CST1:.*]], tensor<10x10xf64>, [
+    print(ten_x)
+    # CHECK: (10, 10)
+    print(ten_x.shape)
+    # CHECK: f64
+    print(ten_x.dtype)
+    # CHECK: True
+    print(ten_x.is_constant())
+    # CHECK: True
+    print(np.allclose(ten_x.literal_value, x))
+
+    y = np.random.random((10, 10))
+    # CHECK: Tensor(%[[CST2:.*]], tensor<10x10xf64>, [
+    ten_y = Tensor(y)
+    print(ten_y)
+    sum_ten_2 = ten_x + ten_y
+    # CHECK: Tensor(%[[CST3:.*]], tensor<10x10xf64>, [
+    print(sum_ten_2)
+    # CHECK: (10, 10)
+    print(sum_ten_2.shape)
+    # CHECK: f64
+    print(sum_ten_2.dtype)
+    # CHECK: True
+    print(sum_ten_2.is_constant())
+    # CHECK: True
+    print(np.allclose(sum_ten_2.literal_value, x + y))
+
+    try:
+      Tensor(arith.ConstantOp(i32, 0).result)
+    except ValueError as e:
+      # CHECK: Cannot cast value to TensorValue (from <mlir_structured._mlir_libs._mlir.ir.OpResult
+      print(e)
 
   # CHECK: module {
-  # CHECK:   func.func @test_tensor_value() -> tensor<10x10xi32> {
-  # CHECK:     %[[TEN]] = tensor.empty() : tensor<10x10xi32>
-  # CHECK:     %[[ADD]] = arith.addi %[[TEN]], %[[TEN]] : tensor<10x10xi32>
-  # CHECK:     %[[MUL]] = arith.muli %[[TEN]], %[[TEN]] : tensor<10x10xi32>
-  # CHECK:     return %[[MUL]] : tensor<10x10xi32>
-  # CHECK:   }
+  # CHECK:   %[[TEN]] = tensor.empty() : tensor<10x10xi32>
+  # CHECK:   %[[ADD]] = arith.addi %[[TEN]], %[[TEN]] : tensor<10x10xi32>
+  # CHECK:   %[[MUL]] = arith.muli %[[TEN]], %[[TEN]] : tensor<10x10xi32>
+  # CHECK:   %[[CST1]] = arith.constant dense<{{.*}}> : tensor<10x10xf64>
+  # CHECK:   %[[CST2]] = arith.constant dense<{{.*}}> : tensor<10x10xf64>
+  # CHECK:   %[[CST3]] = arith.constant dense<{{.*}}> : tensor<10x10xf64>
   # CHECK: }
   print(module)
 
-  pm = PassManager.parse(
-      'builtin.module(func.func(convert-elementwise-to-linalg))')
+  pm = PassManager.parse('builtin.module(convert-elementwise-to-linalg)')
   pm.run(module.operation)
 
   # CHECK: #map = affine_map<(d0, d1) -> (d0, d1)>
   # CHECK: module {
-  # CHECK:   func.func @test_tensor_value() -> tensor<10x10xi32> {
-  # CHECK:     %{{.*}} = tensor.empty()
-  # CHECK:     %{{.*}} = linalg.generic
-  # CHECK:     ^bb0(%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i32):
-  # CHECK:       %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
-  # CHECK:       linalg.yield %{{.*}} : i32
-  # CHECK:     } -> tensor<10x10xi32>
-  # CHECK:     %{{.*}} = linalg.generic
-  # CHECK:     ^bb0(%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i32):
-  # CHECK:       %{{.*}} = arith.muli %{{.*}}, %{{.*}} : i32
-  # CHECK:       linalg.yield %{{.*}} : i32
-  # CHECK:     } -> tensor<10x10xi32>
-  # CHECK:     return %{{.*}} : tensor<10x10xi32>
-  # CHECK:   }
+  # CHECK:   %{{.*}} = tensor.empty()
+  # CHECK:   %{{.*}} = linalg.generic
+  # CHECK:   ^bb0(%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i32):
+  # CHECK:     %{{.*}} = arith.addi %{{.*}}, %{{.*}} : i32
+  # CHECK:     linalg.yield %{{.*}} : i32
+  # CHECK:   } -> tensor<10x10xi32>
+  # CHECK:   %{{.*}} = linalg.generic
+  # CHECK:   ^bb0(%{{.*}}: i32, %{{.*}}: i32, %{{.*}}: i32):
+  # CHECK:     %{{.*}} = arith.muli %{{.*}}, %{{.*}} : i32
+  # CHECK:     linalg.yield %{{.*}} : i32
+  # CHECK:   } -> tensor<10x10xi32>
+  # CHECK:   %[[CST1]] = arith.constant dense<{{.*}}> : tensor<10x10xf64>
+  # CHECK:   %[[CST2]] = arith.constant dense<{{.*}}> : tensor<10x10xf64>
+  # CHECK:   %[[CST3]] = arith.constant dense<{{.*}}> : tensor<10x10xf64>
   # CHECK: }
   print(module)
 
 
-# CHECK-LABEL: TEST: testConcatOp
+# CHECK-LABEL: TEST: testConcatenateOp
 @run
-def testConcatOp():
+def testConcatenateOp():
   i32 = IntegerType.get_signless(32)
   with mlir_mod_ctx() as module:
 
     @func.FuncOp.from_py_func()
     def test_concat_op():
-      ten = idx.Tensor.empty((10, 10), i32)
+      ten = Tensor.empty((10, 10), i32)
       # CHECK: Tensor(%[[TEN:.*]], tensor<10x10xi32>)
       print(ten)
 
-      concat_ten_first_dim = idx.ConcatenateOp((ten, ten), 0).result
+      concat_ten_first_dim = indexing.ConcatenateOp((ten, ten), 0).result
       # CHECK: %{{.*}} = "indexing.concatenate"(%[[TEN]], %[[TEN]]) {dimension = 0 : i64} : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<20x10xi32>
       print(concat_ten_first_dim.owner)
 
-      concat_ten_second_dim = idx.ConcatenateOp((ten, ten), 1).result
+      concat_ten_second_dim = indexing.ConcatenateOp((ten, ten), 1).result
       # CHECK: %{{.*}} = "indexing.concatenate"(%[[TEN]], %[[TEN]]) {dimension = 1 : i64} : (tensor<10x10xi32>, tensor<10x10xi32>) -> tensor<10x20xi32>
       print(concat_ten_second_dim.owner)


### PR DESCRIPTION
This PR refactors adds the `mlir_value_subclass`es `TensorValue` and `ScalarValue` to 

1. Support wrapping arbitrary Python objects, in particular objects corresponding to existing IR (`OpView, Operation, Value`) and Python values that can be mapped to corresponding MLIR types (`int, float, bool, np.ndarray`).
2. Perform constant folding; i.e., arithmetic operations on `TensorValue`s and `ScalarValue`s that are the results of `arith.constant` will be evaluated at the time of execution of the Python script.
3. Carry (cached) convenience methods for querying metadata (such as shape and dtype).

A battery of tests is also added to exercise this new functionality.