### PR TITLE
[Indexing] implement None indices

### DIFF
--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -85,7 +85,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
                        OptionalAttr<IndexAttr>:$startAttr,
                        OptionalAttr<IndexAttr>:$stopAttr,
                        OptionalAttr<IndexAttr>:$stepAttr);
-  let results = (outs 1DTensorOf<[Index]>:$result);
+  let results = (outs 2DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
   let assemblyFormat = [{

--- a/lib/Dialect/Indexing/IR/Indexing.cpp
+++ b/lib/Dialect/Indexing/IR/Indexing.cpp
@@ -123,7 +123,7 @@ LogicalResult ARangeOp::inferReturnTypes(
     RegionRange regions, SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   if (!operands.empty()) {
     inferredReturnTypes.assign({RankedTensorType::get(
-        {ShapedType::kDynamic}, IndexType::get(context))});
+        {ShapedType::kDynamic, 1}, IndexType::get(context))});
   } else if (!attributes.empty() &&
              attributes.contains(ARangeOp::getStartAttrAttrName(context)) &&
              attributes.contains(ARangeOp::getStopAttrAttrName(context)) &&
@@ -138,7 +138,7 @@ LogicalResult ARangeOp::inferReturnTypes(
                     .cast<IntegerAttr>()
                     .getInt();
     inferredReturnTypes.assign({RankedTensorType::get(
-        {getARangeLen(start, stop, step)}, IndexType::get(context))});
+        {getARangeLen(start, stop, step), 1}, IndexType::get(context))});
   } else {
     return failure();
   }
@@ -270,7 +270,7 @@ OpFoldResult ARangeOp::fold(FoldAdaptor adaptor) {
   for (int64_t i = start; i < stop; i += step) {
     arange.push_back(i);
   }
-  auto type = RankedTensorType::get({len}, IndexType::get(getContext()));
+  auto type = RankedTensorType::get({len, 1}, IndexType::get(getContext()));
   return DenseElementsAttr::get(type, ArrayRef(arange));
 }
 

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -492,7 +492,8 @@ def arange(start: Union[Scalar, int],
     stop = start
     start = 0
     if stop.fold() and fold:
-      return Tensor(arange(start=start, stop=stop.literal_value, step=1),
+      return Tensor(np.arange(start=start, stop=stop.literal_value,
+                              step=1)[:, np.newaxis],
                     dtype=IndexType.get())
     else:
       return Tensor(ARangeOp(start=start, stop=stop, step=1),
@@ -505,7 +506,7 @@ def arange(start: Union[Scalar, int],
       if start.fold() and stop.fold() and fold:
         return Tensor(np.arange(start=start.literal_value,
                                 stop=stop.literal_value,
-                                step=1),
+                                step=1)[:, np.newaxis],
                       dtype=IndexType.get(),
                       fold=True)
       else:
@@ -517,7 +518,7 @@ def arange(start: Union[Scalar, int],
     if start.fold() and stop.fold() and step.fold() and fold:
       return Tensor(np.arange(start=start.literal_value,
                               stop=stop.literal_value,
-                              step=step.literal_value),
+                              step=step.literal_value)[:, np.newaxis],
                     dtype=IndexType.get(),
                     fold=True)
     else:

--- a/test/Dialect/Indexing/basic.mlir
+++ b/test/Dialect/Indexing/basic.mlir
@@ -9,7 +9,7 @@
 // CHECK:             %[[VAL_5:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_6:.*]] = arith.constant 100 : index
 // CHECK:             %[[VAL_7:.*]] = arith.constant 2 : index
-// CHECK:             %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) : tensor<?xindex>
+// CHECK:             %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) : tensor<?x1xindex>
 // CHECK:             return
 // CHECK:           }
 // CHECK:         }
@@ -23,7 +23,7 @@ module {
     %c0_index = arith.constant 0 : index
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
-    %4 = indexing.arange(start = %c0_index, stop = %c100_index, step = %c2_index) : tensor<?xindex>
+    %4 = indexing.arange(start = %c0_index, stop = %c100_index, step = %c2_index) : tensor<?x1xindex>
     return
   }
 }
@@ -34,28 +34,28 @@ module {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
-// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
-// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
-// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?x1xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
 // CHECK:         }
 
 module {
   %0 = arith.constant 0 : index
   %1 = arith.constant 100 : index
   %2 = arith.constant 2 : index
-  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
-  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : index} : (index, index) -> tensor<?xindex>
-  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : index} : (index, index) -> tensor<?xindex>
-  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
-  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
-  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : index, stepAttr = 2 : index} : (index) -> tensor<?xindex>
-  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
-  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50xindex>
+  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : index} : (index, index) -> tensor<?x1xindex>
+  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : index} : (index, index) -> tensor<?x1xindex>
+  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : index, stepAttr = 2 : index} : (index) -> tensor<?x1xindex>
+  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
 }
 
 // -----
