### PR TITLE
[Triton] Add basic CAPI and Python bindings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ include(AddLLVM)
 include(AddMLIR)
 
 ################################################################################
-# Set up Trion
+# Set up Triton
 ################################################################################
 
 set(TRITON_ROOT_DIR ${STRUCTURED_MAIN_SRC_DIR}/third_party/triton)

--- a/include/structured-c/Dialects.h
+++ b/include/structured-c/Dialects.h
@@ -69,6 +69,13 @@ MLIR_CAPI_EXPORTED MlirType mlirTabularViewTypeGetColumnType(MlirType type,
 MLIR_CAPI_EXPORTED MlirType mlirTabularViewTypeGetRowType(MlirType type);
 
 //===----------------------------------------------------------------------===//
+// Triton dialects and attributes
+//===----------------------------------------------------------------------===//
+
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Triton, triton);
+MLIR_DECLARE_CAPI_DIALECT_REGISTRATION(Triton, triton_gpu);
+
+//===----------------------------------------------------------------------===//
 // Tuple dialect and attributes
 //===----------------------------------------------------------------------===//
 

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -14,4 +14,6 @@ add_mlir_public_c_api_library(StructuredCAPI
     MLIRTupleTransforms
     MLIRPass
     MLIRStatesToLLVM
+    TritonGPUIR
+    TritonIR
 )

--- a/lib/CAPI/Dialects.cpp
+++ b/lib/CAPI/Dialects.cpp
@@ -18,11 +18,15 @@
 #include "structured/Dialect/Iterators/IR/Iterators.h"
 #include "structured/Dialect/Tabular/IR/Tabular.h"
 #include "structured/Dialect/Tuple/IR/Tuple.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
+#include "triton/Dialect/TritonGPU/IR/Dialect.h"
 
 using namespace mlir;
 using namespace mlir::indexing;
 using namespace mlir::iterators;
 using namespace mlir::tabular;
+using namespace mlir::triton;
+using namespace mlir::triton::gpu;
 using namespace mlir::tuple;
 
 //===----------------------------------------------------------------------===//
