### PR TITLE
[Triton] Extend conversion of tt.load and tt.store to 1D tensor inputs.

### DIFF
--- a/include/structured/Conversion/Passes.td
+++ b/include/structured/Conversion/Passes.td
@@ -135,6 +135,7 @@ def ConvertTritonToLLVM : Pass<"convert-triton-to-llvm", "ModuleOp"> {
   let dependentDialects = [
     "arith::ArithDialect",
     "LLVM::LLVMDialect",
+    "scf::SCFDialect",
     "tensor::TensorDialect"
   ];
 }

--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -122,6 +122,10 @@ struct LoadOpConversion : public OpConversionPattern<triton::LoadOp> {
     }
 
     // Tensor of pointers.
+    // TODO(ingomueller): This is a manual tiling by one. That is fine in order
+    //     to get things running but drops a lot of information. Eventually, we
+    //     want to map this to a vectorized load/gather in order to distribute
+    //     the loading over SIMT threads.
     if (auto tensorType = ptrType.dyn_cast<RankedTensorType>()) {
       if (!tensorType.hasStaticShape())
         return rewriter.notifyMatchFailure(
@@ -264,6 +268,10 @@ struct StoreOpConversion : public OpConversionPattern<triton::StoreOp> {
     }
 
     // Tensor of pointers.
+    // TODO(ingomueller): This is a manual tiling by one. That is fine in order
+    //     to get things running but drops a lot of information. Eventually, we
+    //     want to map this to a vectorized store/scatter in order to distribute
+    //     the storing over SIMT threads.
     if (auto tensorType = ptrType.dyn_cast<RankedTensorType>()) {
       if (!tensorType.hasStaticShape())
         return rewriter.notifyMatchFailure(

--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -209,6 +209,14 @@ void ConvertTritonToLLVMPass::runOnOperation() {
         typeConverter.convertType(type.getPointeeType()),
         type.getAddressSpace());
   });
+  // TODO(ingomueller): This drops the address space attribute. Is that a
+  //     problem?
+  // TODO(ingomueller): This converts a pointer to an index whose value is the
+  //     address of the pointer. While this covers the general case, very often
+  //     the pointers belong to a single allocation, which could be represented
+  //     as a base pointer and a tensor of offsets. That, in turn, would
+  //     preserve the semantics about the loads being local to each other and
+  //     maybe fit to (to be developped) primitives in the indexing dialect.
   typeConverter.addConversion([&](RankedTensorType type) -> Type {
     if (auto ptrType = type.getElementType().dyn_cast<triton::PointerType>()) {
       auto idx = IndexType::get(type.getContext());

--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
@@ -28,6 +29,7 @@ class MLIRContext;
 using namespace mlir;
 using namespace mlir::arith;
 using namespace mlir::LLVM;
+using namespace mlir::scf;
 using namespace mlir::tensor;
 using namespace triton;
 
@@ -108,14 +110,65 @@ struct LoadOpConversion : public OpConversionPattern<triton::LoadOp> {
     if (op.getMask() || op.getOther())
       return failure();
 
+    Location loc = op->getLoc();
     Type ptrType = op.getPtr().getType();
 
-    // Only handle scalar pointers to numerics for now.
+    // Scalar pointer.
     if (auto ttPtrType = ptrType.dyn_cast<triton::PointerType>()) {
       if (ttPtrType.getPointeeType().isIntOrIndexOrFloat()) {
         rewriter.replaceOpWithNewOp<LLVM::LoadOp>(op, adaptor.getPtr());
         return success();
       }
+    }
+
+    // Tensor of pointers.
+    if (auto tensorType = ptrType.dyn_cast<RankedTensorType>()) {
+      if (!tensorType.hasStaticShape())
+        return rewriter.notifyMatchFailure(
+            loc, "only static shapes supported for now");
+      if (tensorType.getRank() != 1)
+        return rewriter.notifyMatchFailure(loc,
+                                           "only 1D tensors supported for now");
+
+      // Derive types.
+      Type elementType =
+          op.getResult().getType().cast<TensorType>().getElementType();
+      auto elementPtrType =
+          tensorType.getElementType().cast<triton::PointerType>();
+      auto llvmPtrType = typeConverter->convertType(elementPtrType);
+
+      // Compute bounds of for loop.
+      Value lb = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      Value ub = rewriter.create<arith::ConstantIndexOp>(
+          loc, tensorType.getDimSize(0));
+      Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+      // Load each tensor element at a time.
+      Value values = rewriter.create<tensor::EmptyOp>(
+          loc, tensorType.getShape(), elementType);
+      auto forOp = rewriter.create<scf::ForOp>(
+          loc, lb, ub, step, ValueRange{values},
+          [&](OpBuilder &b, Location loc, Value iv, ValueRange args) {
+            Value values = args[0];
+            Type idx = b.getIndexType();
+            Type i64 = b.getI64Type();
+
+            // Extract index, convert to pointer, and load from there.
+            Value address =
+                b.create<tensor::ExtractOp>(loc, idx, adaptor.getPtr(), iv);
+            address = b.create<arith::IndexCastOp>(loc, i64, address);
+            address = b.create<LLVM::IntToPtrOp>(loc, llvmPtrType, address);
+            Value element = rewriter.create<LLVM::LoadOp>(loc, address);
+
+            // Insert extracted value into result tensor.
+            values = b.create<tensor::InsertOp>(loc, element, values, iv);
+
+            b.create<scf::YieldOp>(loc, values);
+          });
+      values = forOp.getResult(0);
+
+      rewriter.replaceOp(op, values);
+      return success();
     }
 
     return failure();
@@ -198,15 +251,63 @@ struct StoreOpConversion : public OpConversionPattern<triton::StoreOp> {
     if (op.getMask())
       return failure();
 
+    Location loc = op->getLoc();
     Type ptrType = op.getPtr().getType();
 
-    // Only handle scalar pointers to numerics for now.
+    // Scalar pointer.
     if (auto ttPtrType = ptrType.dyn_cast<triton::PointerType>()) {
       if (ttPtrType.getPointeeType().isIntOrIndexOrFloat()) {
         rewriter.replaceOpWithNewOp<LLVM::StoreOp>(op, adaptor.getValue(),
                                                    adaptor.getPtr());
         return success();
       }
+    }
+
+    // Tensor of pointers.
+    if (auto tensorType = ptrType.dyn_cast<RankedTensorType>()) {
+      if (!tensorType.hasStaticShape())
+        return rewriter.notifyMatchFailure(
+            loc, "only static shapes supported for now");
+      if (tensorType.getRank() != 1)
+        return rewriter.notifyMatchFailure(loc,
+                                           "only 1D tensors supported for now");
+
+      // Derive types.
+      Type elementType =
+          op.getValue().getType().cast<TensorType>().getElementType();
+      auto elementPtrType =
+          tensorType.getElementType().cast<triton::PointerType>();
+      auto llvmPtrType = typeConverter->convertType(elementPtrType);
+
+      // Compute bounds of for loop.
+      Value lb = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+      Value ub = rewriter.create<arith::ConstantIndexOp>(
+          loc, tensorType.getDimSize(0));
+      Value step = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+
+      // Store each tensor element at a time.
+      rewriter.create<scf::ForOp>(
+          loc, lb, ub, step, ValueRange{},
+          [&](OpBuilder &b, Location loc, Value iv, ValueRange args) {
+            Type idx = b.getIndexType();
+            Type i64 = b.getI64Type();
+
+            // Extract value that should be stored
+            Value element = b.create<tensor::ExtractOp>(loc, elementType,
+                                                        adaptor.getValue(), iv);
+
+            // Extract address, cast to pointer, and store value there.
+            Value address =
+                b.create<tensor::ExtractOp>(loc, idx, adaptor.getPtr(), iv);
+            address = b.create<arith::IndexCastOp>(loc, i64, address);
+            address = b.create<LLVM::IntToPtrOp>(loc, llvmPtrType, address);
+            rewriter.create<LLVM::StoreOp>(loc, element, address);
+
+            b.create<scf::YieldOp>(loc);
+          });
+      rewriter.eraseOp(op);
+
+      return success();
     }
 
     return failure();
@@ -260,7 +361,8 @@ void ConvertTritonToLLVMPass::runOnOperation() {
 
   // Convert the remaining ops of this dialect using dialect conversion.
   ConversionTarget target(getContext());
-  target.addLegalDialect<ArithDialect, LLVMDialect, TensorDialect>();
+  target
+      .addLegalDialect<ArithDialect, LLVMDialect, SCFDialect, TensorDialect>();
   target.addLegalOp<ModuleOp>();
   RewritePatternSet patterns(&getContext());
 

--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -122,15 +122,31 @@ struct SplatOpConversion : public OpConversionPattern<triton::SplatOp> {
   LogicalResult
   matchAndRewrite(triton::SplatOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value src = adaptor.getSrc();
+    Location loc = op->getLoc();
+    Type i64 = rewriter.getI64Type();
+    Type idx = rewriter.getIndexType();
 
-    // Don't handle splatting of pointers yet.
-    if (src.getType().isa<LLVMPointerType>())
-      return failure();
-    assert(src.getType().isIntOrFloat());
+    Value src = adaptor.getSrc();
+    TensorType tensorType;
+
+    // Depending on element type: conversion of splat value and tensor type.
+    if (src.getType().isa<LLVMPointerType>()) {
+      // Pointers.
+      Type originalResultType = op.getResult().getType();
+      Type convertedResultType = typeConverter->convertType(originalResultType);
+      tensorType = convertedResultType.cast<TensorType>();
+      assert(tensorType.getElementType() == idx);
+
+      // Convert pointer to int, then cast to index.
+      src = rewriter.create<LLVM::PtrToIntOp>(loc, i64, src);
+      src = rewriter.create<arith::IndexCastOp>(loc, idx, src);
+    } else {
+      // Numeric scalars.
+      assert(src.getType().isIntOrFloat());
+      tensorType = op.getResult().getType().cast<TensorType>();
+    }
 
     // Replace tt.splat with tensor.splat.
-    Type tensorType = op.getResult().getType();
     rewriter.replaceOpWithNewOp<tensor::SplatOp>(op, src, tensorType);
 
     return success();
@@ -192,6 +208,13 @@ void ConvertTritonToLLVMPass::runOnOperation() {
     return LLVM::LLVMPointerType::get(
         typeConverter.convertType(type.getPointeeType()),
         type.getAddressSpace());
+  });
+  typeConverter.addConversion([&](RankedTensorType type) -> Type {
+    if (auto ptrType = type.getElementType().dyn_cast<triton::PointerType>()) {
+      auto idx = IndexType::get(type.getContext());
+      return RankedTensorType::get(type.getShape(), idx);
+    }
+    return type;
   });
 
   // Convert the remaining ops of this dialect using dialect conversion.

--- a/python/mlir_structured/triton/compiler.py
+++ b/python/mlir_structured/triton/compiler.py
@@ -96,8 +96,17 @@ def compile(fn, **kwargs):
     pm = PassManager.parse('builtin.module('
                            '  convert-triton-func-to-func,'
                            '  convert-triton-to-llvm,'
+                           '  convert-elementwise-to-linalg,'
+                           '  empty-tensor-to-alloc-tensor,'
+                           '  one-shot-bufferize,'
+                           '  func.func(convert-linalg-to-loops),'
+                           '  expand-strided-metadata,'
+                           '  finalize-memref-to-llvm,'
                            '  convert-arith-to-llvm,'
-                           '  convert-func-to-llvm'
+                           '  convert-index-to-llvm,'
+                           '  convert-scf-to-cf,'
+                           '  convert-func-to-llvm,'
+                           '  canonicalize'
                            ')')
     try:
       pm.run(mod.operation)

--- a/test/Conversion/TritonToLLVM/add-ptr.mlir
+++ b/test/Conversion/TritonToLLVM/add-ptr.mlir
@@ -1,5 +1,5 @@
 // RUN: structured-opt %s \
-// RUN:   -convert-triton-to-llvm \
+// RUN:   -convert-triton-to-llvm -split-input-file \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: func.func public @kernel(
@@ -9,5 +9,24 @@
 // CHECK-NEXT:    return
 func.func public @kernel(%arg0: !tt.ptr<i32>, %arg1: i32) {
   %0 = tt.addptr %arg0, %arg1 : !tt.ptr<i32>, i32
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func public @kernel(
+// CHECK-SAME:      %[[ARG0:.*]]: !llvm.ptr<i32, 1>)
+// CHECK-DAG:     %[[V0:.*]] = arith.constant dense<0> : tensor<1xi32>
+// CHECK-DAG:     %[[V1:.*]] = tensor.splat %{{.*}} : tensor<1xindex>
+// CHECK-DAG:     %[[V2:.*]] = arith.index_cast %[[V0]] : tensor<1xi32> to tensor<1xindex>
+// CHECK-DAG:     %[[V3:.*]] = arith.constant 4 : index
+// CHECK-DAG:     %[[V4:.*]] = tensor.splat %[[V3]] : tensor<1xindex>
+// CHECK-DAG:     %[[V5:.*]] = arith.muli %[[V2]], %[[V4]] : tensor<1xindex>
+// CHECK-DAG:     %[[V6:.*]] = arith.addi %[[V1]], %[[V5]] : tensor<1xindex>
+// CHECK-NEXT:    return
+func.func public @kernel(%arg0: !tt.ptr<i32>) {
+  %0 = arith.constant dense<[0]> : tensor<1xi32>
+  %1 = tt.splat %arg0 : (!tt.ptr<i32>) -> tensor<1x!tt.ptr<i32>>
+  %2 = tt.addptr %1, %0 : tensor<1x!tt.ptr<i32>>, tensor<1xi32>
   return
 }

--- a/test/Conversion/TritonToLLVM/load.mlir
+++ b/test/Conversion/TritonToLLVM/load.mlir
@@ -1,5 +1,5 @@
 // RUN: structured-opt %s \
-// RUN:   -convert-triton-to-llvm \
+// RUN:   -convert-triton-to-llvm -split-input-file \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: func.func public @kernel(
@@ -8,5 +8,31 @@
 // CHECK-NEXT:    return
 func.func public @kernel(%arg0: !tt.ptr<i32>) {
   %0 = tt.load %arg0 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : i32
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func public @kernel(
+// CHECK-SAME:      %[[ARG0:.*]]: !llvm.ptr<i32, 1>)
+// CHECK-DAG:     %[[V0:.*]] = arith.addi %{{.*}}, %{{.*}} : tensor<2xindex>
+// CHECK-DAG:     %[[V1:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[V2:.*]] = arith.constant 2 : index
+// CHECK-DAG:     %[[V3:.*]] = arith.constant 1 : index
+// CHECK-DAG:     %[[V4:.*]] = tensor.empty() : tensor<2xi32>
+// CHECK-NEXT:    %[[V5:.*]] = scf.for %[[ARG1:.*]] = %[[V1]] to %[[V2]] step %[[V3]] iter_args(%[[ARG2:.*]] = %[[V4]]) -> (tensor<2xi32>) {
+// CHECK-DAG:       %[[V6:.*]] = tensor.extract %[[V0]][%[[ARG1]]] : tensor<2xindex>
+// CHECK-DAG:       %[[V7:.*]] = arith.index_cast %[[V6]] : index to i64
+// CHECK-DAG:       %[[V8:.*]] = llvm.inttoptr %[[V7]] : i64 to !llvm.ptr<i32, 1>
+// CHECK-DAG:       %[[V9:.*]] = llvm.load %[[V8]] : !llvm.ptr<i32, 1>
+// CHECK-DAG:       %[[Va:.*]] = tensor.insert %[[V9]] into %[[ARG2]][%[[ARG1]]] : tensor<2xi32>
+// CHECK-NEXT:      scf.yield %[[Va]] : tensor<2xi32>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+func.func public @kernel(%arg0: !tt.ptr<i32>) {
+  %0 = arith.constant dense<0> : tensor<2xi32>
+  %1 = tt.splat %arg0 : (!tt.ptr<i32>) -> tensor<2x!tt.ptr<i32>>
+  %2 = tt.addptr %1, %0 : tensor<2x!tt.ptr<i32>>, tensor<2xi32>
+  %3 = tt.load %2 {cache = 1 : i32, evict = 1 : i32, isVolatile = false} : tensor<2xi32>
   return
 }

--- a/test/Conversion/TritonToLLVM/splat.mlir
+++ b/test/Conversion/TritonToLLVM/splat.mlir
@@ -1,5 +1,5 @@
 // RUN: structured-opt %s \
-// RUN:   -convert-triton-to-llvm \
+// RUN:   -convert-triton-to-llvm -split-input-file \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: func.func public @kernel(
@@ -8,5 +8,18 @@
 // CHECK-NEXT:    return
 func.func public @kernel(%arg0: f64) {
   %0 = tt.splat %arg0 : (f64) -> tensor<4xf64>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func public @kernel(
+// CHECK-SAME:      %[[ARG0:.*]]: !llvm.ptr<f64, 1>)
+// CHECK-NEXT:    %[[V0:.*]] = llvm.ptrtoint %[[ARG0]] : !llvm.ptr<f64, 1> to i64
+// CHECK-NEXT:    %[[V1:.*]] = arith.index_cast %[[V0]] : i64 to index
+// CHECK-NEXT:    %[[V2:.*]] = tensor.splat %[[V1]] : tensor<4xindex>
+// CHECK-NEXT:    return
+func.func public @kernel(%arg0: !tt.ptr<f64>) {
+  %0 = tt.splat %arg0 : (!tt.ptr<f64>) -> tensor<4x!tt.ptr<f64>>
   return
 }

--- a/test/Conversion/TritonToLLVM/store.mlir
+++ b/test/Conversion/TritonToLLVM/store.mlir
@@ -1,5 +1,5 @@
 // RUN: structured-opt %s \
-// RUN:   -convert-triton-to-llvm \
+// RUN:   -convert-triton-to-llvm -split-input-file \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: func.func public @kernel(
@@ -9,5 +9,30 @@
 // CHECK-NEXT:    return
 func.func public @kernel(%arg0: !tt.ptr<i32>, %arg1: i32) {
   tt.store %arg0, %arg1 {cache = 1 : i32, evict = 1 : i32} : i32
+  return
+}
+
+// -----
+
+// CHECK-LABEL: func.func public @kernel(
+// CHECK-SAME:      %[[ARG0:.*]]: !llvm.ptr<i32, 1>)
+// CHECK-DAG:     %[[V0:.*]] = arith.constant dense<0> : tensor<2xi32>
+// CHECK-DAG:     %[[V1:.*]] = arith.addi %{{.*}}, %{{.*}} : tensor<2xindex>
+// CHECK-DAG:     %[[V2:.*]] = arith.constant 0 : index
+// CHECK-DAG:     %[[V3:.*]] = arith.constant 2 : index
+// CHECK-DAG:     %[[V4:.*]] = arith.constant 1 : index
+// CHECK-NEXT:    scf.for %[[ARG1:.*]] = %[[V2]] to %[[V3]] step %[[V4]] {
+// CHECK-DAG:       %[[V5:.*]] = tensor.extract %[[V0]][%[[ARG1]]] : tensor<2xi32>
+// CHECK-DAG:       %[[V6:.*]] = tensor.extract %[[V1]][%[[ARG1]]] : tensor<2xindex>
+// CHECK-DAG:       %[[V7:.*]] = arith.index_cast %[[V6]] : index to i64
+// CHECK-DAG:       %[[V8:.*]] = llvm.inttoptr %[[V7]] : i64 to !llvm.ptr<i32, 1>
+// CHECK-NEXT:      llvm.store %[[V5]], %[[V8]] : !llvm.ptr<i32, 1>
+// CHECK-NEXT:    }
+// CHECK-NEXT:    return
+func.func public @kernel(%arg0: !tt.ptr<i32>) {
+  %0 = arith.constant dense<0> : tensor<2xi32>
+  %1 = tt.splat %arg0 : (!tt.ptr<i32>) -> tensor<2x!tt.ptr<i32>>
+  %2 = tt.addptr %1, %0 : tensor<2x!tt.ptr<i32>>, tensor<2xi32>
+  tt.store %2, %0 {cache = 1 : i32, evict = 1 : i32} : tensor<2xi32>
   return
 }

--- a/test/python/dialects/triton/jit.py
+++ b/test/python/dialects/triton/jit.py
@@ -45,3 +45,22 @@ def load_store_scalar():
 
   # CHECK-NEXT: tensor([42], dtype=torch.int32)
   print(X)
+
+
+# CHECK-LABEL: TEST: load_store_tensor
+@run
+def load_store_tensor():
+
+  @jit
+  def kernel(ptr):
+    r = tl.arange(0, 4)
+    ptr_r = ptr + r
+    t = tl.load(ptr_r)
+    t = t + t
+    tl.store(ptr_r, t)
+
+  X = torch.tensor(list(range(100, 104)), dtype=torch.int32)
+  kernel[(1,)](X)
+
+  # CHECK-NEXT: tensor([200, 202, 204, 206], dtype=torch.int32)
+  print(X)


### PR DESCRIPTION
This PR depends on ~~#727~~, #731, #750, ~~#746~~, and their dependencies, ~~as well as [D150952](https://reviews.llvm.org/D150952)~~. ~~It also depends on #746 but does not include it yet, and CI is expected to fail while it doesn't.~~

TODO:

- [x] Decide when to lower `func` ops to LLVM (resolved by #750).
   Until now, we converted `tt.func` and friends to `func.func` and those into `llvm.func` in one go (by adding patterns for both steps to the same pass). However, this doesn't allow to use `-convert-linalg-to-loops`, which only works on `func.func` and which this PR uses for the first time. I guess that this indicates, that we shouldn't lower everything to LLVM, but changing that probably requires redesigning the whole pipeline (or actually *designing* one rather than just getting a first thing to work).