### PR TITLE
[Indexing] Arbitrary slicing

### DIFF
--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -9,6 +9,7 @@
 #ifndef STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS
 #define STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS
 
+include "mlir/IR/OpBase.td"
 include "structured/Dialect/Indexing/IR/IndexingDialect.td"
 include "structured/Dialect/Indexing/IR/IndexingTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -63,6 +64,10 @@ def Indexing_ConcatenateOp : Indexing_Op<"concatenate",
   let assemblyFormat = [{
      `(` $inputs `)` `{` `dim` `=` $dimension `}` attr-dict `:` functional-type(operands, results)
   }];
+
+  let extraClassDeclaration = [{
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
+  }];
 }
 
 def Indexing_ARangeOp : Indexing_Op<"arange", [
@@ -84,7 +89,8 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
                        Optional<Index>:$step,
                        OptionalAttr<IndexAttr>:$startAttr,
                        OptionalAttr<IndexAttr>:$stopAttr,
-                       OptionalAttr<IndexAttr>:$stepAttr);
+                       OptionalAttr<IndexAttr>:$stepAttr,
+                       DefaultValuedAttr<BoolAttr, "false">:$foldAttr);
   let results = (outs 2DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
@@ -95,6 +101,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
         `stop` `=` ($stop^) : ($stopAttr)?
         `,`
         `step` `=` ($step^) : ($stepAttr)?
+        (`,` `fold` `=` $foldAttr^)?
     `)` attr-dict `:` type($result)
   }];
 

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -36,6 +36,9 @@ def Indexing_GatherOp : Indexing_Op<"gather", [
     $source `[` $indices `]` `gather_dims` `(` $gather_dims `)` (`unique` $unique^)? attr-dict
         `:` functional-type(operands, results)
   }];
+  let extraClassDeclaration = [{
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
+  }];
 }
 
 def Indexing_ConcatenateOp : Indexing_Op<"concatenate",
@@ -79,7 +82,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
   let description = [{
     Example:
     ```mlir
-    %range = arange(%start, %stop, %step) -> tensor<?xi64>
+    %range = arange(%start, %stop, %step) -> tensor<?xindex>
     ```
     Values are generated within the half-open interval [start, stop), with spacing between values given by step.
   }];

--- a/lib/Dialect/Indexing/IR/Indexing.cpp
+++ b/lib/Dialect/Indexing/IR/Indexing.cpp
@@ -17,10 +17,6 @@
 #include "mlir/Support/MathExtras.h"
 #include "mlir/Transforms/InliningUtils.h"
 #include "llvm/ADT/TypeSwitch.h"
-#include "llvm/Support/Debug.h"
-#include <mlir/IR/BuiltinAttributes.h>
-
-#define DEBUG_TYPE "indexing-dialect"
 
 #include <numeric>
 
@@ -80,6 +76,12 @@ LogicalResult GatherOp::inferReturnTypes(
       /*rankReduced=*/true);
   inferredReturnTypes.assign({expectedResultType});
   return success();
+}
+
+bool GatherOp::isCompatibleReturnTypes(TypeRange l, TypeRange r) {
+  if (l.size() != r.size() || l.size() != 1)
+    return false;
+  return succeeded(verifyCompatibleShape(l[0], r[0]));
 }
 
 //===----------------------------------------------------------------------===//

--- a/python/mlir_structured/dialects/_indexing_ops_ext.py
+++ b/python/mlir_structured/dialects/_indexing_ops_ext.py
@@ -16,7 +16,14 @@ except ImportError as e:
 class ARangeOp:
   OPERATION_NAME = "indexing.arange"
 
-  def __init__(self, *, start=None, stop=None, step=None, loc=None, ip=None):
+  def __init__(self,
+               *,
+               start=None,
+               stop=None,
+               step=None,
+               fold=None,
+               loc=None,
+               ip=None):
     operands = []
 
     for i, inp in enumerate([start, stop, step]):
@@ -72,6 +79,13 @@ class ARangeOp:
                                  not ir.AttrBuilder.contains('IndexAttr')) else
                                 ir.AttrBuilder.get('IndexAttr')(
                                     stepAttr, context=_ods_context))
