### PR TITLE
[Indexing] Add `ARangeOp`

### DIFF
--- a/include/structured/Dialect/Indexing/IR/IndexingDialect.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingDialect.td
@@ -20,6 +20,7 @@ def Indexing_Dialect
   let name = "indexing";
   let cppNamespace = "::mlir::indexing";
   let useDefaultTypePrinterParser = 1;
+  let hasConstantMaterializer = 1;
 }
 
 #endif // STRUCTURED_DIALECT_INDEXING_IR_INDEXINGDIALECT

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -65,4 +65,49 @@ def Indexing_ConcatenateOp : Indexing_Op<"concatenate",
   }];
 }
 
+def Indexing_ARangeOp : Indexing_Op<"arange", [
+    Pure,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>,
+    AttrSizedOperandSegments
+  ]> {
+  let summary = "Return evenly spaced values within a given interval.";
+  let description = [{
+    Example:
+    ```mlir
+    %range = arange(%start, %stop, %step) -> tensor<?xi64>
+    ```
+    Values are generated within the half-open interval [start, stop), with spacing between values given by step.
+  }];
+
+  let arguments = (ins Optional<I64>:$start,
+                       Optional<I64>:$stop,
+                       Optional<I64>:$step,
+                       OptionalAttr<I64Attr>:$startAttr,
+                       OptionalAttr<I64Attr>:$stopAttr,
+                       OptionalAttr<I64Attr>:$stepAttr);
+  let results = (outs 1DTensorOf<[AnyInteger, Index]>:$result);
+  // the reason for the extra double backtick in (```start
+  // is because otherwise an extraneous space is emitted in the pretty print
+  let assemblyFormat = [{
+    `(`
+        (`start` `=` $start^)? (```start` `=` $startAttr^)?
+        `,`
+        (`stop` `=` $stop^)? (`stop` `=` $stopAttr^)?
+        `,`
+        (`step` `=` $step^)? (`step` `=` $stepAttr^)?
+    `)` attr-dict `:` type($result)
+  }];
+
+  let extraClassDeclaration = [{
+    static StringAttr getStartAttrAttrName(MLIRContext *ctx) { return getStartAttrAttrName(OperationName(getOperationName(), ctx)); }
+    static StringAttr getStopAttrAttrName(MLIRContext *ctx) { return getStopAttrAttrName(OperationName(getOperationName(), ctx)); }
+    static StringAttr getStepAttrAttrName(MLIRContext *ctx) { return getStepAttrAttrName(OperationName(getOperationName(), ctx)); }
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
+  }];
+
+  let hasVerifier = 1;
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 #endif // STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -17,6 +17,7 @@ declare_mlir_dialect_python_bindings(
   TD_FILE dialects/IndexingOps.td
   SOURCES
   dialects/indexing.py
+  dialects/_indexing_ops_ext.py
   DIALECT_NAME indexing
 )
 

