### PR TITLE
[Indexing] Implement mapping of advanced indexing to `GatherOp`

### DIFF
--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -368,7 +368,41 @@ class Tensor(ArithValue, TensorValue):
     return RankedTensorType.get(static_sizes, dtype)
 
   def __getitem__(self, idx: tuple) -> Scalar:
-    # Early bail for most trivial corner cases (ellipse or one slice(None))
+    """Advanced indexing for tensors.
+
+    This method implements (primarily) a mapping from Numpy style advanced indexing
+    (see https://numpy.org/doc/stable/user/basics.indexing.html#advanced-indexing)
+    to indexing.GatherOp. In particular that means element indexing like ten[0, 1, 2, 3],
+    indexing with slicing like ten[0, :, 1, :], and indexing with lists and tensors is mapped
+    to IR like
+        indexing.gather %[ten][...%idx_tensor...] gather_dims([0]) unique
+          : (tensor<10x10x10x10xf32>, tensor<2x1xindex>) -> tensor<2x10x10x10xf32>
+
+    One particular case to emphasize: indexing with multiple advanced indexors (tensors or lists)
+    For example, ten[ [[0], [0]] , [[1], [1]] , :, :] where the two separate advanced indexers are
+    [[0], [0]] and [[1], [1]]. In such cases (and in more advanced cases) the indexers are concatenated along
+    the last dimension to construct the actual coordinate tuples; i.e., in this case the final advanced indexer
+    is [[0, 0], [1, 1]], which means the slices selected from the tensor `ten` are ten[0, 0, :, :] and ten[1, 1, :, :].
+    The IR generated is like
+
+        indexing.gather %ten[%idx_gensor] gather_dims([0, 1]) unique
+          : (tensor<10x10x10x10xf32>, tensor<2x2xindex>) -> tensor<2x10x10xf32>
+
+    For non-contiguous advanced indexers (i.e., indexing objects inserted at non-contiguous positions in the
+    indexing tuple), e.g., ten[ [[0], [0]] , :, [[1], [1]] , :], exactly the same things occur and the only thing
+    that changes is gather_dims reflect the alternate dimensions:
+
+        indexing.gather %ten[%idx_gensor] gather_dims([0, 2]) unique
+          : (tensor<10x10x10x10xf32>, tensor<2x2xindex>) -> tensor<2x10x10xf32>
+
+    i.e., this is a mechanism for expressing non-contiguous gather_dims.
+
+    Args:
+      idx: The indexing tuple made up various combinations of integers, lists (and lists of) integers, slice objects (:)
+           ellipses, and indexing tensors.
+
+    Returns: A handle to the SSA value corresponding to the result of the indexing.GatherOp instruction.
+    """
     if idx == Ellipsis or idx == slice(None):
       return self
     idx = list((idx,) if isinstance(idx, int) else idx)
