### PR TITLE
[Indexing] For-loop sugar

### DIFF
--- a/python/mlir_structured/runtime/util.py
+++ b/python/mlir_structured/runtime/util.py
@@ -1,4 +1,5 @@
 import contextlib
+import inspect
 from typing import Optional
 
 from mlir_structured.ir import (
@@ -7,6 +8,8 @@ from mlir_structured.ir import (
     InsertionPoint,
     Location,
 )
+from mlir_structured.dialects.indexing import constant, maybe_cast, _update_caller_vars
+from mlir_structured.dialects import scf
 
 
 @contextlib.contextmanager
@@ -28,3 +31,32 @@ def mlir_mod_ctx(src: Optional[str] = None,
       module = Module.create(loc=location)
     with InsertionPoint(module.body):
       yield module
+
+
+def scf_range(start, stop=None, step=1, iter_args=None):
+  if iter_args is None:
+    iter_args = []
+  if stop is None:
+    stop = start
+    start = 0
+
+  if isinstance(start, int):
+    start = constant(start, index=True)
+  if isinstance(stop, int):
+    stop = constant(stop, index=True)
+  if isinstance(step, int):
+    step = constant(step, index=True)
+  for_op = scf.ForOp(start, stop, step, iter_args)
+  iv = maybe_cast(for_op.induction_variable)
+  with InsertionPoint(for_op.body):
+    if len(iter_args):
+      previous_frame = inspect.currentframe().f_back
+      _update_caller_vars(previous_frame, iter_args, for_op.inner_iter_args)
+      yield iv, for_op.result
+    else:
+      yield iv
+      scf.YieldOp([])
+
+
+def scf_yield(*val):
+  scf.YieldOp(val)


### PR DESCRIPTION
This PR adds syntactical sugar for `for` loops; things like

```python
    ten = Tensor.empty((7, 22, 330, 4400), f32)
    for i, _ in scf_range(0, 10, iter_args=[ten]):
      y = ten + ten
      scf_yield(y)
```
lower to

```mlir
module {
  %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
  %[[VAL_1:.*]] = arith.constant 0 : index
  %[[VAL_2:.*]] = arith.constant 10 : index
  %[[VAL_3:.*]] = arith.constant 1 : index
  %[[VAL_4:.*]] = scf.for %[[VAL_5:.*]] = %[[VAL_1]] to %[[VAL_2]] step %[[VAL_3]] iter_args(%[[VAL_6:.*]] = %[[VAL_0]]) -> (tensor<7x22x330x4400xf32>) {
    %[[VAL_7:.*]] = arith.addf %[[VAL_6]], %[[VAL_6]] : tensor<7x22x330x4400xf32>
    scf.yield %[[VAL_7]] : tensor<7x22x330x4400xf32>
  }
}
```

and things like 

```python
      ten = Tensor.empty((7, 22, 330, 4400), f32)
      for i, result in scf_range(0, 10, iter_args=[ten]):
        y = ten + ten
        scf_yield(y)
      return result
```

lower to

```mlir
module {
  func.func @test_fold() -> tensor<7x22x330x4400xf32> {
    %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
    %[[VAL_1:.*]] = arith.constant 0 : index
    %[[VAL_2:.*]] = arith.constant 10 : index
    %[[VAL_3:.*]] = arith.constant 1 : index
    %[[VAL_4:.*]] = scf.for %[[VAL_5:.*]] = %[[VAL_1]] to %[[VAL_2]] step %[[VAL_3]] iter_args(%[[VAL_6:.*]] = %[[VAL_0]]) -> (tensor<7x22x330x4400xf32>) {
      %[[VAL_7:.*]] = arith.addf %[[VAL_6]], %[[VAL_6]] : tensor<7x22x330x4400xf32>
      scf.yield %[[VAL_7]] : tensor<7x22x330x4400xf32>
    }
    return %[[VAL_8:.*]] : tensor<7x22x330x4400xf32>
  }
}
```