--- a/python/mlir_structured/dialects/_indexing_ops_ext.py
+++ b/python/mlir_structured/dialects/_indexing_ops_ext.py
@@ -1,0 +1,90 @@
+#  Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+#  See https://llvm.org/LICENSE.txt for license information.
+#  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+try:
+  from .. import ir
+  from ._ods_common import (
+      get_op_result_or_value as _get_op_result_or_value,
+      get_op_results_or_values as _get_op_results_or_values,
+      get_default_loc_context as _get_default_loc_context,
+  )
+except ImportError as e:
+  raise RuntimeError("Error loading imports from extension module") from e
+
+
+class ARangeOp:
+  OPERATION_NAME = "indexing.arange"
+
+  def __init__(self, *, start=None, stop=None, step=None, loc=None, ip=None):
+    operands = []
+
+    for i, inp in enumerate([start, stop, step]):
+      if not bool(isinstance(inp, int)) != bool(isinstance(inp, ir.Value)):
+        raise RuntimeError(
+            f"expected either Value or int but not both for arg {i=}: {inp}.")
+
+    attributes = {"operand_segment_sizes": []}
+    if start is not None and isinstance(start, ir.Value):
+      operands.append(_get_op_result_or_value(start))
+      attributes["operand_segment_sizes"].append(1)
+      startAttr = None
+    else:
+      attributes["operand_segment_sizes"].append(0)
+      startAttr = start
+
+    if stop is not None and isinstance(stop, ir.Value):
+      operands.append(_get_op_result_or_value(stop))
+      attributes["operand_segment_sizes"].append(1)
+      stopAttr = None
+    else:
+      attributes["operand_segment_sizes"].append(0)
+      stopAttr = stop
+
+    if step is not None and isinstance(step, ir.Value):
+      operands.append(_get_op_result_or_value(step))
+      attributes["operand_segment_sizes"].append(1)
+      stepAttr = None
+    else:
+      attributes["operand_segment_sizes"].append(0)
+      stepAttr = step
+
+    attributes["operand_segment_sizes"] = ir.DenseI32ArrayAttr.get(
+        attributes["operand_segment_sizes"])
+
+    _ods_context = _get_default_loc_context(loc)
+
+    if startAttr is not None:
+      attributes["startAttr"] = (startAttr if
+                                 (issubclass(type(startAttr), ir.Attribute) or
+                                  not ir.AttrBuilder.contains('I64Attr')) else
+                                 ir.AttrBuilder.get('I64Attr')(
+                                     startAttr, context=_ods_context))
+    if stopAttr is not None:
+      attributes["stopAttr"] = (stopAttr if
+                                (issubclass(type(stopAttr), ir.Attribute) or
+                                 not ir.AttrBuilder.contains('I64Attr')) else
+                                ir.AttrBuilder.get('I64Attr')(
+                                    stopAttr, context=_ods_context))
+    if stepAttr is not None:
+      attributes["stepAttr"] = (stepAttr if
+                                (issubclass(type(stepAttr), ir.Attribute) or
+                                 not ir.AttrBuilder.contains('I64Attr')) else
+                                ir.AttrBuilder.get('I64Attr')(
+                                    stepAttr, context=_ods_context))
+    results = ir.InferTypeOpInterface(ARangeOp).inferReturnTypes(
+        operands=operands,
+        attributes=ir.DictAttr.get(attributes, context=_ods_context),
+        context=_ods_context,
+        loc=loc)
+    _ods_successors = None
+    # TODO(max): use a regular builder after https://reviews.llvm.org/D151409
+    # gets merged and we catch up.
+    arange_op = ir.Operation.create(self.OPERATION_NAME,
+                                    operands=operands,
+                                    results=results,
+                                    regions=0,
+                                    attributes=attributes,
+                                    loc=loc,
+                                    ip=ip)
+    ir.OpView.__init__(self, arange_op)

