### PR TITLE
[Triton][CI] Install CPU-only version of pytorch in CI. (NFC)

### DIFF
--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -35,7 +35,8 @@ jobs:
     - name: Install Python depends
       run: |
         cd ${STRUCTURED_MAIN_SRC_DIR}
-        python -m pip install -r requirements.txt
+        python -m pip install -v -r requirements.txt
+        python -m pip install -v -r requirements-triton.txt
 
     - name: Install Ninja
       uses: llvm/actions/install-ninja@6a57890d0e3f9f35dfc72e7e48bc5e1e527cdd6c # Jan 17

--- a/requirements-triton.txt
+++ b/requirements-triton.txt
@@ -1,0 +1,5 @@
+# Install CPU-only version of Torch. This is in an extra file because the way to
+# install that version is via the --index-url option, and that option applies to
+# the whole command.
+--index-url https://download.pytorch.org/whl/cpu
+torch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # MLIR dependencies.
 -r third_party/llvm-project/mlir/python/requirements.txt
 
-# Triton and dependencies.
-torch
+# Compile and install triton.
 third_party/triton/python/
 
 # Testing.


### PR DESCRIPTION
I had occasional out-of-disk-space errors in CI recently and the CUDA dependencies of pytorch for GPUs sum up to over 1GB.