### PR TITLE
[Indexing] Remove all i64

### DIFF
--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -79,22 +79,22 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
     Values are generated within the half-open interval [start, stop), with spacing between values given by step.
   }];
 
-  let arguments = (ins Optional<I64>:$start,
-                       Optional<I64>:$stop,
-                       Optional<I64>:$step,
-                       OptionalAttr<I64Attr>:$startAttr,
-                       OptionalAttr<I64Attr>:$stopAttr,
-                       OptionalAttr<I64Attr>:$stepAttr);
-  let results = (outs 1DTensorOf<[AnyInteger, Index]>:$result);
+  let arguments = (ins Optional<Index>:$start,
+                       Optional<Index>:$stop,
+                       Optional<Index>:$step,
+                       OptionalAttr<IndexAttr>:$startAttr,
+                       OptionalAttr<IndexAttr>:$stopAttr,
+                       OptionalAttr<IndexAttr>:$stepAttr);
+  let results = (outs 1DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
   let assemblyFormat = [{
     `(`
-        (`start` `=` $start^)? (```start` `=` $startAttr^)?
+        `start` `=` ($start^) : ($startAttr)?
         `,`
-        (`stop` `=` $stop^)? (`stop` `=` $stopAttr^)?
+        `stop` `=` ($stop^) : ($stopAttr)?
         `,`
-        (`step` `=` $step^)? (`step` `=` $stepAttr^)?
+        `step` `=` ($step^) : ($stepAttr)?
     `)` attr-dict `:` type($result)
   }];
 

--- a/python/mlir_structured/dialects/_indexing_ops_ext.py
+++ b/python/mlir_structured/dialects/_indexing_ops_ext.py
@@ -57,20 +57,20 @@ class ARangeOp:
     if startAttr is not None:
       attributes["startAttr"] = (startAttr if
                                  (issubclass(type(startAttr), ir.Attribute) or
-                                  not ir.AttrBuilder.contains('I64Attr')) else
-                                 ir.AttrBuilder.get('I64Attr')(
+                                  not ir.AttrBuilder.contains('IndexAttr')) else
+                                 ir.AttrBuilder.get('IndexAttr')(
                                      startAttr, context=_ods_context))
     if stopAttr is not None:
       attributes["stopAttr"] = (stopAttr if
                                 (issubclass(type(stopAttr), ir.Attribute) or
-                                 not ir.AttrBuilder.contains('I64Attr')) else
-                                ir.AttrBuilder.get('I64Attr')(
+                                 not ir.AttrBuilder.contains('IndexAttr')) else
+                                ir.AttrBuilder.get('IndexAttr')(
                                     stopAttr, context=_ods_context))
     if stepAttr is not None:
       attributes["stepAttr"] = (stepAttr if
                                 (issubclass(type(stepAttr), ir.Attribute) or
-                                 not ir.AttrBuilder.contains('I64Attr')) else
-                                ir.AttrBuilder.get('I64Attr')(
+                                 not ir.AttrBuilder.contains('IndexAttr')) else
+                                ir.AttrBuilder.get('IndexAttr')(
                                     stepAttr, context=_ods_context))
     results = ir.InferTypeOpInterface(ARangeOp).inferReturnTypes(
         operands=operands,

--- a/test/Dialect/Indexing/basic.mlir
+++ b/test/Dialect/Indexing/basic.mlir
@@ -1,57 +1,89 @@
 // RUN: structured-opt %s --split-input-file | FileCheck %s
 
-// CHECK: module {
-// CHECK:   func.func @foo(%arg0: !indexing.custom<"bob">) {
-// CHECK:     %[[TEN1:.*]] = tensor.empty() : tensor<10x10xi32>
-// CHECK:     %[[IDXTEN:.*]] = tensor.empty() : tensor<1x2x2xi32>
-// CHECK:     %[[GATHER:.*]] = indexing.gather %[[TEN1]][%[[IDXTEN]]] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
-// CHECK:     %[[CONCAT:.*]] = indexing.concatenate(%2, %2) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
-// CHECK:     %[[C0:.*]] = arith.constant 0 : i64
-// CHECK:     %[[C100:.*]] = arith.constant 100 : i64
-// CHECK:     %[[C2:.*]] = arith.constant 2 : i64
-// CHECK:     %4 = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) : tensor<?xindex>
-// CHECK:     return
-// CHECK:   }
-// CHECK: }
+// CHECK-LABEL:   module {
+// CHECK:           func.func @foo(%[[VAL_0:.*]]: !indexing.custom<"bob">) {
+// CHECK:             %[[VAL_1:.*]] = tensor.empty() : tensor<10x10xi32>
+// CHECK:             %[[VAL_2:.*]] = tensor.empty() : tensor<1x2x2xi32>
+// CHECK:             %[[VAL_3:.*]] = indexing.gather %[[VAL_1]]{{\[}}%[[VAL_2]]] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
+// CHECK:             %[[VAL_4:.*]] = indexing.concatenate(%[[VAL_3]], %[[VAL_3]]) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
+// CHECK:             %[[VAL_5:.*]] = arith.constant 0 : index
+// CHECK:             %[[VAL_6:.*]] = arith.constant 100 : index
+// CHECK:             %[[VAL_7:.*]] = arith.constant 2 : index
+// CHECK:             %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) : tensor<?xindex>
+// CHECK:             return
+// CHECK:           }
+// CHECK:         }
+
 module {
   func.func @foo(%arg0: !indexing.custom<"bob">) {
     %0 = tensor.empty() : tensor<10x10xi32>
     %1 = tensor.empty() : tensor<1x2x2xi32>
     %2 = indexing.gather %0[%1] gather_dims([0, 1]) : (tensor<10x10xi32>, tensor<1x2x2xi32>) -> tensor<1x2xi32>
     %3 = indexing.concatenate (%2, %2) {dim = 0} : (tensor<1x2xi32>, tensor<1x2xi32>) -> tensor<2x2xi32>
-    %c0_i64 = arith.constant 0 : i64
-    %c100_i64 = arith.constant 100 : i64
-    %c2_i64 = arith.constant 2 : i64
-    %4 = indexing.arange(start = %c0_i64, stop = %c100_i64, step = %c2_i64) : tensor<?xindex>
+    %c0_index = arith.constant 0 : index
+    %c100_index = arith.constant 100 : index
+    %c2_index = arith.constant 2 : index
+    %4 = indexing.arange(start = %c0_index, stop = %c100_index, step = %c2_index) : tensor<?xindex>
     return
   }
 }
 
 // -----
 
-// CHECK: module {
-// CHECK:   %[[START:.*]] = arith.constant 0 : i64
-// CHECK:   %[[STOP:.*]] = arith.constant 100 : i64
-// CHECK:   %[[STEP:.*]] = arith.constant 2 : i64
-// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
-// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
-// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?xindex>
-// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?xindex>
-// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?xindex>
-// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?xindex>
-// CHECK:   %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?xindex>
-// CHECK:   %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
-// CHECK: }
+// CHECK-LABEL:   module {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
+// CHECK:         }
+
 module {
-  %0 = arith.constant 0 : i64
-  %1 = arith.constant 100 : i64
-  %2 = arith.constant 2 : i64
-  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
-  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : i64} : (i64, i64) -> tensor<?xindex>
-  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : i64} : (i64, i64) -> tensor<?xindex>
-  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : i64} : (i64, i64) -> tensor<?xindex>
-  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xindex>
-  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : i64, stepAttr = 2 : i64} : (i64) -> tensor<?xindex>
-  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xindex>
-  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : i64, stepAttr = 2 : i64, stopAttr = 100 : i64} : () -> tensor<50xindex>
+  %0 = arith.constant 0 : index
+  %1 = arith.constant 100 : index
+  %2 = arith.constant 2 : index
+  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : index} : (index, index) -> tensor<?xindex>
+  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : index} : (index, index) -> tensor<?xindex>
+  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : index, stepAttr = 2 : index} : (index) -> tensor<?xindex>
+  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50xindex>
+}
+
+// -----
+
+// CHECK-LABEL:   module {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
+// CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
+// CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
+// CHECK:         }
+
+module {
+  %c0 = arith.constant 0 : index
+  %c100 = arith.constant 100 : index
+  %c2 = arith.constant 2 : index
+  %0 = indexing.arange(start = %c0, stop = %c100, step = %c2) : tensor<?xindex>
+  %1 = indexing.arange(start = 0, stop = %c100, step = %c2) : tensor<?xindex>
+  %2 = indexing.arange(start = %c0, stop = 100, step = %c2) : tensor<?xindex>
+  %3 = indexing.arange(start = %c0, stop = %c100, step = 2) : tensor<?xindex>
+  %4 = indexing.arange(start = 0, stop = 100, step = %c2) : tensor<?xindex>
+  %5 = indexing.arange(start = 0, stop = %c100, step = 2) : tensor<?xindex>
+  %6 = indexing.arange(start = %c0, stop = 100, step = 2) : tensor<?xindex>
+  %7 = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
 }

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -1,46 +1,46 @@
 // RUN: structured-opt -canonicalize -allow-unregistered-dialect -mlir-print-op-generic -split-input-file %s | FileCheck %s
 
