### PR TITLE
[Triton] Add new TritonToLLVM pass that lowers tt.func etc to LLVM.

### DIFF
--- a/include/structured/Conversion/Passes.h
+++ b/include/structured/Conversion/Passes.h
@@ -13,6 +13,7 @@
 #include "structured/Conversion/IteratorsToLLVM/IteratorsToLLVM.h"
 #include "structured/Conversion/StatesToLLVM/StatesToLLVM.h"
 #include "structured/Conversion/TabularToLLVM/TabularToLLVM.h"
+#include "structured/Conversion/TritonToLLVM/TritonToLLVM.h"
 #include "triton/Conversion/TritonGPUToLLVM/TritonGPUToLLVMPass.h"
 #include "triton/Conversion/TritonToTritonGPU/TritonToTritonGPUPass.h"
 #include "triton/Dialect/Triton/Transforms/Passes.h"

--- a/include/structured/Conversion/Passes.td
+++ b/include/structured/Conversion/Passes.td
@@ -101,9 +101,17 @@ def ConvertTabularToLLVM : Pass<"convert-tabular-to-llvm", "ModuleOp"> {
 def ConvertTritonToLLVM : Pass<"convert-triton-to-llvm", "ModuleOp"> {
   let summary = "Convert the operations from Triton dialect to LLVM";
   let description = [{
+    Converts the operations from Triton's `tt` dialect to the LLVM dialect such
+    that they can run on a CPU.
+
+    For now, only a subset of the tt dialect is supported. The plan is to extend
+    the coverage progressively. Some of the conversions may go through upstream
+    dialects, which are then lowered to LLVM using upstream pattersn; another
+    possibility is to use a subset of Triton's pattern if they happen to work.
   }];
   let constructor = "mlir::createConvertTritonToLLVMPass()";
   let dependentDialects = [
+    "func::FuncDialect",
     "LLVM::LLVMDialect"
   ];
 }

--- a/include/structured/Conversion/Passes.td
+++ b/include/structured/Conversion/Passes.td
@@ -94,4 +94,18 @@ def ConvertTabularToLLVM : Pass<"convert-tabular-to-llvm", "ModuleOp"> {
   let dependentDialects = ["LLVM::LLVMDialect"];
 }
 
+//===----------------------------------------------------------------------===//
+// TritonToLLVM
+//===----------------------------------------------------------------------===//
+
+def ConvertTritonToLLVM : Pass<"convert-triton-to-llvm", "ModuleOp"> {
+  let summary = "Convert the operations from Triton dialect to LLVM";
+  let description = [{
+  }];
+  let constructor = "mlir::createConvertTritonToLLVMPass()";
+  let dependentDialects = [
+    "LLVM::LLVMDialect"
+  ];
+}
+
 #endif // STRUCTURED_CONVERSION_PASSES

--- a/include/structured/Conversion/TritonToLLVM/TritonToLLVM.h
+++ b/include/structured/Conversion/TritonToLLVM/TritonToLLVM.h
@@ -1,0 +1,30 @@
+//===-- TritonToLLVM.h - Utils to convert from Triton to LLVM ---*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef STRUCTURED_CONVERSION_TRITONTOLLVM_TRITONTOLLVM_H
+#define STRUCTURED_CONVERSION_TRITONTOLLVM_TRITONTOLLVM_H
+
+#include <memory>
+
+namespace mlir {
+class ModuleOp;
+template <typename T>
+class OperationPass;
+class RewritePatternSet;
+class TypeConverter;
+
+/// Populate the given list with patterns that convert from Triton to LLVM.
+void populateTritonToLLVMConversionPatterns(RewritePatternSet &patterns,
+                                            TypeConverter &typeConverter);
+
+/// Create a pass to convert Triton operations to the LLVM dialect.
+std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonToLLVMPass();
+
+} // namespace mlir
+
+#endif // STRUCTURED_CONVERSION_TRITONTOLLVM_TRITONTOLLVM_H

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -18,6 +18,7 @@ add_mlir_public_c_api_library(StructuredCAPI
     MLIRIteratorsTransforms
     MLIRTabular
     MLIRTabularToLLVM
+    MLIRTritonToLLVM
     MLIRTupleDialect
     MLIRTupleTransforms
     MLIRPass

--- a/lib/Conversion/CMakeLists.txt
+++ b/lib/Conversion/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(IteratorsToLLVM)
 add_subdirectory(StatesToLLVM)
 add_subdirectory(TabularToLLVM)
+add_subdirectory(TritonToLLVM)

--- a/lib/Conversion/TritonToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonToLLVM/CMakeLists.txt
@@ -5,7 +5,11 @@ add_mlir_conversion_library(MLIRTritonToLLVM
   MLIRStructuredConversionIncGen
 
   LINK_LIBS PUBLIC
+  MLIRFuncDialect
+  MLIRFuncToLLVM
+  MLIRLLVMCommonConversion
   MLIRLLVMDialect
   MLIRPass
   MLIRTransformUtils
+  TritonIR
 )

--- a/lib/Conversion/TritonToLLVM/CMakeLists.txt
+++ b/lib/Conversion/TritonToLLVM/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_conversion_library(MLIRTritonToLLVM
+  TritonToLLVM.cpp
+
+  DEPENDS
+  MLIRStructuredConversionIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRLLVMDialect
+  MLIRPass
+  MLIRTransformUtils
+)

--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -1,0 +1,61 @@
+//===-- TritonToLLVM.cpp - Conversion from Triton to LLVM -------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "structured/Conversion/TritonToLLVM/TritonToLLVM.h"
+
+#include "../PassDetail.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+class MLIRContext;
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::LLVM;
+
+namespace {
+struct ConvertTritonToLLVMPass
+    : public ConvertTritonToLLVMBase<ConvertTritonToLLVMPass> {
+  void runOnOperation() override;
+};
+} // namespace
+
+void mlir::populateTritonToLLVMConversionPatterns(
+    RewritePatternSet &patterns, TypeConverter &typeConverter) {}
+
+void ConvertTritonToLLVMPass::runOnOperation() {
+  auto module = getOperation();
+  TypeConverter typeConverter;
+
+  // Convert the remaining ops of this dialect using dialect conversion.
+  ConversionTarget target(getContext());
+  target.addLegalDialect<LLVMDialect>();
+  target.addLegalOp<ModuleOp>();
+  RewritePatternSet patterns(&getContext());
+
+  populateTritonToLLVMConversionPatterns(patterns, typeConverter);
+
+  // Use UnrealizedConversionCast as materializations, which have to be cleaned
+  // up by later passes.
+  auto addUnrealizedCast = [](OpBuilder &builder, Type type, ValueRange inputs,
+                              Location loc) {
+    auto cast = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
+    return Optional<Value>(cast.getResult(0));
+  };
+  typeConverter.addSourceMaterialization(addUnrealizedCast);
+  typeConverter.addTargetMaterialization(addUnrealizedCast);
+
+  if (failed(applyPartialConversion(module, target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> mlir::createConvertTritonToLLVMPass() {
+  return std::make_unique<ConvertTritonToLLVMPass>();
+}

--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -9,30 +9,72 @@
 #include "structured/Conversion/TritonToLLVM/TritonToLLVM.h"
 
 #include "../PassDetail.h"
+#include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "triton/Dialect/Triton/IR/Dialect.h"
 
 namespace mlir {
 class MLIRContext;
 } // namespace mlir
 
 using namespace mlir;
+using namespace mlir::func;
 using namespace mlir::LLVM;
+using namespace triton;
 
 namespace {
 struct ConvertTritonToLLVMPass
     : public ConvertTritonToLLVMBase<ConvertTritonToLLVMPass> {
   void runOnOperation() override;
 };
+
+/// Replaces an op of type SourceOp to an op of type TargetOp while preserving
+/// all types, operands, attributes, successors, regions, and its location.
+template <typename SourceOp, typename TargetOp>
+struct OneToOneOpConversion : public OpConversionPattern<SourceOp> {
+  OneToOneOpConversion(TypeConverter &typeConverter, MLIRContext *context,
+                       PatternBenefit benefit = 1)
+      : OpConversionPattern<SourceOp>(typeConverter, context, benefit) {}
+
+  using OpAdaptor = typename OpConversionPattern<SourceOp>::OpAdaptor;
+
+  LogicalResult
+  matchAndRewrite(SourceOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MLIRContext *context = this->getContext();
+    SmallVector<std::unique_ptr<Region>> regions;
+    for (auto &region : op->getRegions()) {
+      auto &newRegion = regions.emplace_back(new Region);
+      rewriter.inlineRegionBefore(region, *newRegion, newRegion->end());
+    }
+    Operation *newOp = rewriter.create(
+        op->getLoc(), StringAttr::get(context, TargetOp::getOperationName()),
+        op->getOperands(), op->getResultTypes(), op->getAttrs(),
+        op->getSuccessors(), regions);
+    rewriter.replaceOp(op, newOp->getResults());
+    return success();
+  }
+};
 } // namespace
 
 void mlir::populateTritonToLLVMConversionPatterns(
-    RewritePatternSet &patterns, TypeConverter &typeConverter) {}
+    RewritePatternSet &patterns, TypeConverter &typeConverter) {
+  patterns.add<
+      // clang-format off
+      OneToOneOpConversion<triton::CallOp, func::CallOp>,
+      OneToOneOpConversion<triton::FuncOp, func::FuncOp>,
+      OneToOneOpConversion<triton::ReturnOp, func::ReturnOp>
+      // clang-format on
+      >(typeConverter, patterns.getContext());
+}
 
 void ConvertTritonToLLVMPass::runOnOperation() {
   auto module = getOperation();
-  TypeConverter typeConverter;
+  LLVMTypeConverter typeConverter(&getContext());
 
   // Convert the remaining ops of this dialect using dialect conversion.
   ConversionTarget target(getContext());
@@ -40,7 +82,12 @@ void ConvertTritonToLLVMPass::runOnOperation() {
   target.addLegalOp<ModuleOp>();
   RewritePatternSet patterns(&getContext());
 
+  // Lower tt.func op and friends to corresponding ops from func.
   populateTritonToLLVMConversionPatterns(patterns, typeConverter);
+
+  // Lower ops from func to LLVM.
+  populateFuncToLLVMFuncOpConversionPattern(typeConverter, patterns);
+  populateFuncToLLVMConversionPatterns(typeConverter, patterns);
 
   // Use UnrealizedConversionCast as materializations, which have to be cleaned
   // up by later passes.

--- a/test/Conversion/TritonToLLVM/empty.mlir
+++ b/test/Conversion/TritonToLLVM/empty.mlir
@@ -1,0 +1,10 @@
+// RUN: structured-opt %s \
+// RUN:   -convert-triton-to-llvm \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: llvm.func @kernel()
+// CHECK-SAME:      attributes {sym_visibility = "public"} {
+// CHECK-NEXT:    llvm.return
+tt.func public @kernel() {
+  tt.return
+}

--- a/test/Integration/Dialect/Triton/CPU/empty.mlir
+++ b/test/Integration/Dialect/Triton/CPU/empty.mlir
@@ -1,7 +1,14 @@
 // Run through CPU runner to make sure the output of the full pipeline is valid.
+
+// Pipeline with original passes from Triton.
 // RUN: structured-opt %s \
 // RUN:   -convert-triton-to-tritongpu \
 // RUN:   -convert-triton-gpu-to-llvm \
+// RUN: | mlir-cpu-runner -e kernel -entry-point-result=void
+
+// Pipeline with our own passes.
+// RUN: structured-opt %s \
+// RUN:   -convert-triton-to-llvm \
 // RUN: | mlir-cpu-runner -e kernel -entry-point-result=void
 
 tt.func public @kernel() {


### PR DESCRIPTION
This PR currently depends on #720 and its dependencies.