@@ -64,26 +64,26 @@ module {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
-// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
-// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
-// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
-// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?x1xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
 // CHECK:         }
 
 module {
   %c0 = arith.constant 0 : index
   %c100 = arith.constant 100 : index
   %c2 = arith.constant 2 : index
-  %0 = indexing.arange(start = %c0, stop = %c100, step = %c2) : tensor<?xindex>
-  %1 = indexing.arange(start = 0, stop = %c100, step = %c2) : tensor<?xindex>
-  %2 = indexing.arange(start = %c0, stop = 100, step = %c2) : tensor<?xindex>
-  %3 = indexing.arange(start = %c0, stop = %c100, step = 2) : tensor<?xindex>
-  %4 = indexing.arange(start = 0, stop = 100, step = %c2) : tensor<?xindex>
-  %5 = indexing.arange(start = 0, stop = %c100, step = 2) : tensor<?xindex>
-  %6 = indexing.arange(start = %c0, stop = 100, step = 2) : tensor<?xindex>
-  %7 = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
+  %0 = indexing.arange(start = %c0, stop = %c100, step = %c2) : tensor<?x1xindex>
+  %1 = indexing.arange(start = 0, stop = %c100, step = %c2) : tensor<?x1xindex>
+  %2 = indexing.arange(start = %c0, stop = 100, step = %c2) : tensor<?x1xindex>
+  %3 = indexing.arange(start = %c0, stop = %c100, step = 2) : tensor<?x1xindex>
+  %4 = indexing.arange(start = 0, stop = 100, step = %c2) : tensor<?x1xindex>
+  %5 = indexing.arange(start = 0, stop = %c100, step = 2) : tensor<?x1xindex>
+  %6 = indexing.arange(start = %c0, stop = 100, step = 2) : tensor<?x1xindex>
+  %7 = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
 }

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -5,16 +5,16 @@
 // CHECK:             %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
 // CHECK:             %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
 // CHECK:             %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
-// CHECK:             %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
-// CHECK:             "use1"(%[[VAL_3]]) : (tensor<?xindex>) -> ()
-// CHECK:             %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
-// CHECK:             "use2"(%[[VAL_4]]) : (tensor<?xindex>) -> ()
-// CHECK:             %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
-// CHECK:             "use3"(%[[VAL_5]]) : (tensor<?xindex>) -> ()
-// CHECK:             %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
-// CHECK:             "use4"(%[[VAL_6]]) : (tensor<?xindex>) -> ()
-// CHECK:             %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
-// CHECK:             "use5"(%[[VAL_7]]) : (tensor<?xindex>) -> ()
+// CHECK:             %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:             "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
+// CHECK:             %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:             "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
+// CHECK:             %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+// CHECK:             "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
+// CHECK:             %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:             "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
+// CHECK:             %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:             "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
 // CHECK:             "func.return"() : () -> ()
 // CHECK:           }) : () -> ()
 // CHECK:         }) : () -> ()
@@ -28,20 +28,20 @@ module {
     %c100_index_dyn = "c100_index_dyn"() : () -> (index)
     %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
-    "use1"(%10) : (tensor<?xindex>) -> ()
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    "use1"(%10) : (tensor<?x1xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
-    "use2"(%11) : (tensor<?xindex>) -> ()
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    "use2"(%11) : (tensor<?x1xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
-    "use3"(%12) : (tensor<?xindex>) -> ()
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    "use3"(%12) : (tensor<?x1xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_index_dyn) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
-    "use4"(%13) : (tensor<?xindex>) -> ()
+    %13 = "indexing.arange"(%c0_index_dyn) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    "use4"(%13) : (tensor<?x1xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?xindex>
-    "use5"(%14) : (tensor<?xindex>) -> ()
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
+    "use5"(%14) : (tensor<?x1xindex>) -> ()
 
     return
   }
@@ -51,14 +51,15 @@ module {
 
 // CHECK-LABEL:   "builtin.module"() ({
 // CHECK:           "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
-// CHECK:             %[[VAL_0:.*]] = "arith.constant"() <{value = dense<[0, 2, 4, 6, 8, 10, {{.*}}, 98]> : tensor<50xindex>}> : () -> tensor<50xindex>
-// CHECK:             "use1"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
-// CHECK:             "use2"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
-// CHECK:             "use3"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
-// CHECK:             "use4"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
+// CHECK:             %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
+// CHECK:             "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
+// CHECK:             "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
+// CHECK:             "use3"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
+// CHECK:             "use4"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
 // CHECK:             "func.return"() : () -> ()
 // CHECK:           }) : () -> ()
 // CHECK:         }) : () -> ()
+
 
 
 module {
@@ -67,14 +68,14 @@ module {
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
-    "use1"(%4) : (tensor<?xindex>) -> ()
-    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?xindex>
-    "use2"(%5) : (tensor<?xindex>) -> ()
-    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
-    "use3"(%si) : (tensor<?xindex>) -> ()
-    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50xindex>
-    "use4"(%se) : (tensor<50xindex>) -> ()
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    "use1"(%4) : (tensor<?x1xindex>) -> ()
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
+    "use2"(%5) : (tensor<?x1xindex>) -> ()
+    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    "use3"(%si) : (tensor<?x1xindex>) -> ()
+    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
+    "use4"(%se) : (tensor<50x1xindex>) -> ()
 
     return
   }

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -652,35 +652,35 @@ def testARangeOpBasics():
     print(step.get_name())
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=stop, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=100, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=stop, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=100, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
     print(ara.owner)
 
   module.operation.verify()
@@ -698,7 +698,7 @@ def testARangeFun():
     # CHECK: Value(%[[C2:.*]] = arith.constant 2 : index)
     print(ara.owner.operands[2])
 
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(0, 100, fold=False)
@@ -706,25 +706,25 @@ def testARangeFun():
     print(ara.owner.operands[0])
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[1])
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(100, fold=False)
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[0])
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) : tensor<?xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(0, 100, 2)
-    # CHECK: %{{.*}} = arith.constant dense<[0, 2, 4, 6, 8, {{.*}}, 98]> : tensor<50xindex>
+    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [2], [4], [6], [8], {{.*}}, [98]]> : tensor<50x1xindex>
     print(ara.owner)
 
     ara = arange(0, 100)
-    # CHECK: %{{.*}} = arith.constant dense<[0, 1, 2, 3, 4, {{.*}}, 99]> : tensor<100xindex>
+    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
     print(ara.owner)
 
     ara = arange(100)
-    # CHECK: %{{.*}} = arith.constant dense<[0, 1, 2, 3, 4, 5, 6, 7, {{.*}}, 99]> : tensor<100xindex>
+    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
     print(ara.owner)
 
   print(module.operation.verify())
@@ -756,7 +756,7 @@ def testARangeOpSemantics():
       step = np.random.randint(1, 100)
 
       ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=step))
-      r = np.arange(start, stop, step)
+      r = np.arange(start, stop, step)[:, np.newaxis]
 
       if len(r) != (stop - start) // step + 1:
         assert (stop - start) % step == 0


### PR DESCRIPTION
Depends on https://github.com/iree-org/iree-llvm-sandbox/pull/736

This PR implements `None` indexing by way of `tensor.ExpandShapeOp`:

```python
    ten = Tensor.empty((7, 22, 333, 4444), f32)
    w = ten[:, None]
    print(w.owner)
```

which prints

```
    %2 = tensor.expand_shape %1 [[0, 1], [2], [3], [4]] : tensor<7x22x333x4444xf32> into tensor<7x1x22x333x4444xf32>
```