-// CHECK: "builtin.module"() ({
-// CHECK:   "func.func"() <{function_type = () -> (), sym_name = "test_canonicalize_to_attrs"}> ({
-// CHECK:     %[[C0:.*]] = "c0_i64_dyn"() : () -> i64
-// CHECK:     %[[C100:.*]] = "c100_i64_dyn"() : () -> i64
-// CHECK:     %[[C2:.*]] = "c2_i64_dyn"() : () -> i64
-// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xi64>
-// CHECK:     "use1"(%[[ARA]]) : (tensor<?xi64>) -> ()
-// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]], %[[C100]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : i64} : (i64, i64) -> tensor<?xi64>
-// CHECK:     "use2"(%[[ARA]]) : (tensor<?xi64>) -> ()
-// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]], %[[C100]], %[[C2]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
-// CHECK:     "use3"(%[[ARA]]) : (tensor<?xindex>) -> ()
-// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : i64, stopAttr = 100 : i64} : (i64) -> tensor<?xindex>
-// CHECK:     "use4"(%[[ARA]]) : (tensor<?xindex>) -> ()
-// CHECK:     %[[ARA:.*]] = "indexing.arange"(%[[C0]], %[[C100]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : i64} : (i64, i64) -> tensor<?xindex>
-// CHECK:     "use5"(%[[ARA]]) : (tensor<?xindex>) -> ()
-// CHECK:     "func.return"() : () -> ()
-// CHECK:   }) : () -> ()
-// CHECK: }) : () -> ()
+// CHECK-LABEL:   "builtin.module"() ({
+// CHECK:           "func.func"() <{function_type = () -> (), sym_name = "test_canonicalize_to_attrs"}> ({
+// CHECK:             %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
+// CHECK:             %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
+// CHECK:             %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
+// CHECK:             %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+// CHECK:             "use1"(%[[VAL_3]]) : (tensor<?xindex>) -> ()
+// CHECK:             %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+// CHECK:             "use2"(%[[VAL_4]]) : (tensor<?xindex>) -> ()
+// CHECK:             %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+// CHECK:             "use3"(%[[VAL_5]]) : (tensor<?xindex>) -> ()
+// CHECK:             %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+// CHECK:             "use4"(%[[VAL_6]]) : (tensor<?xindex>) -> ()
+// CHECK:             %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+// CHECK:             "use5"(%[[VAL_7]]) : (tensor<?xindex>) -> ()
+// CHECK:             "func.return"() : () -> ()
+// CHECK:           }) : () -> ()
+// CHECK:         }) : () -> ()
 
 module {
   func.func @test_canonicalize_to_attrs() {
-    %c100_i64 = arith.constant 100 : i64
-    %c2_i64 = arith.constant 2 : i64
-    %one = arith.constant 1 : i64
-    %c0_i64_dyn = "c0_i64_dyn"() : () -> (i64)
-    %c100_i64_dyn = "c100_i64_dyn"() : () -> (i64)
-    %c2_i64_dyn = "c2_i64_dyn"() : () -> (i64)
+    %c100_index = arith.constant 100 : index
+    %c2_index = arith.constant 2 : index
+    %one = arith.constant 1 : index
+    %c0_index_dyn = "c0_index_dyn"() : () -> (index)
+    %c100_index_dyn = "c100_index_dyn"() : () -> (index)
+    %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_i64_dyn, %c100_i64, %c2_i64) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
     "use1"(%10) : (tensor<?xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_i64_dyn, %c100_i64_dyn, %c2_i64) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
     "use2"(%11) : (tensor<?xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_i64_dyn, %c100_i64_dyn, %c2_i64_dyn) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
     "use3"(%12) : (tensor<?xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_i64_dyn) {stopAttr = 100 : i64, stepAttr = 2 : i64, operand_segment_sizes = array<i32: 1, 0, 0>} : (i64) -> tensor<?xindex>
+    %13 = "indexing.arange"(%c0_index_dyn) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
     "use4"(%13) : (tensor<?xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_i64_dyn, %c100_i64_dyn) {stepAttr = 2 : i64, operand_segment_sizes = array<i32: 1, 1, 0>} : (i64, i64) -> tensor<?xindex>
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?xindex>
     "use5"(%14) : (tensor<?xindex>) -> ()
 
     return
@@ -49,32 +49,31 @@ module {
 
 // -----
 
-// CHECK: "builtin.module"() ({
-// CHECK:   "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
-// CHECK:     %[[ARA:.*]] = "arith.constant"() <{value = dense<[0, 2, {{.*}}, 98]> : tensor<50xi64>}> : () -> tensor<50xi64>
-// CHECK:     "use1"(%[[ARA]]) : (tensor<50xi64>) -> ()
-// CHECK:     "use2"(%[[ARA]]) : (tensor<50xi64>) -> ()
-// CHECK:     "use3"(%[[ARA]]) : (tensor<50xi64>) -> ()
-//           this doesn't get folded because the return type is index
-// CHECK:     %[[ARA:.*]] = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : i64, stepAttr = 2 : i64, stopAttr = 100 : i64} : () -> tensor<50xindex>
-// CHECK:     "use4"(%[[ARA]]) : (tensor<50xindex>) -> ()
-// CHECK:     "func.return"() : () -> ()
-// CHECK:   }) : () -> ()
-// CHECK: }) : () -> ()
+// CHECK-LABEL:   "builtin.module"() ({
+// CHECK:           "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
+// CHECK:             %[[VAL_0:.*]] = "arith.constant"() <{value = dense<[0, 2, 4, 6, 8, 10, {{.*}}, 98]> : tensor<50xindex>}> : () -> tensor<50xindex>
+// CHECK:             "use1"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
+// CHECK:             "use2"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
+// CHECK:             "use3"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
+// CHECK:             "use4"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
+// CHECK:             "func.return"() : () -> ()
+// CHECK:           }) : () -> ()
+// CHECK:         }) : () -> ()
+
 
 module {
   func.func @test_fold() {
-    %c0_i64 = arith.constant 0 : i64
-    %c100_i64 = arith.constant 100 : i64
-    %c2_i64 = arith.constant 2 : i64
+    %c0_index = arith.constant 0 : index
+    %c100_index = arith.constant 100 : index
+    %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_i64, %c100_i64, %c2_i64) {operand_segment_sizes = array<i32: 1, 1, 1>} : (i64, i64, i64) -> tensor<?xindex>
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
     "use1"(%4) : (tensor<?xindex>) -> ()
-    %5 = "indexing.arange"(%c0_i64, %c2_i64) {stopAttr = 100 : i64, operand_segment_sizes = array<i32: 1, 0, 1>} : (i64, i64) -> tensor<?xindex>
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?xindex>
     "use2"(%5) : (tensor<?xindex>) -> ()
-    %si = "indexing.arange"(%c0_i64) {stopAttr = 100 : i64, stepAttr = 2 : i64, operand_segment_sizes = array<i32: 1, 0, 0>} : (i64) -> tensor<?xindex>
+    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
     "use3"(%si) : (tensor<?xindex>) -> ()
-    %se = "indexing.arange"() {startAttr = 0 : i64, stopAttr = 100 : i64, stepAttr = 2 : i64, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50xindex>
+    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50xindex>
     "use4"(%se) : (tensor<50xindex>) -> ()
 
     return


### PR DESCRIPTION
I made a mistake in implementing `ARangeOp` in assuming that the arith canonicalizers wouldn't canonicalize/evaluate arithmetic on tensors of index; turns out that's not the case:

```python
import numpy as np

from mlir_structured._mlir_libs._mlir.ir import IndexType
from mlir_structured.dialects import func
from mlir_structured.dialects.indexing import Tensor
from mlir_structured.passmanager import PassManager
from mlir_structured.runtime.util import mlir_mod_ctx

with mlir_mod_ctx() as module:
  @func.FuncOp.from_py_func(*[])
  def sddmm():
    a = Tensor(np.random.randint(0, 10, (2, 2)), fold=False, dtype=IndexType.get())
    b = Tensor(np.random.randint(0, 10, (2, 2)), fold=False, dtype=IndexType.get())
    c = a + b
    return c

  print(module)
  pm = PassManager.parse('builtin.module(canonicalize)')
  pm.run(module.operation)
  print(module)
```

will happily print

```mlir
module {
  func.func @sddmm() -> tensor<2x2xindex> {
    %cst = arith.constant dense<[[2, 9], [9, 5]]> : tensor<2x2xindex>
    %cst_0 = arith.constant dense<[[1, 3], [3, 6]]> : tensor<2x2xindex>
    %0 = arith.addi %cst, %cst_0 : tensor<2x2xindex>
    return %0 : tensor<2x2xindex>
  }
}

module {
  func.func @sddmm() -> tensor<2x2xindex> {
    %cst = arith.constant dense<[[3, 12], [12, 11]]> : tensor<2x2xindex>
    return %cst : tensor<2x2xindex>
  }
}
```

So this diff removes all reliance on `i64` and normalizes everything to use `index`.

This diff also transitions to using [`mlir/utils/generate-test-checks.py`](https://github.com/llvm/llvm-project/blob/main/mlir/utils/generate-test-checks.py) which is fantastic.