+    if fold is not None:
+      attributes["foldAttr"] = (fold if
+                                (issubclass(type(fold), ir.Attribute) or
+                                 not ir.AttrBuilder.contains('BoolAttr')) else
+                                ir.AttrBuilder.get('BoolAttr')(
+                                    fold, context=_ods_context))
+
     results = ir.InferTypeOpInterface(ARangeOp).inferReturnTypes(
         operands=operands,
         attributes=ir.DictAttr.get(attributes, context=_ods_context),

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -355,8 +355,6 @@ class Tensor(ArithValue, TensorValue):
 
   @cached_property
   def shape(self) -> Tuple[int, ...]:
-    if not self._shaped_type.has_static_shape:
-      raise ValueError("Only static shapes currently supported.")
     return tuple(self._shaped_type.shape)
 
   @cached_property
@@ -643,7 +641,7 @@ def _expand_dims(inp, newaxis_dims) -> Tensor:
 
   if isinstance(inp, Scalar):
     assert newaxis_dims == [0, 1], f"{newaxis_dims=}"
-    if inp.is_constant():
+    if inp.fold():
       return _as_index_tensor(np.array(inp.literal_value).reshape((1, 1)))
     else:
       return Tensor(
@@ -656,6 +654,9 @@ def _expand_dims(inp, newaxis_dims) -> Tensor:
     for i in reversed(newaxis_dims):
       result_shape.insert(i, 1)
 
+    if inp.fold():
+      return _as_index_tensor(inp.literal_value.reshape(result_shape))
+
     reassoc_list = [[i] for i in range(len(inp.shape))]
     for i, d in enumerate(newaxis_dims):
       reassoc_list.append([len(inp.shape) + i])
@@ -663,13 +664,10 @@ def _expand_dims(inp, newaxis_dims) -> Tensor:
         d = 1
       reassoc_list[max(d - 1, 0)].extend(reassoc_list.pop(d))
 
-    if inp.is_constant():
-      return _as_index_tensor(inp.literal_value)
-    else:
-      reassoc_list = _get_int_int_array_attr(reassoc_list)
-      return Tensor(
-          tensor.ExpandShapeOp(RankedTensorType.get(result_shape, inp.dtype),
-                               inp, reassoc_list))
+    reassoc_list = _get_int_int_array_attr(reassoc_list)
+    return Tensor(
+        tensor.ExpandShapeOp(RankedTensorType.get(result_shape, inp.dtype), inp,
+                             reassoc_list))
 
   raise NotImplementedError(inp, newaxis_dims)
 
@@ -682,7 +680,7 @@ def _has_index_type(e: Any) -> bool:
     e: Anything
   """
   return isinstance(e, int) or isinstance(e, np.ndarray) and e.dtype in {
-      np.uintp, np.longlong
+      np.intp
   } or isinstance(e, (Tensor, Scalar)) and IndexType.isinstance(e.dtype)
 
 
@@ -847,7 +845,9 @@ def _indices_to_indexer(idx: Sequence[Any],
         advanced_axes_are_contiguous and idx_i == idx_advanced_axes[0] or
         not advanced_axes_are_contiguous and idx_i == 0):
       if len(set([tuple(a.shape) for a in advanced_indexes])) != 1:
-        raise IndexError("All advanced indices must have the same shape.")
+        raise IndexError(
+            f"All advanced indices must have the same shape: {set([tuple(a.shape) for a in advanced_indexes])=}"
+        )
       indices.extend(advanced_indexes)
       collapsed_dims = _compute_idx_tensor_extent(collapsed_dims, idx,
                                                   idx_advanced_axes)
@@ -886,6 +886,23 @@ def _indices_to_indexer(idx: Sequence[Any],
               f"Negative step indexing mode not yet supported:\n{idx}")
         out_axis += 1
         in_axis += 1
+
+      # Handle slice index (only static, otherwise an error is raised)
+      else:
+        if not isinstance(in_shape[in_axis], int):
+          msg = ("Cannot use NumPy slice indexing on an array dimension whose "
+                 f"size is not statically known ({in_shape[in_axis]}). ")
+          raise IndexError(msg)
+
+        if all(isinstance(s, int) or s is None for s in (start, stop, step)):
+          ara = arange(*slice(start, stop, step).indices(in_shape[in_axis]))
+        else:
+          ara = arange(start, stop, step)
+        indices.append(ara)
+        collapsed_dims.append(in_axis)
+
+        out_axis += 1
+        in_axis += 1
     else:
       raise IndexError(f"Indexing mode not yet supported:\n{idx}")
 
@@ -902,7 +919,7 @@ def _indices_to_indexer(idx: Sequence[Any],
         -1,
     )
 
-  if indices_tensor is not None and indices_tensor.is_constant():
+  if indices_tensor is not None and indices_tensor.fold():
     lit = indices_tensor.literal_value
     # flatten all but last dim (i.e., idx/coord dim)
     coords = lit.reshape(-1, lit.shape[-1])

--- a/python/mlir_structured/runtime/util.py
+++ b/python/mlir_structured/runtime/util.py
@@ -10,11 +10,9 @@ from mlir_structured.ir import (
 
 
 @contextlib.contextmanager
-def mlir_mod_ctx(
-    src: Optional[str] = None,
-    context: Optional[Context] = None,
-    location: Optional[Location] = None,
-):
+def mlir_mod_ctx(src: Optional[str] = None,
+                 context: Optional[Context] = None,
+                 location: Optional[Location] = None):
   if context is None:
     try:
       context = Context.current
@@ -25,8 +23,8 @@ def mlir_mod_ctx(
     location = Location.unknown(context=context)
   with context, location:
     if src is not None:
-      module = Module.parse(src)
+      module = Module.parse(src, context=context)
     else:
-      module = Module.create()
+      module = Module.create(loc=location)
     with InsertionPoint(module.body):
       yield module

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -1,23 +1,23 @@
 // RUN: structured-opt -canonicalize -allow-unregistered-dialect -mlir-print-op-generic -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   "builtin.module"() ({
-// CHECK:           "func.func"() <{function_type = () -> (), sym_name = "test_canonicalize_to_attrs"}> ({
-// CHECK:             %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
-// CHECK:             %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
-// CHECK:             %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
-// CHECK:             %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:             "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:             "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-// CHECK:             "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:             "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:             "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             "func.return"() : () -> ()
-// CHECK:           }) : () -> ()
+// CHECK-LABEL: "builtin.module"() ({
+// CHECK:         "func.func"() <{function_type = () -> (), sym_name = "test_canonicalize_to_attrs"}> ({
+// CHECK:           %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
+// CHECK:           %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
+// CHECK:           %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+// CHECK:           "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
+// CHECK:       }) : () -> ()
 
 module {
   func.func @test_canonicalize_to_attrs() {
@@ -28,19 +28,19 @@ module {
     %c100_index_dyn = "c100_index_dyn"() : () -> (index)
     %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%10) : (tensor<?x1xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use2"(%11) : (tensor<?x1xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use3"(%12) : (tensor<?x1xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_index_dyn) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %13 = "indexing.arange"(%c0_index_dyn) {foldAttr = false, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use4"(%13) : (tensor<?x1xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {foldAttr = false, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
     "use5"(%14) : (tensor<?x1xindex>) -> ()
 
     return
@@ -49,18 +49,18 @@ module {
 
 // -----
 
-// CHECK-LABEL:   "builtin.module"() ({
-// CHECK:           "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
-// CHECK:             %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
-// CHECK:             "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "use3"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "use4"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "func.return"() : () -> ()
-// CHECK:           }) : () -> ()
+// CHECK-LABEL: "builtin.module"() ({
+// CHECK:         "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
+// CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
+// CHECK:           "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           "use3"(%[[VAL_1]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           "use4"(%[[VAL_2]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
-
-
+// CHECK:       }) : () -> ()
 
 module {
   func.func @test_fold() {
@@ -68,13 +68,13 @@ module {
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {foldAttr = true, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%4) : (tensor<?x1xindex>) -> ()
-    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, foldAttr = true, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
     "use2"(%5) : (tensor<?x1xindex>) -> ()
-    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use3"(%si) : (tensor<?x1xindex>) -> ()
-    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
+    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
     "use4"(%se) : (tensor<50x1xindex>) -> ()
 
     return

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -4,7 +4,7 @@ from random import random
 
 import numpy as np
 
-from mlir_structured.dialects import arith, indexing
+from mlir_structured.dialects import arith, indexing, func
 from mlir_structured.dialects.indexing import (Scalar, Tensor, IndexTensorType,
                                                _canonicalize_tuple_index,
                                                arange)
@@ -280,21 +280,21 @@ def testSimpleLiteralIndexing():
     print(ten.get_name())
 
     w = ten[0]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [0])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[0]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[2, 4]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [2 4])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[2 4]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x333x4444xi32>
     print(w.owner)
 
     w = ten[2, 4, 6]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [2 4 6])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[2 4 6]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x4444xi32>
     print(w.owner)
 
     w = ten[2, 4, 6, 8]
@@ -330,21 +330,21 @@ def testSimpleLiteralIndexing():
     print(w.get_name())
 
     w = ten[1, ...]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, ...]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :, ...]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     try:
@@ -354,99 +354,99 @@ def testSimpleLiteralIndexing():
       print(e)
 
     w = ten[1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[:, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x10x333x4444xi32>
     print(w.owner)
 
     w = ten[:, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x22x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x10x22x4444xi32>
     print(w.owner)
 
     w = ten[:, :, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([3]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x22x333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x10x22x333xi32>
     print(w.owner)
 
     w = ten[:, 1, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x10x333xi32>
     print(w.owner)
 
     w = ten[1, :, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<22x333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x22x333xi32>
     print(w.owner)
 
     w = ten[1, 1, :, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x333x4444xi32>
     print(w.owner)
 
     w = ten[:, :, 1, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x22xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x10x22xi32>
     print(w.owner)
 
     w = ten[:, 1, 1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x10x4444xi32>
     print(w.owner)
 
     w = ten[1, :, 1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<22x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x22x4444xi32>
     print(w.owner)
 
     w = ten[1, 1, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x333xi32>
     print(w.owner)
 
     w = ten[1, :, 1, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<22xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x22xi32>
     print(w.owner)
 
     w = ten[:, 1, 1, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x10xi32>
     print(w.owner)
 
     w = ten[1, 1, 1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x4444xi32>
     print(w.owner)
 
 
@@ -677,6 +677,10 @@ def testARangeOpBasics():
     # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
     print(ara.owner)
 
+    ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, fold=True))
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2, fold = true) : tensor<50x1xindex>
+    print(ara.owner)
+
   module.operation.verify()
 
 
@@ -709,19 +713,19 @@ def testARangeFun():
     # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) : tensor<?x1xindex>
     print(ara.owner)
 
-    ara = arange(0, 100, 2)
+    ara = arange(0, 100, 2, fold=True)
     # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [2], [4], [6], [8], {{.*}}, [98]]> : tensor<50x1xindex>
     print(ara.owner)
 
-    ara = arange(0, 100)
+    ara = arange(0, 100, fold=True)
     # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
     print(ara.owner)
 
-    ara = arange(100)
+    ara = arange(100, fold=True)
     # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
     print(ara.owner)
 
-  print(module.operation.verify())
+  module.operation.verify()
 
 
 # CHECK-LABEL: TEST: testARangeOpSemantics


### PR DESCRIPTION
Depends on https://github.com/iree-org/iree-llvm-sandbox/pull/740.

This PR implements the remainder of slicing, i.e. with arbitrary `start`, `stop`, and `step`:

```python
    ten = Tensor.empty((7, 22, 330, 4400), f32)
    # CHECK: Tensor(%[[TEN:.*]], tensor<7x22x330x4400xf32>)
    print(ten)

    w = ten[:, ::2]
    # CHECK: %[[ARA:.*]] = arith.constant dense<[[0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20]]> : tensor<11x1xindex>
    print(w.owner.operands[1].owner)
    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<11x1xindex>) -> tensor<11x7x330x4400xf32>
    print(w.owner)

    w = ten[:, ::2, ::30]
    # CHECK: %[[ARA:.*]] = arith.constant dense<[[0, 0], [2, 30], [4, 60], [6, 90], [8, 120], [10, 150], [12, 180], [14, 210], [16, 240], [18, 270], [20, 300]]> : tensor<11x2xindex>
    print(w.owner.operands[1].owner)
    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<11x2xindex>) -> tensor<11x7x4400xf32>
    print(w.owner)

    w = ten[:, ::2, ::30, ::400]
    # CHECK: %[[ARA:.*]] = arith.constant dense<[[0, 0, 0], ..., [20, 300, 4000]]> : tensor<11x3xindex>
    print(w.owner.operands[1].owner)
    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<11x3xindex>) -> tensor<11x7xf32>
    print(w.owner)

    w = ten[:, :, 100:200:5, 1000:2000:50]
    # CHECK: %[[ARA:.*]] = arith.constant dense<[[100, 1000], [105, 1050], ..., [195, 1950]]> : tensor<20x2xindex>
    print(w.owner.operands[1].owner)
    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<20x2xindex>) -> tensor<20x7x22xf32>
    print(w.owner)
```

including with non-constant operands for the slice object:

```python
      ten = Tensor.empty((7, 22, 330, 4400), f32)
      one = Scalar(1, dtype=index, fold=False)
      start = 100 * one
      stop = 200 * one
      step = 5 * one

      w = ten[:, :, start:stop:step]
      # CHECK: %[[VAL_8:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
      print(w.owner.operands[1].owner)
      # CHECK: %[[VAL_9:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_8]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
      print(w.owner)

      w = ten[:, :, start:stop:5]
      # CHECK: %[[VAL_10:.*]] = "arith.constant"() <{value = 5 : index}> : () -> index
      print(w.owner.operands[1].owner.operands[2])
      # CHECK: %[[VAL_11:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_10]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
      print(w.owner.operands[1].owner)
      # CHECK: %[[VAL_12:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_11]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
      print(w.owner)
```