@@ -103,6 +107,13 @@ MlirType mlirTabularViewTypeGetColumnType(MlirType type, intptr_t pos) {
 MlirType mlirTabularViewTypeGetRowType(MlirType type) {
   return wrap(unwrap(type).cast<TabularViewType>().getRowType());
 }
+
+//===----------------------------------------------------------------------===//
+// Triton dialect and attributes
+//===----------------------------------------------------------------------===//
+
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(Triton, triton, TritonDialect)
+MLIR_DEFINE_CAPI_DIALECT_REGISTRATION(TritonGPU, triton_gpu, TritonGPUDialect)
 
 //===----------------------------------------------------------------------===//
 // Tuple dialect and attributes

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -41,6 +41,24 @@ declare_mlir_dialect_python_bindings(
 declare_mlir_dialect_python_bindings(
   ADD_TO_PARENT StructuredPythonSources.Dialects
   ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
+  TD_FILE dialects/TritonOps.td
+  SOURCES
+  dialects/triton.py
+  DIALECT_NAME tt
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT StructuredPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
+  TD_FILE dialects/TritonGPUOps.td
+  SOURCES
+  dialects/triton_gpu.py
+  DIALECT_NAME triton_gpu
+)
+
+declare_mlir_dialect_python_bindings(
+  ADD_TO_PARENT StructuredPythonSources.Dialects
+  ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/mlir_structured"
   TD_FILE dialects/TupleOps.td
   SOURCES
   dialects/tuple.py

--- a/python/StructuredDialects.cpp
+++ b/python/StructuredDialects.cpp
@@ -140,6 +140,46 @@ PYBIND11_MODULE(_structuredDialects, mainModule) {
       .def("get_row_type", mlirTabularViewTypeGetRowType);
 
   //===--------------------------------------------------------------------===//
+  // Triton dialect.
+  //===--------------------------------------------------------------------===//
+  auto tritonModule = mainModule.def_submodule("triton");
+
+  //
+  // Dialect
+  //
+
+  tritonModule.def(
+      "register_dialect",
+      [](MlirContext context, bool doLoad) {
+        MlirDialectHandle handle = mlirGetDialectHandle__triton__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (doLoad) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context") = py::none(), py::arg("load") = true);
+
+  //===--------------------------------------------------------------------===//
+  // Triton GPU dialect.
+  //===--------------------------------------------------------------------===//
+  auto tritonGpuModule = mainModule.def_submodule("triton_gpu");
+
+  //
+  // Dialect
+  //
+
+  tritonGpuModule.def(
+      "register_dialect",
+      [](MlirContext context, bool doLoad) {
+        MlirDialectHandle handle = mlirGetDialectHandle__triton_gpu__();
+        mlirDialectHandleRegisterDialect(handle, context);
+        if (doLoad) {
+          mlirDialectHandleLoadDialect(handle, context);
+        }
+      },
+      py::arg("context") = py::none(), py::arg("load") = true);
+
+  //===--------------------------------------------------------------------===//
   // Tuple dialect.
   //===--------------------------------------------------------------------===//
   auto tupleModule = mainModule.def_submodule("tuple");

--- a/python/mlir_structured/dialects/TritonGPUOps.td
+++ b/python/mlir_structured/dialects/TritonGPUOps.td
@@ -1,0 +1,13 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYTHON_BINDINGS_TRITONGPU_OPS
+#define PYTHON_BINDINGS_TRITONGPU_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "triton/Dialect/TritonGPU/IR/TritonGPUOps.td"
+
+#endif // PYTHON_BINDINGS_TRITONGPU_OPS

--- a/python/mlir_structured/dialects/TritonOps.td
+++ b/python/mlir_structured/dialects/TritonOps.td
@@ -1,0 +1,13 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef PYTHON_BINDINGS_TRITON_OPS
+#define PYTHON_BINDINGS_TRITON_OPS
+
+include "mlir/Bindings/Python/Attributes.td"
+include "triton/Dialect/Triton/IR/TritonOps.td"
+
+#endif // PYTHON_BINDINGS_TRITON_OPS

--- a/python/mlir_structured/dialects/triton.py
+++ b/python/mlir_structured/dialects/triton.py
@@ -1,0 +1,9 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._tt_ops_gen import *
+from .._mlir_libs._structuredDialects.triton import *
+from .._mlir_libs import _mlirStructuredPasses as _cextStructuredPasses

--- a/python/mlir_structured/dialects/triton_gpu.py
+++ b/python/mlir_structured/dialects/triton_gpu.py
@@ -1,0 +1,9 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from ._triton_gpu_ops_gen import *
+from .._mlir_libs._structuredDialects.triton_gpu import *
+from .._mlir_libs import _mlirStructuredPasses as _cextStructuredPasses

--- a/test/python/dialects/triton/dialect.py
+++ b/test/python/dialects/triton/dialect.py
@@ -1,0 +1,39 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+from mlir_structured.dialects import triton as tt
+from mlir_structured.dialects import triton_gpu as ttg
+from mlir_structured.ir import (
+    Context,
+    IntegerType,
+    Location,
+    RankedTensorType,
+)
+
+
+def run(f):
+  print("\nTEST:", f.__name__)
+  with Context(), Location.unknown():
+    tt.register_dialect()
+    ttg.register_dialect()
+    f()
+  return f
+
+
+# CHECK-LABEL: TEST: testTritionDialectRegistered
+@run
+def testTritionDialectRegistered():
+  i32 = IntegerType.get_signless(32)
+  tensor_type = RankedTensorType.get([16], i32)
+  r = tt.MakeRangeOp(tensor_type, 0, 16)
+  # CHECK-NEXT: %{{.*}} = tt.make_range {end = 16 : i32, start = 0 : i32} : tensor<16xi32>
+  print(r)
+
+
+# CHECK-LABEL: TEST: testTritionGpuDialectRegistered
+@run
+def testTritionGpuDialectRegistered():
+  i32 = IntegerType.get_signless(32)
+  tensor_type = RankedTensorType.get([16], i32)
+  # CHECK-NEXT: %{{.*}} = "triton_gpu.alloc_tensor"() : () -> tensor<16xi32>
+  t = ttg.AllocTensorOp(tensor_type)
+  print(t)


### PR DESCRIPTION
This depends on #708 and its transitive dependencies.