@@ -469,8 +503,6 @@ def _expand_dims(y, axis: int) -> Tensor:
      View of `a` with the number of dimensions increased.
 
   """
-  if len(axis) == 0:
-    return y
   if isinstance(y, Scalar):
     assert axis == (0,), f"Expected axis to be 0 but {axis=}."
     if y.fold():
@@ -549,8 +581,8 @@ def _canonicalize_tuple_index(idx: Tuple[Any], rank: int):
   if _is_advanced_int_indexer(idx):
     idx = list(idx)
     for idx_i, idx_e in enumerate(idx):
-      if idx_e is not None and not isinstance(idx_e,
-                                              slice) and idx_e != Ellipsis:
+      if idx_e is not None and not isinstance(
+          idx_e, (slice, Tensor)) and idx_e != Ellipsis:
         idx[idx_i] = _as_index_tensor(idx_e)
     idx = tuple(idx)
 
@@ -594,40 +626,96 @@ def _indices_to_indexer(idx: Sequence[Any],
   idx = _canonicalize_tuple_index(idx, len(in_shape))
 
   in_axis = 0  # Current axis in input.
-  out_axis = 0  # Current axis in output, before collapsing. See below.
   collapsed_dims: Sequence[int] = []
   indices: List[Tensor] = []
+  indices_shape: List[int] = []
   newaxis_dims: Sequence[int] = []
 
+  # Contiguous in terms of dims that the index/slice
+  advanced_axes_are_contiguous = False
+  advanced_indexes: Optional[Sequence[Tensor]] = None
+  # The positions of the advanced indexing axes in `idx`.
+  idx_advanced_axes: Sequence[int] = []
+
+  if _is_advanced_int_indexer(idx):
+    advanced_pairs = [(i, d)
+                      for i, d in enumerate(idx)
+                      if d is not None and _is_index_tensor(d)]
+    idx_advanced_axes, advanced_indexes = zip(*advanced_pairs)
+    advanced_axes_are_contiguous = bool(
+        all([d == 1 for d in np.diff(idx_advanced_axes)]))
+
+  # nb: idx_e <-> idx_element
   for idx_i, idx_e in enumerate(idx):
+    # Handle the advanced indices here if:
+    # * the advanced indices were not contiguous, and we are the start.
+    # * we are at the position of the first advanced index.
+    if advanced_indexes is not None and (
+        advanced_axes_are_contiguous and idx_i == idx_advanced_axes[0] or
+        not advanced_axes_are_contiguous and idx_i == 0):
+      if len(set([tuple(a.shape) for a in advanced_indexes])) != 1:
+        raise IndexError("All advanced indices must have the same shape.")
+      shape = advanced_indexes[0].shape
+
+      indices.extend(advanced_indexes)
+      indices_shape += shape
+
+      # Compute the proper "extent" of index Tensor, e.g., if ten ~ 10x10x10x10x10 and idx ~ 5x6x2
+      # then ten[:, idx, ...] means dims [1, 2] are collapsed and ten[idx, :, idx] means
+      # dims [0, 1, 3, 4] are collapsed.
+      # TODO(max): maybe there's a more "declarative" way to spell this...
+      prev_idx = collapsed_dims[-1] if len(collapsed_dims) else -1
+      for idx_pos, idx_ in enumerate(idx):
+        if idx_pos in idx_advanced_axes:
+          collapsed_dims.extend(np.array(prev_idx + 1) + np.arange(shape[-1]))
+          prev_idx = collapsed_dims[-1]
+        else:
+          prev_idx += 1
+
+    if idx_i in idx_advanced_axes:
+      # skip ahead the number of coordinates, e.g., for a 5x6x2 idx tensor,
+      # skip ahead two axes
+      in_axis += idx[idx_i].shape[-1]
+      continue
+
     if _is_scalar(idx_e) and _has_index_type(idx_e):
-      # Handle basic int indexes.
+      # Handle basic Scalar indexes.
       idx_e = _expand_dims(idx_e, (0,))
       indices.append(idx_e)
       collapsed_dims.append(in_axis)
       in_axis += 1
     elif isinstance(idx_e, slice):
       # Handle slice indices
-      out_axis += 1
+      start, stop, step = idx_e.start, idx_e.stop, idx_e.step
+      if idx_e != slice(None) and (start, stop, step) != (0, in_shape[in_axis],
+                                                          1):
+        raise IndexError(f"Partial slicing currently not supported:\n{idx}")
+
       in_axis += 1
     else:
-      raise IndexError(
-          f"Indexing mode not yet supported. Open a feature request!\n{idx}")
+      raise IndexError(f"Indexing mode not yet supported:\n{idx}")
 
   collapsed_dims: Tuple[int, ...] = tuple(sorted(collapsed_dims))
 
   if len(indices) == 1:
     indices_tensor = indices[0]
   else:
+    if len(indices_shape) == 0:
+      last_dim = 0
+    else:
+      last_dim = len(indices_shape) - 1
     indices_tensor = concatenate(
         indices,
-        0,
+        last_dim,
     )
 
-  lit = indices_tensor.literal_value
-  # flatten all but last dim (i.e., idx/coord dim)
-  coords = lit.reshape(-1, lit.shape[-1])
-  unique_indices = len(np.unique(coords, axis=0)) == len(coords)
+  if indices_tensor.is_constant():
+    lit = indices_tensor.literal_value
+    # flatten all but last dim (i.e., idx/coord dim)
+    coords = lit.reshape(-1, lit.shape[-1])
+    unique_indices = len(np.unique(coords, axis=0)) == len(coords)
+  else:
+    unique_indices = advanced_indexes is None
 
   return _Indexer(
       newaxis_dims=tuple(newaxis_dims),

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -4,12 +4,16 @@ from random import random
 
 import numpy as np
 
-from mlir_structured._mlir_libs._mlir.ir import IndexType
+from mlir_structured._mlir_libs._mlir.ir import IndexType, F32Type
 from mlir_structured.dialects import arith, indexing
 from mlir_structured.dialects.indexing import Scalar, Tensor, IndexTensorType, _canonicalize_tuple_index
 from mlir_structured.ir import Context, IntegerType, F64Type
 from mlir_structured.passmanager import PassManager
 from mlir_structured.runtime.util import mlir_mod_ctx
+
+
+def get_array_on_one_line(a):
+  return np.array_str(a, max_line_width=np.inf).replace("\n", ",")
 
 
 def run(f):
@@ -231,7 +235,6 @@ def testTensorValue():
 def testConcatenateOp():
   i32 = IntegerType.get_signless(32)
   with mlir_mod_ctx() as module:
-
     ten = Tensor.empty((10, 10), i32)
     # CHECK: Tensor(%[[TEN:.*]], tensor<10x10xi32>)
     print(ten)
@@ -271,26 +274,26 @@ def testSimpleLiteralIndexing():
   i32 = IntegerType.get_signless(32)
   with mlir_mod_ctx() as module:
 
-    ten = Tensor.empty((10, 10, 10, 10), i32)
+    ten = Tensor.empty((10, 22, 333, 4444), i32)
     # CHECK: %[[TEN:.*]]
     print(ten.get_name())
 
     w = ten[0]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [0])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
     print(w.owner)
 
     w = ten[2, 4]
     # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [2 4])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x10x10x10xi32>, tensor<2xindex>) -> tensor<10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<333x4444xi32>
     print(w.owner)
 
     w = ten[2, 4, 6]
     # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [2 4 6])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x10x10x10xi32>, tensor<3xindex>) -> tensor<10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<4444xi32>
     print(w.owner)
 
     w = ten[2, 4, 6, 8]
@@ -302,7 +305,7 @@ def testSimpleLiteralIndexing():
     print(Scalar(w.owner.operands[3]))
     # CHECK: Scalar(%[[CST4:.*]], index, 8)
     print(Scalar(w.owner.operands[4]))
-    # CHECK: %extracted = tensor.extract %[[TEN]][%[[CST1]], %[[CST2]], %[[CST3]], %[[CST4]]] : tensor<10x10x10x10xi32>
+    # CHECK: %extracted = tensor.extract %[[TEN]][%[[CST1]], %[[CST2]], %[[CST3]], %[[CST4]]] : tensor<10x22x333x4444xi32>
     print(w.owner)
 
     w = ten[...]
@@ -328,19 +331,19 @@ def testSimpleLiteralIndexing():
     w = ten[1, ...]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, ...]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :, ...]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
     print(w.owner)
 
     try:
@@ -352,97 +355,97 @@ def testSimpleLiteralIndexing():
     w = ten[1, :]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :, :]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
     print(w.owner)
 
     w = ten[:, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x333x4444xi32>
     print(w.owner)
 
     w = ten[:, :, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x22x4444xi32>
     print(w.owner)
 
     w = ten[:, :, :, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([3]) unique : (tensor<10x10x10x10xi32>, tensor<1xindex>) -> tensor<10x10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([3]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x22x333xi32>
     print(w.owner)
 
     w = ten[:, 1, :, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 3]) unique : (tensor<10x10x10x10xi32>, tensor<2xindex>) -> tensor<10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x333xi32>
     print(w.owner)
 
     w = ten[1, :, :, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 3]) unique : (tensor<10x10x10x10xi32>, tensor<2xindex>) -> tensor<10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<22x333xi32>
     print(w.owner)
 
     w = ten[1, 1, :, :]
     # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x10x10x10xi32>, tensor<2xindex>) -> tensor<10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<333x4444xi32>
     print(w.owner)
 
     w = ten[:, :, 1, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2, 3]) unique : (tensor<10x10x10x10xi32>, tensor<2xindex>) -> tensor<10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x22xi32>
     print(w.owner)
 
     w = ten[:, 1, 1, :]
     # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2]) unique : (tensor<10x10x10x10xi32>, tensor<2xindex>) -> tensor<10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x4444xi32>
     print(w.owner)
 
     w = ten[1, :, 1, :]
     # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2]) unique : (tensor<10x10x10x10xi32>, tensor<2xindex>) -> tensor<10x10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<22x4444xi32>
     print(w.owner)
 
     w = ten[1, 1, :, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 3]) unique : (tensor<10x10x10x10xi32>, tensor<3xindex>) -> tensor<10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<333xi32>
     print(w.owner)
 
     w = ten[1, :, 1, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2, 3]) unique : (tensor<10x10x10x10xi32>, tensor<3xindex>) -> tensor<10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<22xi32>
     print(w.owner)
 
     w = ten[:, 1, 1, 1]
     # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2, 3]) unique : (tensor<10x10x10x10xi32>, tensor<3xindex>) -> tensor<10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<10xi32>
     print(w.owner)
 
     w = ten[1, 1, 1, :]
     # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x10x10x10xi32>, tensor<3xindex>) -> tensor<10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<4444xi32>
     print(w.owner)
 
 
@@ -480,3 +483,151 @@ def testCanonicalizeTupleIndexCastListLiteral():
             str(t.type) == 'tensor<2x1xindex>' and t.is_constant() and
             np.array_equal(t.literal_value, [[0], [1]])
             for _, t in tens) and set(i for i, _ in tens) == set(tens_is)
+
+
+# CHECK-LABEL: TEST: testAdvancedIndexing
+@run
+def testAdvancedIndexing():
+  index = IndexType.get()
+  f32 = F32Type.get()
+  with mlir_mod_ctx() as module:
+    ten = Tensor.empty((7, 22, 333, 4444), f32)
+    # CHECK: Tensor(%[[TEN:.*]], tensor<7x22x333x4444xf32>)
+    print(ten)
+
+    w = ten[[[0], [1]], :, :, :]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<2x1xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK{LITERAL}: [[0], [1]]
+    print(get_array_on_one_line(idx_tensor_operand.literal_value))
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0]) unique : (tensor<7x22x333x4444xf32>, tensor<2x1xindex>) -> tensor<2x22x333x4444xf32>
+    print(w.owner)
+
+    w = ten[[[0], [1]], [[0], [1]], :, :]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<2x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK{LITERAL}: [[0 0], [1 1]]
+    print(get_array_on_one_line(idx_tensor_operand.literal_value))
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 1]) unique : (tensor<7x22x333x4444xf32>, tensor<2x2xindex>) -> tensor<2x333x4444xf32>
+    print(w.owner)
+
+    w = ten[[[0], [1]], :, [[0], [1]], :]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<2x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK{LITERAL}: [[0 0], [1 1]]
+    print(get_array_on_one_line(idx_tensor_operand.literal_value))
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 2]) unique : (tensor<7x22x333x4444xf32>, tensor<2x2xindex>) -> tensor<2x22x4444xf32>
+    print(w.owner)
+
+    idx_tensor = np.array([[[0], [5], [1], [8]], [[0], [3], [6], [4]],
+                           [[8], [7], [9], [1]]])
+    idx_tensor = Tensor(idx_tensor, dtype=index)
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x1xindex> True
+    print(idx_tensor.get_name(), idx_tensor.type, idx_tensor.is_constant())
+    # CHECK: %[[IDXTEN:.*]] = arith.constant dense<{{.*}}> : tensor<3x4x1xindex>
+    print(idx_tensor.owner)
+    # CHECK: True
+    print(np.array(idx_tensor.literal_value).dtype == np.int64)
+
+    w = ten[idx_tensor, ...]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x1xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0]) : (tensor<7x22x333x4444xf32>, tensor<3x4x1xindex>) -> tensor<3x4x22x333x4444xf32>
+    print(w.owner)
+
+    w = ten[idx_tensor, idx_tensor, ...]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 1]) : (tensor<7x22x333x4444xf32>, tensor<3x4x2xindex>) -> tensor<3x4x333x4444xf32>
+    print(w.owner)
+
+    w = ten[idx_tensor, :, idx_tensor]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 2]) : (tensor<7x22x333x4444xf32>, tensor<3x4x2xindex>) -> tensor<3x4x22x4444xf32>
+    print(w.owner)
+
+    w = ten[idx_tensor, :, idx_tensor, idx_tensor]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x3xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 2, 3]) : (tensor<7x22x333x4444xf32>, tensor<3x4x3xindex>) -> tensor<3x4x22xf32>
+    print(w.owner)
+
+    idx_tensor = np.array([[[1, 4], [2, 8], [8, 0], [0, 3]],
+                           [[9, 5], [8, 6], [6, 5], [7, 1]],
+                           [[9, 3], [3, 1], [6, 7], [0, 0]]])
+    idx_tensor = Tensor(idx_tensor, dtype=index)
+    # CHECK: %[[IDXTEN:.*]] = arith.constant dense<{{.*}}> : tensor<3x4x2xindex>
+    print(idx_tensor.owner)
+
+    w = indexing.gather(ten, idx_tensor, [0, 1])
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN]] tensor<3x4x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 1]) : (tensor<7x22x333x4444xf32>, tensor<3x4x2xindex>) -> tensor<3x4x333x4444xf32>
+    print(w.owner)
+
+    w = indexing.gather(ten, idx_tensor, [0, 2])
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN]] tensor<3x4x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 2]) : (tensor<7x22x333x4444xf32>, tensor<3x4x2xindex>) -> tensor<3x4x22x4444xf32>
+    print(w.owner)
+
+    w = ten[idx_tensor, ...]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 1]) unique : (tensor<7x22x333x4444xf32>, tensor<3x4x2xindex>) -> tensor<3x4x333x4444xf32>
+    print(w.owner)
+
+    w = ten[:, idx_tensor, ...]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x2xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([1, 2]) unique : (tensor<7x22x333x4444xf32>, tensor<3x4x2xindex>) -> tensor<3x4x7x4444xf32>
+    print(w.owner)
+
+    ten = Tensor.empty((7, 22, 333, 4444, 55555), f32)
+    # CHECK: Tensor(%[[TEN:.*]], tensor<7x22x333x4444x55555xf32>)
+    print(ten)
+
+    w = ten[idx_tensor, :, idx_tensor, ...]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x4xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 1, 3, 4]) unique : (tensor<7x22x333x4444x55555xf32>, tensor<3x4x4xindex>) -> tensor<3x4x333xf32>
+    print(w.owner)
+
+    w = ten[idx_tensor, 0:333:1, idx_tensor, ...]
+    idx_tensor_operand = Tensor(w.owner.operands[1])
+    # CHECK: %[[IDXTEN:.*]] tensor<3x4x4xindex> True
+    print(idx_tensor_operand.get_name(), idx_tensor_operand.type,
+          idx_tensor_operand.is_constant())
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[IDXTEN]]] gather_dims([0, 1, 3, 4]) unique : (tensor<7x22x333x4444x55555xf32>, tensor<3x4x4xindex>) -> tensor<3x4x333xf32>
+    print(w.owner)
+
+    try:
+      w = ten[idx_tensor, 0:333:7, idx_tensor, ...]
+    except IndexError as e:
+      # CHECK: Partial slicing currently not supported
+      print(e)


### PR DESCRIPTION
This PR implements advanced indexing (`gather`) with rectangular array-like objects (Python lists of lists, and index `Tensor`s). Again, the approach closely follows the implementation of `index_to_gather` in [jax](https://github.com/google/jax/blob/main/jax/_src/numpy/lax_numpy.py#L4199).

@nicolasvasilache please take a close look at the lit tests to see whether the semantics are correct (at least the type level).

Currently stacked on top of 

https://github.com/iree-org/iree-llvm-sandbox/pull/711

https://github.com/iree-org/iree-llvm-sandbox/pull/712