### PR TITLE
[Indexing] Make `arange` `fold=False` default

### DIFF
--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -9,6 +9,7 @@
 #ifndef STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS
 #define STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS
 
+include "mlir/IR/OpBase.td"
 include "structured/Dialect/Indexing/IR/IndexingDialect.td"
 include "structured/Dialect/Indexing/IR/IndexingTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
@@ -63,6 +64,10 @@ def Indexing_ConcatenateOp : Indexing_Op<"concatenate",
   let assemblyFormat = [{
      `(` $inputs `)` `{` `dim` `=` $dimension `}` attr-dict `:` functional-type(operands, results)
   }];
+
+  let extraClassDeclaration = [{
+    static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
+  }];
 }
 
 def Indexing_ARangeOp : Indexing_Op<"arange", [
@@ -84,7 +89,8 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
                        Optional<Index>:$step,
                        OptionalAttr<IndexAttr>:$startAttr,
                        OptionalAttr<IndexAttr>:$stopAttr,
-                       OptionalAttr<IndexAttr>:$stepAttr);
+                       OptionalAttr<IndexAttr>:$stepAttr,
+                       DefaultValuedAttr<BoolAttr, "false">:$foldAttr);
   let results = (outs 2DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
@@ -95,6 +101,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
         `stop` `=` ($stop^) : ($stopAttr)?
         `,`
         `step` `=` ($step^) : ($stepAttr)?
+        (`,` `fold` `=` $foldAttr^)?
     `)` attr-dict `:` type($result)
   }];
 

--- a/python/mlir_structured/dialects/_indexing_ops_ext.py
+++ b/python/mlir_structured/dialects/_indexing_ops_ext.py
@@ -16,7 +16,14 @@ except ImportError as e:
 class ARangeOp:
   OPERATION_NAME = "indexing.arange"
 
-  def __init__(self, *, start=None, stop=None, step=None, loc=None, ip=None):
+  def __init__(self,
+               *,
+               start=None,
+               stop=None,
+               step=None,
+               fold=None,
+               loc=None,
+               ip=None):
     operands = []
 
     for i, inp in enumerate([start, stop, step]):
@@ -72,6 +79,13 @@ class ARangeOp:
                                  not ir.AttrBuilder.contains('IndexAttr')) else
                                 ir.AttrBuilder.get('IndexAttr')(
                                     stepAttr, context=_ods_context))