--- a/python/mlir_structured/runtime/util.py
+++ b/python/mlir_structured/runtime/util.py
@@ -10,13 +10,19 @@ from mlir_structured.ir import (
 
 
 @contextlib.contextmanager
-def mlir_mod_ctx(src: Optional[str] = None,
-                 context: Optional[Context] = None,
-                 location: Optional[Location] = None):
+def mlir_mod_ctx(
+    src: Optional[str] = None,
+    context: Optional[Context] = None,
+    location: Optional[Location] = None,
+):
   if context is None:
-    context = Context()
+    try:
+      context = Context.current
+    except ValueError as e:
+      assert str(e) == "No current Context"
+      context = Context()
   if location is None:
-    location = Location.unknown()
+    location = Location.unknown(context=context)
   with context, location:
     if src is not None:
       module = Module.parse(src)

--- a/test/Dialect/Indexing/basic.mlir
+++ b/test/Dialect/Indexing/basic.mlir
@@ -1,23 +1,57 @@
-// RUN: structured-opt %s \
-// RUN: | FileCheck %s
+// RUN: structured-opt %s --split-input-file | FileCheck %s
 
 // CHECK: module {
 // CHECK:   func.func @foo(%arg0: !indexing.custom<"bob">) {
-// CHECK:     %c2_i32 = arith.constant 2 : i32
-// CHECK:     %0 = tensor.empty() : tensor<10x10xi32>
-// CHECK:     %1 = tensor.empty() : tensor<1x2x2xi32>
-// CHECK:     %2 = indexing.gather %0[%1] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
-// CHECK:     %3 = indexing.concatenate(%2, %2) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
+// CHECK:     %[[TEN1:.*]] = tensor.empty() : tensor<10x10xi32>
+// CHECK:     %[[IDXTEN:.*]] = tensor.empty() : tensor<1x2x2xi32>
+// CHECK:     %[[GATHER:.*]] = indexing.gather %[[TEN1]][%[[IDXTEN]]] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
+// CHECK:     %[[CONCAT:.*]] = indexing.concatenate(%2, %2) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
+// CHECK:     %[[C0:.*]] = arith.constant 0 : i64
+// CHECK:     %[[C100:.*]] = arith.constant 100 : i64
+// CHECK:     %[[C2:.*]] = arith.constant 2 : i64
+// CHECK:     %4 = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) : tensor<?xindex>
 // CHECK:     return
 // CHECK:   }
 // CHECK: }
 module {
   func.func @foo(%arg0: !indexing.custom<"bob">) {
-    %c2_i32 = arith.constant 2 : i32
     %0 = tensor.empty() : tensor<10x10xi32>
     %1 = tensor.empty() : tensor<1x2x2xi32>
     %2 = indexing.gather %0[%1] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
     %3 = indexing.concatenate (%2, %2) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
+    %c0_i64 = arith.constant 0 : i64
+    %c100_i64 = arith.constant 100 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %4 = indexing.arange(start = %c0_i64, stop = %c100_i64, step = %c2_i64) : tensor<?xindex>
     return
   }
+}
+
+// -----
+
+// CHECK: module {
+// CHECK:   %[[START:.*]] = arith.constant 0 : i64
+// CHECK:   %[[STOP:.*]] = arith.constant 100 : i64
+// CHECK:   %[[STEP:.*]] = arith.constant 2 : i64
+// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
+// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
+// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?xindex>
+// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?xindex>
+// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?xindex>
+// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?xindex>
+// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?xindex>
+// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
+// CHECK: }
+module {
+  %0 = arith.constant 0 : i64
+  %1 = arith.constant 100 : i64
+  %2 = arith.constant 2 : i64
+  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : i64} : (i64, i64) -> tensor<?xindex>
+  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : i64} : (i64, i64) -> tensor<?xindex>
+  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : i64} : (i64, i64) -> tensor<?xindex>
+  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xindex>
+  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : i64, stepAttr = 2 : i64} : (i64) -> tensor<?xindex>
+  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xindex>
+  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : i64, stepAttr = 2 : i64, stopAttr = 100 : i64} : () -> tensor<50xindex>
 }

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -1,0 +1,82 @@
+// RUN: structured-opt -canonicalize -allow-unregistered-dialect -mlir-print-op-generic -split-input-file %s | FileCheck %s
+
+// CHECK: "builtin.module"() ({
+// CHECK:   "func.func"() <{function_type = () -> (), sym_name = "test_canonicalize_to_attrs"}> ({
+// CHECK:     %[[C0:.*]] = "c0_i64_dyn"() : () -> i64
+// CHECK:     %[[C100:.*]] = "c100_i64_dyn"() : () -> i64
+// CHECK:     %[[C2:.*]] = "c2_i64_dyn"() : () -> i64
+// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xi64>
+// CHECK:     "use1"(%[[ARA]]) : (tensor<?xi64>) -> ()
+// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]], %[[C100]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : i64} : (i64, i64) -> tensor<?xi64>
+// CHECK:     "use2"(%[[ARA]]) : (tensor<?xi64>) -> ()
+// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]], %[[C100]], %[[C2]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+// CHECK:     "use3"(%[[ARA]]) : (tensor<?xindex>) -> ()
+// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xindex>
+// CHECK:     "use4"(%[[ARA]]) : (tensor<?xindex>) -> ()
+// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]], %[[C100]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : i64} : (i64, i64) -> tensor<?xindex>
+// CHECK:     "use5"(%[[ARA]]) : (tensor<?xindex>) -> ()
+// CHECK:     "func.return"() : () -> ()
+// CHECK:   }) : () -> ()
+// CHECK: }) : () -> ()
+
+module {
+  func.func @test_canonicalize_to_attrs() {
+    %c100_i64 = arith.constant 100 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %one = arith.constant 1 : i64
+    %c0_i64_dyn = "c0_i64_dyn"() : () -> (i64)
+    %c100_i64_dyn = "c100_i64_dyn"() : () -> (i64)
+    %c2_i64_dyn = "c2_i64_dyn"() : () -> (i64)
+
+    %10 = "indexing.arange"(%c0_i64_dyn, %c100_i64, %c2_i64) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    "use1"(%10) : (tensor<?xindex>) -> ()
+
+    %11 = "indexing.arange"(%c0_i64_dyn, %c100_i64_dyn, %c2_i64) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    "use2"(%11) : (tensor<?xindex>) -> ()
+
+    %12 = "indexing.arange"(%c0_i64_dyn, %c100_i64_dyn, %c2_i64_dyn) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    "use3"(%12) : (tensor<?xindex>) -> ()
+
+    %13 = "indexing.arange"(%c0_i64_dyn) {stopAttr = 100 : i64, stepAttr = 2 : i64, operand_segment_sizes = array<i32: 1, 0, 0>} : (i64) -> tensor<?xindex>
+    "use4"(%13) : (tensor<?xindex>) -> ()
+
+    %14 = "indexing.arange"(%c0_i64_dyn, %c100_i64_dyn) {stepAttr = 2 : i64, operand_segment_sizes = array<i32: 1, 1, 0>} : (i64, i64) -> tensor<?xindex>
+    "use5"(%14) : (tensor<?xindex>) -> ()
+
+    return
+  }
+}
+
+// -----
+
+// CHECK: "builtin.module"() ({
+// CHECK:   "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
+// CHECK:     %[[ARA:.*]] = "arith.constant"() <{value = dense<[0, 2, {{.*}}, 98]> : tensor<50xi64>}> : () -> tensor<50xi64>
+// CHECK:     "use1"(%[[ARA]]) : (tensor<50xi64>) -> ()
+// CHECK:     "use2"(%[[ARA]]) : (tensor<50xi64>) -> ()
+// CHECK:     "use3"(%[[ARA]]) : (tensor<50xi64>) -> ()
+//           this doesn't get folded because the return type is index
+// CHECK:     %[[ARA:.*]] = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : i64, stepAttr = 2 : i64, stopAttr = 100 : i64} : () -> tensor<50xindex>
+// CHECK:     "use4"(%[[ARA]]) : (tensor<50xindex>) -> ()
+// CHECK:     "func.return"() : () -> ()
+// CHECK:   }) : () -> ()
+// CHECK: }) : () -> ()
+
+module {
+  func.func @test_fold() {
+    %c0_i64 = arith.constant 0 : i64
+    %c100_i64 = arith.constant 100 : i64
+    %c2_i64 = arith.constant 2 : i64
+
+    %4 = "indexing.arange"(%c0_i64, %c100_i64, %c2_i64) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    "use1"(%4) : (tensor<?xindex>) -> ()
+    %5 = "indexing.arange"(%c0_i64, %c2_i64) {stopAttr = 100 : i64, operand_segment_sizes = array<i32: 1, 0, 1>} : (i64, i64) -> tensor<?xindex>
+    "use2"(%5) : (tensor<?xindex>) -> ()
+    %si = "indexing.arange"(%c0_i64) {stopAttr = 100 : i64, stepAttr = 2 : i64, operand_segment_sizes = array<i32: 1, 0, 0>} : (i64) -> tensor<?xindex>
+    "use3"(%si) : (tensor<?xindex>) -> ()
+    %se = "indexing.arange"() {startAttr = 0 : i64, stopAttr = 100 : i64, stepAttr = 2 : i64, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50xindex>
+    "use4"(%se) : (tensor<50xindex>) -> ()
+
+    return
+  }
+}


### PR DESCRIPTION
This PR adds an `indexing.arange` op that supports literals for `start, stop, step` and runtime values. As well, a canonicalizer is provided that converts the former to the lateral if the runtime values are all `arith.constant`s.