+    if fold is not None:
+      attributes["foldAttr"] = (fold if
+                                (issubclass(type(fold), ir.Attribute) or
+                                 not ir.AttrBuilder.contains('BoolAttr')) else
+                                ir.AttrBuilder.get('BoolAttr')(
+                                    fold, context=_ods_context))
+
     results = ir.InferTypeOpInterface(ARangeOp).inferReturnTypes(
         operands=operands,
         attributes=ir.DictAttr.get(attributes, context=_ods_context),

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -1,23 +1,23 @@
 // RUN: structured-opt -canonicalize -allow-unregistered-dialect -mlir-print-op-generic -split-input-file %s | FileCheck %s
 
-// CHECK-LABEL:   "builtin.module"() ({
-// CHECK:           "func.func"() <{function_type = () -> (), sym_name = "test_canonicalize_to_attrs"}> ({
-// CHECK:             %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
-// CHECK:             %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
-// CHECK:             %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
-// CHECK:             %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:             "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:             "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-// CHECK:             "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:             "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:             "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
-// CHECK:             "func.return"() : () -> ()
-// CHECK:           }) : () -> ()
+// CHECK-LABEL: "builtin.module"() ({
+// CHECK:         "func.func"() <{function_type = () -> (), sym_name = "test_canonicalize_to_attrs"}> ({
+// CHECK:           %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
+// CHECK:           %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
+// CHECK:           %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+// CHECK:           "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
+// CHECK:       }) : () -> ()
 
 module {
   func.func @test_canonicalize_to_attrs() {
@@ -28,19 +28,19 @@ module {
     %c100_index_dyn = "c100_index_dyn"() : () -> (index)
     %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%10) : (tensor<?x1xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use2"(%11) : (tensor<?x1xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use3"(%12) : (tensor<?x1xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_index_dyn) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %13 = "indexing.arange"(%c0_index_dyn) {foldAttr = false, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use4"(%13) : (tensor<?x1xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {foldAttr = false, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
     "use5"(%14) : (tensor<?x1xindex>) -> ()
 
     return
@@ -49,18 +49,18 @@ module {
 
 // -----
 
-// CHECK-LABEL:   "builtin.module"() ({
-// CHECK:           "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
-// CHECK:             %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
-// CHECK:             "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "use3"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "use4"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:             "func.return"() : () -> ()
-// CHECK:           }) : () -> ()
+// CHECK-LABEL: "builtin.module"() ({
+// CHECK:         "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
+// CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
+// CHECK:           "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           "use3"(%[[VAL_1]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           "use4"(%[[VAL_2]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
-
-
+// CHECK:       }) : () -> ()
 
 module {
   func.func @test_fold() {
@@ -68,13 +68,13 @@ module {
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {foldAttr = true, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%4) : (tensor<?x1xindex>) -> ()
-    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, foldAttr = true, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
     "use2"(%5) : (tensor<?x1xindex>) -> ()
-    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use3"(%si) : (tensor<?x1xindex>) -> ()
-    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
+    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
     "use4"(%se) : (tensor<50x1xindex>) -> ()
 
     return

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -4,7 +4,7 @@ from random import random
 
 import numpy as np
 
-from mlir_structured.dialects import arith, indexing
+from mlir_structured.dialects import arith, indexing, func
 from mlir_structured.dialects.indexing import (Scalar, Tensor, IndexTensorType,
                                                _canonicalize_tuple_index,
                                                arange)
@@ -280,21 +280,21 @@ def testSimpleLiteralIndexing():
     print(ten.get_name())
 
     w = ten[0]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [0])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[0]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[2, 4]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [2 4])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[2 4]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x333x4444xi32>
     print(w.owner)
 
     w = ten[2, 4, 6]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [2 4 6])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[2 4 6]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x4444xi32>
     print(w.owner)
 
     w = ten[2, 4, 6, 8]
@@ -330,21 +330,21 @@ def testSimpleLiteralIndexing():
     print(w.get_name())
 
     w = ten[1, ...]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, ...]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :, ...]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     try:
@@ -354,99 +354,99 @@ def testSimpleLiteralIndexing():
       print(e)
 
     w = ten[1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[1, :, :, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<22x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x22x333x4444xi32>
     print(w.owner)
 
     w = ten[:, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x10x333x4444xi32>
     print(w.owner)
 
     w = ten[:, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x22x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x10x22x4444xi32>
     print(w.owner)
 
     w = ten[:, :, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<1xindex>, [1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x1xindex>, {{\[}}[1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([3]) unique : (tensor<10x22x333x4444xi32>, tensor<1xindex>) -> tensor<10x22x333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x1xindex>) -> tensor<1x10x22x333xi32>
     print(w.owner)
 
     w = ten[:, 1, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x10x333xi32>
     print(w.owner)
 
     w = ten[1, :, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<22x333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x22x333xi32>
     print(w.owner)
 
     w = ten[1, 1, :, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<333x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x333x4444xi32>
     print(w.owner)
 
     w = ten[:, :, 1, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x22xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x10x22xi32>
     print(w.owner)
 
     w = ten[:, 1, 1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<10x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x10x4444xi32>
     print(w.owner)
 
     w = ten[1, :, 1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<2xindex>, [1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x2xindex>, {{\[}}[1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<2xindex>) -> tensor<22x4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x2xindex>) -> tensor<1x22x4444xi32>
     print(w.owner)
 
     w = ten[1, 1, :, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<333xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x333xi32>
     print(w.owner)
 
     w = ten[1, :, 1, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<22xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x22xi32>
     print(w.owner)
 
     w = ten[:, 1, 1, 1]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<10xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([1, 2, 3]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x10xi32>
     print(w.owner)
 
     w = ten[1, 1, 1, :]
-    # CHECK: Tensor(%[[CST0:.*]], tensor<3xindex>, [1 1 1])
+    # CHECK: Tensor(%[[CST0:.*]], tensor<1x3xindex>, {{\[}}[1 1 1]])
     print(Tensor(w.owner.operands[1]))
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<3xindex>) -> tensor<4444xi32>
+    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[CST0]]] gather_dims([0, 1, 2]) unique : (tensor<10x22x333x4444xi32>, tensor<1x3xindex>) -> tensor<1x4444xi32>
     print(w.owner)
 
 
@@ -677,6 +677,10 @@ def testARangeOpBasics():
     # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
     print(ara.owner)
 
+    ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, fold=True))
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2, fold = true) : tensor<50x1xindex>
+    print(ara.owner)
+
   module.operation.verify()
 
 
@@ -709,19 +713,19 @@ def testARangeFun():
     # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) : tensor<?x1xindex>
     print(ara.owner)
 
-    ara = arange(0, 100, 2)
+    ara = arange(0, 100, 2, fold=True)
     # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [2], [4], [6], [8], {{.*}}, [98]]> : tensor<50x1xindex>
     print(ara.owner)
 
-    ara = arange(0, 100)
+    ara = arange(0, 100, fold=True)
     # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
     print(ara.owner)
 
-    ara = arange(100)
+    ara = arange(100, fold=True)
     # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
     print(ara.owner)
 
-  print(module.operation.verify())
+  module.operation.verify()
 
 
 # CHECK-LABEL: TEST: testARangeOpSemantics


### PR DESCRIPTION
This diff fixes two things: `arange` should not fold by default and literal indices should be "cast" to `tensor<1x3xindex>` rather than `tensor<3xindex>`.