### PR TITLE
[Indexing] Add runtime infra and runnable, tiled matmul example

### DIFF
--- a/include/structured-c/Passes.h
+++ b/include/structured-c/Passes.h
@@ -23,6 +23,8 @@ extern "C" {
 
 #include "structured/Dialect/Iterators/Transforms/Passes.capi.h.inc" // IWYU pragma: export
 
+#include "structured/Dialect/Indexing/Transforms/Passes.capi.h.inc" // IWYU pragma: export
+
 #include "structured/Dialect/Triton/Transforms/Passes.capi.h.inc" // IWYU pragma: export
 
 #include "structured/Dialect/TritonGPU/Transforms/Passes.capi.h.inc" // IWYU pragma: export

--- a/include/structured/Dialect/Indexing/CMakeLists.txt
+++ b/include/structured/Dialect/Indexing/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/include/structured/Dialect/Indexing/IR/Indexing.h
+++ b/include/structured/Dialect/Indexing/IR/Indexing.h
@@ -15,6 +15,12 @@
 #include "mlir/IR/SymbolTable.h"
 #include "mlir/Interfaces/InferTypeOpInterface.h"
 
+namespace mlir {
+namespace indexing {
+bool isARangeIndices(Value indices);
+} // namespace indexing
+} // namespace mlir
+
 #include "structured/Dialect/Indexing/IR/IndexingOpsDialect.h.inc"
 
 #define GET_TYPEDEF_CLASSES

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -142,4 +142,20 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
   let hasFolder = 1;
 }
 
+def Indexing_MeshGridOp : Indexing_Op<"meshgrid",
+    [Pure, SameOperandsAndResultElementType,
+     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Return coordinate matrices from coordinate vectors.";
+  let arguments = (ins
+    Variadic<1DTensorOf<[Index]>>:$inputs
+  );
+
+  let results = (outs AnyRankedTensor);
+
+  let assemblyFormat = [{
+     `(` $inputs `)` attr-dict `:` functional-type(operands, results)
+  }];
+  let hasVerifier = 1;
+}
+
 #endif // STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -115,7 +115,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
                        OptionalAttr<IndexAttr>:$startAttr,
                        OptionalAttr<IndexAttr>:$stopAttr,
                        OptionalAttr<IndexAttr>:$stepAttr,
-                       DefaultValuedAttr<BoolAttr, "false">:$foldAttr);
+                       UnitAttr:$nofold);
   let results = (outs 2DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
@@ -126,8 +126,8 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
         `stop` `=` ($stop^) : ($stopAttr)?
         `,`
         `step` `=` ($step^) : ($stepAttr)?
-        (`,` `fold` `=` $foldAttr^)?
-    `)` attr-dict `:` type($result)
+
+    `)` (`nofold` $nofold^)? attr-dict `:` type($result)
   }];
 
   let extraClassDeclaration = [{

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -33,10 +33,13 @@ def Indexing_GatherOp : Indexing_Op<"gather", [
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $source `[` $indices `]` `gather_dims` `(` $gather_dims `)` (`unique` $unique^)? attr-dict
-        `:` functional-type(operands, results)
+    $source `[` $indices `]`
+            `gather_dims` `(` $gather_dims `)`
+            (`unique` $unique^)?
+            attr-dict `:` functional-type(operands, results)
   }];
   let extraClassDeclaration = [{
+    static StringAttr getGatherDimsAttrName(MLIRContext *ctx) { return getGatherDimsAttrName(OperationName(getOperationName(), ctx)); }
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
   }];
 }
@@ -54,8 +57,10 @@ def Indexing_ScatterOp : Indexing_Op<"scatter", [
   let results = (outs AnyRankedTensor:$result);
 
   let assemblyFormat = [{
-    $source `into` $dest `[` $indices `]` `scatter_dims` `(` $scatter_dims `)` (`unique` $unique^)? attr-dict
-        `:` functional-type(operands, results)
+    $source `into` $dest `[` $indices `]`
+            `scatter_dims` `(` $scatter_dims `)`
+            (`unique` $unique^)?
+            attr-dict `:` functional-type(operands, results)
   }];
   let extraClassDeclaration = [{
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
@@ -91,8 +96,10 @@ def Indexing_ConcatenateOp : Indexing_Op<"concatenate",
   }];
 
   let extraClassDeclaration = [{
+    static StringAttr getDimensionAttrName(MLIRContext *ctx) { return getDimensionAttrName(OperationName(getOperationName(), ctx)); }
     static bool isCompatibleReturnTypes(TypeRange l, TypeRange r);
   }];
+  let hasCanonicalizer = 1;
 }
 
 def Indexing_ARangeOp : Indexing_Op<"arange", [

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -116,7 +116,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
                        OptionalAttr<IndexAttr>:$stopAttr,
                        OptionalAttr<IndexAttr>:$stepAttr,
                        UnitAttr:$nofold);
-  let results = (outs 2DTensorOf<[Index]>:$result);
+  let results = (outs 1DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
   let assemblyFormat = [{

--- a/include/structured/Dialect/Indexing/Transforms/CMakeLists.txt
+++ b/include/structured/Dialect/Indexing/Transforms/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Indexing)
+mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix Indexing)
+mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix Indexing)
+add_public_tablegen_target(MLIRIndexingPassIncGen)

--- a/include/structured/Dialect/Indexing/Transforms/Passes.h
+++ b/include/structured/Dialect/Indexing/Transforms/Passes.h
@@ -1,0 +1,36 @@
+//===-- Passes.h - Indexing Pass Construction and Registration -*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+
+#ifndef STRUCTURED_DIALECT_INDEXING_TRANSFORMS_PASSES_H
+#define STRUCTURED_DIALECT_INDEXING_TRANSFORMS_PASSES_H
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+
+//===----------------------------------------------------------------------===//
+// Construction
+//===----------------------------------------------------------------------===//
+
+/// Generate pass declarations.
+#define GEN_PASS_DECL
+#include "structured/Dialect/Indexing/Transforms/Passes.h.inc"
+
+std::unique_ptr<Pass> createGatherToExtractSlicePass();
+std::unique_ptr<Pass> createScatterToInsertSlicePass();
+
+//===----------------------------------------------------------------------===//
+// Registration
+//===----------------------------------------------------------------------===//
+
+/// Generate the code for registering conversion passes.
+#define GEN_PASS_REGISTRATION
+#include "structured/Dialect/Indexing/Transforms/Passes.h.inc"
+
+} // namespace mlir
+
+#endif // STRUCTURED_DIALECT_INDEXING_TRANSFORMS_PASSES_H

--- a/include/structured/Dialect/Indexing/Transforms/Passes.h
+++ b/include/structured/Dialect/Indexing/Transforms/Passes.h
@@ -22,6 +22,7 @@ namespace mlir {
 
 std::unique_ptr<Pass> createGatherToExtractSlicePass();
 std::unique_ptr<Pass> createScatterToInsertSlicePass();
+std::unique_ptr<Pass> createMungeCallingConventionsPass();
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/include/structured/Dialect/Indexing/Transforms/Passes.td
+++ b/include/structured/Dialect/Indexing/Transforms/Passes.td
@@ -1,0 +1,40 @@
+//===-- Passes.td - Transform pass definition file ---------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef INDEXING_TRANSFORMS_PASSES
+#define INDEXING_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+//===----------------------------------------------------------------------===//
+// GatherToExtractSlice
+//===----------------------------------------------------------------------===//
+
+def GatherToExtractSlice : Pass<"gather-to-extract-slice", "func::FuncOp"> {
+  let summary = "Transform indexing::GatherOp to tensor::ExtractSliceOp";
+  let constructor = "mlir::createGatherToExtractSlicePass()";
+  let dependentDialects = [
+    "tensor::TensorDialect",
+    "func::FuncDialect",
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// ScatterToInsertSlice
+//===----------------------------------------------------------------------===//
+
+def ScatterToInsertSlice : Pass<"scatter-to-insert-slice", "func::FuncOp"> {
+  let summary = "Transform indexing::ScatterOp to tensor::InsertSliceOp";
+  let constructor = "mlir::createScatterToInsertSlicePass()";
+  let dependentDialects = [
+    "tensor::TensorDialect",
+    "func::FuncDialect",
+  ];
+}
+
+#endif // INDEXING_TRANSFORMS_PASSES

--- a/include/structured/Dialect/Indexing/Transforms/Passes.td
+++ b/include/structured/Dialect/Indexing/Transforms/Passes.td
@@ -37,4 +37,10 @@ def ScatterToInsertSlice : Pass<"scatter-to-insert-slice", "func::FuncOp"> {
   ];
 }
 
+def MungeCallingConventions : Pass<"refbackend-munge-calling-conventions", "ModuleOp"> {
+  let summary = "Munge calling conventions for calling via ExecutionEngine";
+  let constructor = "mlir::createMungeCallingConventionsPass()";
+  let dependentDialects = ["memref::MemRefDialect"];
+}
+
 #endif // INDEXING_TRANSFORMS_PASSES

--- a/include/structured/Dialect/Indexing/Transforms/ScatterGatherToInsertExtractSlice.h
+++ b/include/structured/Dialect/Indexing/Transforms/ScatterGatherToInsertExtractSlice.h
@@ -1,0 +1,12 @@
+//===-- DecomposeIndexingtates.h - Pass Utilities --------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef STRUCTURED_DIALECT_INDEXING_TRANSFORMS_SCATTER_GATHER_TO_INSERT_EXTRACT_SLICE_H
+#define STRUCTURED_DIALECT_INDEXING_TRANSFORMS_SCATTER_GATHER_TO_INSERT_EXTRACT_SLICE_H
+
+#endif // STRUCTURED_DIALECT_INDEXING_TRANSFORMS_SCATTER_GATHER_TO_INSERT_EXTRACT_SLICE_H

--- a/lib/CAPI/CMakeLists.txt
+++ b/lib/CAPI/CMakeLists.txt
@@ -13,6 +13,7 @@ add_mlir_public_c_api_library(StructuredCAPI
   LINK_LIBS PUBLIC
     MLIRCAPIIR
     MLIRIndexing
+    MLIRIndexingTransforms
     MLIRIterators
     MLIRIteratorsToLLVM
     MLIRIteratorsTransforms

--- a/lib/CAPI/Transforms.cpp
+++ b/lib/CAPI/Transforms.cpp
@@ -10,12 +10,15 @@
 #include "mlir/CAPI/Pass.h"
 #include "mlir/Pass/Pass.h"
 #include "structured/Dialect/Iterators/Transforms/Passes.h"
+#include "structured/Dialect/Indexing/Transforms/Passes.h"
 #include "structured/Dialect/Tuple/Transforms/Passes.h"
 
 using namespace mlir;
 
 // Must include the declarations as they carry important visibility attributes.
 #include "structured/Dialect/Iterators/Transforms/Passes.capi.h.inc"
+
+#include "structured/Dialect/Indexing/Transforms/Passes.capi.h.inc"
 
 #include "structured/Dialect/Tuple/Transforms/Passes.capi.h.inc"
 
@@ -24,6 +27,8 @@ extern "C" {
 #endif
 
 #include "structured/Dialect/Iterators/Transforms/Passes.capi.cpp.inc"
+
+#include "structured/Dialect/Indexing/Transforms/Passes.capi.cpp.inc"
 
 #include "structured/Dialect/Tuple/Transforms/Passes.capi.cpp.inc"
 

--- a/lib/Dialect/Indexing/CMakeLists.txt
+++ b/lib/Dialect/Indexing/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/lib/Dialect/Indexing/IR/Indexing.cpp
+++ b/lib/Dialect/Indexing/IR/Indexing.cpp
@@ -141,7 +141,7 @@ LogicalResult ARangeOp::inferReturnTypes(
     RegionRange regions, SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   if (!operands.empty()) {
     inferredReturnTypes.assign({RankedTensorType::get(
-        {ShapedType::kDynamic, 1}, IndexType::get(context))});
+        {ShapedType::kDynamic}, IndexType::get(context))});
   } else if (!attributes.empty() &&
              attributes.contains(ARangeOp::getStartAttrAttrName(context)) &&
              attributes.contains(ARangeOp::getStopAttrAttrName(context)) &&
@@ -156,7 +156,7 @@ LogicalResult ARangeOp::inferReturnTypes(
                     .cast<IntegerAttr>()
                     .getInt();
     inferredReturnTypes.assign({RankedTensorType::get(
-        {getARangeLen(start, stop, step), 1}, IndexType::get(context))});
+        {getARangeLen(start, stop, step)}, IndexType::get(context))});
   } else {
     return failure();
   }
@@ -267,7 +267,8 @@ struct ARangeOpPattern : public RewritePattern {
     if (arangeOp.getNofold())
       attributes.push_back(
           {arangeOp.getNofoldAttrName(), arangeOp.getNofoldAttr()});
-    rewriter.replaceOpWithNewOp<ARangeOp>(arangeOp, operands, attributes);
+    rewriter.replaceOpWithNewOp<ARangeOp>(arangeOp, arangeOp->getResultTypes(),
+                                          operands, attributes);
   }
 };
 
@@ -291,7 +292,7 @@ OpFoldResult ARangeOp::fold(FoldAdaptor adaptor) {
   for (int64_t i = start; i < stop; i += step) {
     arange.push_back(i);
   }
-  auto type = RankedTensorType::get({len, 1}, IndexType::get(getContext()));
+  auto type = RankedTensorType::get({len}, IndexType::get(getContext()));
   return DenseElementsAttr::get(type, ArrayRef(arange));
 }
 

--- a/lib/Dialect/Indexing/IR/Indexing.cpp
+++ b/lib/Dialect/Indexing/IR/Indexing.cpp
@@ -264,8 +264,9 @@ struct ARangeOpPattern : public RewritePattern {
 
     auto attr = rewriter.getDenseI32ArrayAttr(segmentSizes);
     attributes.push_back({arangeOp.getOperandSegmentSizesAttrName(), attr});
-    attributes.push_back(
-        {arangeOp.getFoldAttrAttrName(), arangeOp.getFoldAttrAttr()});
+    if (arangeOp.getNofold())
+      attributes.push_back(
+          {arangeOp.getNofoldAttrName(), arangeOp.getNofoldAttr()});
     rewriter.replaceOpWithNewOp<ARangeOp>(arangeOp, operands, attributes);
   }
 };
@@ -279,7 +280,7 @@ void ARangeOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 OpFoldResult ARangeOp::fold(FoldAdaptor adaptor) {
   if (!adaptor.getStartAttr() || !adaptor.getStopAttr() ||
-      !adaptor.getStepAttr() || !adaptor.getFoldAttr())
+      !adaptor.getStepAttr() || adaptor.getNofold())
     return {};
 
   int64_t start = adaptor.getStartAttr().value().getSExtValue(),

--- a/lib/Dialect/Indexing/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Indexing/Transforms/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_mlir_dialect_library(MLIRIndexingTransforms
+  ScatterGatherToInsertExtractSlice.cpp
+
+  DEPENDS
+  MLIRIndexingPassIncGen
+
+  LINK_LIBS PUBLIC
+  # generic
+  MLIRIR
+  MLIRPass
+  MLIRRewrite
+  MLIRTransforms
+  # specific
+  MLIRIndexing
+  MLIRTensorDialect
+)

--- a/lib/Dialect/Indexing/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Indexing/Transforms/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_mlir_dialect_library(MLIRIndexingTransforms
   ScatterGatherToInsertExtractSlice.cpp
+  RefBackend.cpp
 
   DEPENDS
   MLIRIndexingPassIncGen
@@ -13,4 +14,6 @@ add_mlir_dialect_library(MLIRIndexingTransforms
   # specific
   MLIRIndexing
   MLIRTensorDialect
+  MLIRFuncDialect
+  MLIRMemRefDialect
 )

--- a/lib/Dialect/Indexing/Transforms/RefBackend.cpp
+++ b/lib/Dialect/Indexing/Transforms/RefBackend.cpp
@@ -1,0 +1,205 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// Also available under a BSD-style license. See LICENSE.
+//
+
+#include "structured/Dialect/Indexing/IR/Indexing.h"
+#include "structured/Dialect/Indexing/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Utils/StructuredOpsUtils.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Support/Debug.h"
+
+#include <iostream>
+#include <numeric>
+
+#define DEBUG_TYPE "refbackend"
+
+namespace mlir {
+#define GEN_PASS_DEF_MUNGECALLINGCONVENTIONS
+#include "structured/Dialect/Indexing/Transforms/Passes.h.inc"
+} // namespace mlir
+
+using namespace llvm;
+using namespace mlir;
+
+static bool isArgMemRefTypeValid(mlir::Type type) {
+  if (auto memRefType = type.dyn_cast<MemRefType>()) {
+    mlir::Type elemTy = memRefType.getElementType();
+    if (elemTy.isa<Float16Type, Float32Type, Float64Type>()) {
+      return true;
+    } else if (auto integerTy = elemTy.dyn_cast<IntegerType>()) {
+      if (integerTy.isSignlessInteger(64))
+        return true;
+      if (integerTy.isSignlessInteger(32))
+        return true;
+      if (integerTy.isSignlessInteger(8))
+        return true;
+      if (integerTy.isSignedInteger(8))
+        return true;
+      if (integerTy.isSignlessInteger(1))
+        return true;
+    }
+  }
+  return false;
+}
+
+// Helper function to get the type string for one return value like i32, f64,
+// mri32 etc. The strings from multiple return values are concatenated to get
+// the consumeFuncReturnFunc name.
+static std::string getTypeToken(mlir::Type type) {
+  if (type.isSignlessInteger())
+    return ("i" + Twine(type.getIntOrFloatBitWidth())).str();
+  else if (type.isa<mlir::FloatType>())
+    return ("f" + Twine(type.getIntOrFloatBitWidth())).str();
+  else if (auto memRefType = type.dyn_cast<mlir::UnrankedMemRefType>())
+    return "mr" + getTypeToken(memRefType.getElementType());
+
+  llvm_unreachable(
+      "Type token should handle all types: memref, float and int type");
+}
+
+void addEmitCInterfaceAttr(func::FuncOp func) {
+  func->setAttr("llvm.emit_c_interface", UnitAttr::get(func.getContext()));
+}
+
+static mlir::Type getAbiTypeForMemRef(mlir::Type type) {
+  return UnrankedMemRefType::get(type.cast<MemRefType>().getElementType(), 0);
+}
+
+// Systematically derive the consumeFuncReturnFunc name from return value types.
+static std::string
+getConsumeReturnFunctionNameForReturnTypes(mlir::TypeRange types) {
+  SmallVector<std::string> tokens = {"refbackend_consume_func_return"};
+  for (auto type : types)
+    tokens.push_back(getTypeToken(type));
+
+  return std::accumulate(tokens.begin(), tokens.end(), std::string(),
+                         [](std::string &a, std::string &b) {
+                           return a.empty() ? b : (a + "_" + b);
+                         });
+}
+
+// Replace the original returnOp with a call to consumeFuncReturnFunc and add
+// the op to the `toErase` vector.
+static void replaceReturnWithCall(mlir::OpBuilder b, mlir::func::ReturnOp op,
+                                  StringRef funcName, mlir::TypeRange retTypes,
+                                  SmallVectorImpl<mlir::Value> &vals,
+                                  SmallVectorImpl<Operation *> &toErase) {
+  b.create<mlir::func::CallOp>(op.getLoc(), funcName, TypeRange({}), vals);
+  b.create<mlir::func::ReturnOp>(op.getLoc());
+  toErase.push_back(op);
+}
+
+LogicalResult mungeFunction(func::FuncOp func,
+                            std::map<std::string, std::vector<mlir::Type>>
+                                &invokedConsumeFuncReturnFuncs) {
+  // Only need to call mungeFunction for functions callable from outside of the
+  // module.
+  if (func.isPrivate())
+    return success();
+  // Add `llvm.emit_c_interface`.
+  // This allows ExecutionEngine to resolve the symbol properly.
+  addEmitCInterfaceAttr(func);
+
+  // Rewrite the function as follows:
+  // - replace all memref arguments with unranked memref
+  // - replace all returns with a call to a function, which is going to be
+  //   supplied by the code setting up the ExecutionEngine to process the
+  //   result. Additionally, ensure that all results are passed as unranked
+  //   memrefs.
+  // - replace the function signature accordingly (unranked inputs, no returns).
+  OpBuilder b(func.getBody());
+
+  SmallVector<mlir::Type> newArgTypes;
+  for (auto arg : func.getArguments()) {
+    auto type = arg.getType();
+    if (!isArgMemRefTypeValid(type)) {
+      return emitError(arg.getLoc())
+          .append("argument must be a memref of f32, f64, i32, i64, i8, i1 but "
+                  "got ",
+                  type);
+    }
+    auto cast = b.create<memref::CastOp>(arg.getLoc(), type, arg);
+    arg.replaceAllUsesExcept(cast, cast);
+    arg.setType(getAbiTypeForMemRef(type));
+    newArgTypes.push_back(arg.getType());
+  }
+
+  SmallVector<Operation *> toErase;
+  func.walk([&](func::ReturnOp op) {
+    auto types = op.getOperandTypes();
+    b.setInsertionPoint(op);
+    // Memref Types.
+    std::vector<mlir::Type> retTypes;
+    SmallVector<mlir::Value> retVals;
+    for (auto en : llvm::enumerate(types)) {
+      mlir::Type retType = en.value();
+      mlir::Value retVal = op.getOperand(en.index());
+      if (auto memrefReturnType = retType.dyn_cast<MemRefType>()) {
+        auto elemType = memrefReturnType.getElementType();
+        retType = UnrankedMemRefType::get(elemType, 0);
+        // Cast to unranked memref type before sending it as a function
+        // argument.
+        retVal = b.create<memref::CastOp>(
+            op.getLoc(), getAbiTypeForMemRef(types[en.index()]), retVal);
+      }
+      retTypes.push_back(retType);
+      retVals.push_back(retVal);
+    }
+
+    std::string funcName = getConsumeReturnFunctionNameForReturnTypes(retTypes);
+
+    auto invokedFuncsEnd = invokedConsumeFuncReturnFuncs.end();
+    if (invokedConsumeFuncReturnFuncs.find(funcName) == invokedFuncsEnd)
+      invokedConsumeFuncReturnFuncs.insert({funcName, retTypes});
+    replaceReturnWithCall(b, op, funcName, retTypes, retVals, toErase);
+  });
+  func.setType(FunctionType::get(func.getContext(), newArgTypes, {}));
+  for (Operation *op : toErase)
+    op->erase();
+  return success();
+}
+
+namespace {
+struct MungeCallingConventionsPass
+    : public mlir::impl::MungeCallingConventionsBase<
+          MungeCallingConventionsPass> {
+  void runOnOperation() override {
+    auto module = getOperation();
+    OpBuilder b(module.getBodyRegion());
+    std::map<std::string, std::vector<mlir::Type>>
+        invokedConsumeFuncReturnFuncs;
+    for (auto func : module.getOps<func::FuncOp>()) {
+      if (failed(mungeFunction(func, invokedConsumeFuncReturnFuncs)))
+        return signalPassFailure();
+    }
+
+    // Create FuncOp for consumeFuncReturnFuncs that are used.
+    for (auto &p : invokedConsumeFuncReturnFuncs) {
+      auto consumeFuncReturnFunc = b.create<func::FuncOp>(
+          module.getLoc(), p.first,
+          FunctionType::get(module.getContext(), p.second, {}));
+      consumeFuncReturnFunc.setPrivate();
+      addEmitCInterfaceAttr(consumeFuncReturnFunc);
+    }
+  }
+};
+} // namespace
+
+std::unique_ptr<Pass> mlir::createMungeCallingConventionsPass() {
+  return std::make_unique<MungeCallingConventionsPass>();
+}

--- a/lib/Dialect/Indexing/Transforms/ScatterGatherToInsertExtractSlice.cpp
+++ b/lib/Dialect/Indexing/Transforms/ScatterGatherToInsertExtractSlice.cpp
@@ -1,0 +1,208 @@
+//===-- ScatterGatherToInsertExtractSlice.cpp - Pass Implementation -------*-
+// C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "structured/Dialect/Indexing/Transforms/ScatterGatherToInsertExtractSlice.h"
+#include "structured/Dialect/Indexing/IR/Indexing.h"
+#include "structured/Dialect/Indexing/Transforms/Passes.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/SmallVector.h"
+
+#include <tuple>
+
+namespace mlir {
+#define GEN_PASS_CLASSES
+#include "structured/Dialect/Indexing/Transforms/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+using namespace mlir::indexing;
+
+namespace {
+
+SmallVector<OpFoldResult, 3>
+getMakeOffsetSizeStrideFromARange(ARangeOp arangeOp,
+                                  PatternRewriter &rewriter) {
+  SmallVector<OpFoldResult, 3> results;
+  SmallVector<StringAttr> attrs = {arangeOp.getStartAttrAttrName(),
+                                   arangeOp.getStopAttrAttrName(),
+                                   arangeOp.getStepAttrAttrName()};
+  SmallVector<Value> opers = {arangeOp.getStart(), arangeOp.getStop(),
+                              arangeOp.getStep()};
+  for (const auto &[index, tuple] : llvm::enumerate(llvm::zip(opers, attrs))) {
+    auto val = std::get<0>(tuple);
+    auto attrName = std::get<1>(tuple);
+    if (val)
+      results.push_back(val);
+    else
+      results.push_back(arangeOp->getAttr(attrName));
+  }
+
+  if (results[0].is<Attribute>() && results[1].is<Attribute>() &&
+      results[2].is<Attribute>())
+    results[1] =
+        rewriter.getIndexAttr((getConstantIntValue(results[1]).value() -
+                               getConstantIntValue(results[0]).value()) /
+                              getConstantIntValue(results[2]).value());
+  else {
+
+    auto start = results[0].is<Value>()
+                     ? results[0].dyn_cast<Value>()
+                     : rewriter.create<arith::ConstantOp>(
+                           arangeOp->getLoc(),
+                           rewriter.getSI32IntegerAttr(
+                               getConstantIntValue(results[0]).value()));
+    auto stop = results[1].is<Value>()
+                    ? results[1].dyn_cast<Value>()
+                    : rewriter.create<arith::ConstantOp>(
+                          arangeOp->getLoc(),
+                          rewriter.getSI32IntegerAttr(
+                              getConstantIntValue(results[1]).value()));
+    auto step = results[2].is<Value>()
+                    ? results[2].dyn_cast<Value>()
+                    : rewriter.create<arith::ConstantOp>(
+                          arangeOp->getLoc(),
+                          rewriter.getSI32IntegerAttr(
+                              getConstantIntValue(results[2]).value()));
+    auto diff = rewriter.create<arith::SubIOp>(arangeOp->getLoc(), stop, start)
+                    .getResult();
+    results[1] =
+        rewriter.create<arith::FloorDivSIOp>(arangeOp->getLoc(), diff, step)
+            .getResult();
+  }
+
+  return results;
+}
+
+SmallVector<SmallVector<OpFoldResult, 3>, 3> getMakeMixedOffsetsSizesStrides(
+    const Value indices, ArrayRef<int64_t> collapseDims,
+    ArrayRef<int64_t> sourceDestShape, PatternRewriter &rewriter) {
+
+  SmallVector<ARangeOp, 3> arangeOps;
+  if (auto arangeOp = indices.getDefiningOp<indexing::ARangeOp>()) {
+    arangeOps.push_back(arangeOp);
+  } else {
+    for (const auto &arangeVal :
+         indices.getDefiningOp<indexing::MeshGridOp>()->getOperands())
+      arangeOps.push_back(arangeVal.getDefiningOp<ARangeOp>());
+  }
+
+  llvm::SmallMapVector<int64_t, int64_t, 4> collapseDimsMap;
+  for (const auto &item : llvm::enumerate(collapseDims))
+    collapseDimsMap[item.value()] = item.index();
+
+  SmallVector<OpFoldResult, 3> mixedOffsets;
+  SmallVector<OpFoldResult, 3> mixedSizes;
+  SmallVector<OpFoldResult, 3> mixedStrides;
+  for (int dim = 0; dim < sourceDestShape.size(); ++dim) {
+    if (collapseDimsMap.contains(dim)) {
+      auto arangeOp = arangeOps[collapseDimsMap[dim]];
+      auto offsetSizeStride =
+          getMakeOffsetSizeStrideFromARange(arangeOp, rewriter);
+      mixedOffsets.push_back(offsetSizeStride[0]);
+      mixedSizes.push_back(offsetSizeStride[1]);
+      mixedStrides.push_back(offsetSizeStride[2]);
+    } else {
+      mixedOffsets.push_back(rewriter.getI64IntegerAttr(0));
+      mixedSizes.push_back(rewriter.getI64IntegerAttr(sourceDestShape[dim]));
+      mixedStrides.push_back(rewriter.getI64IntegerAttr(1));
+    }
+  }
+  return {mixedOffsets, mixedSizes, mixedStrides};
+}
+
+struct ConvertScatterOpToInsertSliceOp : public OpRewritePattern<ScatterOp> {
+  using OpRewritePattern<ScatterOp>::OpRewritePattern;
+  LogicalResult match(ScatterOp op) const override {
+    if (op.getSource().getType().hasRank() &&
+        op.getDest().getType().hasRank() && isARangeIndices(op.getIndices())) {
+      return success();
+    }
+    return failure();
+  }
+
+  void rewrite(ScatterOp op, PatternRewriter &rewriter) const override {
+    auto mixedOffsetsSizesStrides = getMakeMixedOffsetsSizesStrides(
+        op.getIndices(), op.getScatterDims(), op.getDest().getType().getShape(),
+        rewriter);
+    rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
+        op, op.getSource(), op.getDest(), mixedOffsetsSizesStrides[0],
+        mixedOffsetsSizesStrides[1], mixedOffsetsSizesStrides[2]);
+  }
+};
+
+struct ConvertGatherOpToInsertSliceOp : public OpRewritePattern<GatherOp> {
+  using OpRewritePattern<GatherOp>::OpRewritePattern;
+  LogicalResult match(GatherOp op) const override {
+    if (op.getSource().getType().hasRank() &&
+        isARangeIndices(op.getIndices())) {
+      return success();
+    }
+    return failure();
+  }
+
+  void rewrite(GatherOp op, PatternRewriter &rewriter) const override {
+    auto mixedOffsetsSizesStrides = getMakeMixedOffsetsSizesStrides(
+        op.getIndices(), op.getGatherDims(),
+        op.getSource().getType().getShape(), rewriter);
+    auto resultType = tensor::ExtractSliceOp::inferResultType(
+        op.getSource().getType(), mixedOffsetsSizesStrides[0],
+        mixedOffsetsSizesStrides[1], mixedOffsetsSizesStrides[2]);
+    auto newOp = rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
+        op, resultType, op.getSource(), mixedOffsetsSizesStrides[0],
+        mixedOffsetsSizesStrides[1], mixedOffsetsSizesStrides[2]);
+  }
+};
+
+} // namespace
+
+namespace {
+
+struct GatherToExtractSlicePass
+    : public GatherToExtractSliceBase<GatherToExtractSlicePass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<ConvertGatherOpToInsertSliceOp>(&getContext());
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  };
+};
+
+struct ScatterToInsertSlicePass
+    : public ScatterToInsertSliceBase<ScatterToInsertSlicePass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.add<ConvertScatterOpToInsertSliceOp>(&getContext());
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      signalPassFailure();
+  };
+};
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createGatherToExtractSlicePass() {
+  return std::make_unique<GatherToExtractSlicePass>();
+}
+
+std::unique_ptr<Pass> mlir::createScatterToInsertSlicePass() {
+  return std::make_unique<ScatterToInsertSlicePass>();
+}

--- a/lib/Dialect/Indexing/Transforms/ScatterGatherToInsertExtractSlice.cpp
+++ b/lib/Dialect/Indexing/Transforms/ScatterGatherToInsertExtractSlice.cpp
@@ -28,7 +28,8 @@
 #include <tuple>
 
 namespace mlir {
-#define GEN_PASS_CLASSES
+#define GEN_PASS_DEF_GATHERTOEXTRACTSLICE
+#define GEN_PASS_DEF_SCATTERTOINSERTSLICE
 #include "structured/Dialect/Indexing/Transforms/Passes.h.inc"
 } // namespace mlir
 
@@ -176,7 +177,7 @@ struct ConvertGatherOpToInsertSliceOp : public OpRewritePattern<GatherOp> {
 namespace {
 
 struct GatherToExtractSlicePass
-    : public GatherToExtractSliceBase<GatherToExtractSlicePass> {
+    : public mlir::impl::GatherToExtractSliceBase<GatherToExtractSlicePass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     patterns.add<ConvertGatherOpToInsertSliceOp>(&getContext());
@@ -187,7 +188,7 @@ struct GatherToExtractSlicePass
 };
 
 struct ScatterToInsertSlicePass
-    : public ScatterToInsertSliceBase<ScatterToInsertSlicePass> {
+    : public mlir::impl::ScatterToInsertSliceBase<ScatterToInsertSlicePass> {
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     patterns.add<ConvertScatterOpToInsertSliceOp>(&getContext());

--- a/python/StructuredPasses.cpp
+++ b/python/StructuredPasses.cpp
@@ -20,6 +20,7 @@ PYBIND11_MODULE(_mlirStructuredPasses, m) {
   // Register all Structured passes on load.
   mlirRegisterStructuredConversionPasses();
   mlirRegisterIteratorsPasses();
+  mlirRegisterIndexingPasses();
   mlirRegisterTuplePasses();
 
   // Register all Triton passes on load.

--- a/python/mlir_structured/dialects/_indexing_ops_ext.py
+++ b/python/mlir_structured/dialects/_indexing_ops_ext.py
@@ -21,7 +21,7 @@ class ARangeOp:
                start=None,
                stop=None,
                step=None,
-               fold=None,
+               nofold=None,
                loc=None,
                ip=None):
     operands = []
@@ -79,12 +79,8 @@ class ARangeOp:
                                  not ir.AttrBuilder.contains('IndexAttr')) else
                                 ir.AttrBuilder.get('IndexAttr')(
                                     stepAttr, context=_ods_context))
-    if fold is not None:
-      attributes["foldAttr"] = (fold if
-                                (issubclass(type(fold), ir.Attribute) or
-                                 not ir.AttrBuilder.contains('BoolAttr')) else
-                                ir.AttrBuilder.get('BoolAttr')(
-                                    fold, context=_ods_context))
+    if bool(nofold):
+      attributes["nofold"] = ir.UnitAttr.get(_ods_context)
 
     results = ir.InferTypeOpInterface(ARangeOp).inferReturnTypes(
         operands=operands,

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -504,6 +504,7 @@ class Tensor(ArithValue, TensorValue):
   def __iadd__(self, other):
     if isinstance(other, Tensor) and hasattr(
         other.owner, "name") and other.owner.name == "linalg.matmul":
+      # TODO(max): erase previous owner
       return Tensor(
           linalg.matmul(other.owner.operands[0],
                         other.owner.operands[1],

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -710,6 +710,10 @@ def expand_dims(inp, newaxis_dims, reshape=None) -> Tensor:
   raise NotImplementedError(inp, newaxis_dims)
 
 
+def meshgrid(*xi: Tuple[Tensor]) -> Tensor:
+  return Tensor(MeshGridOp(inputs=xi))
+
+
 ########################
 # advanced indexing impl
 ########################

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -615,9 +615,9 @@ def arange(start: Union[Scalar, int],
                     dtype=IndexType.get(),
                     fold=True)
     else:
-      return Tensor(ARangeOp(start=start, stop=stop, step=1),
+      return Tensor(ARangeOp(start=start, stop=stop, step=1, nofold=True),
                     dtype=IndexType.get(),
-                    fold=stop.fold() and fold)
+                    fold=False)
   else:
     if isinstance(stop, int):
       stop = Scalar(stop, dtype=index)
@@ -630,9 +630,9 @@ def arange(start: Union[Scalar, int],
                       dtype=IndexType.get(),
                       fold=True)
       else:
-        return Tensor(ARangeOp(start=start, stop=stop, step=1),
+        return Tensor(ARangeOp(start=start, stop=stop, step=1, nofold=True),
                       dtype=IndexType.get(),
-                      fold=start.fold() and stop.fold() and fold)
+                      fold=False)
     if isinstance(step, int):
       step = Scalar(step, dtype=index)
     if start.fold() and stop.fold() and step.fold() and fold:
@@ -642,9 +642,9 @@ def arange(start: Union[Scalar, int],
                     dtype=IndexType.get(),
                     fold=True)
     else:
-      return Tensor(ARangeOp(start=start, stop=stop, step=step),
+      return Tensor(ARangeOp(start=start, stop=stop, step=step, nofold=True),
                     dtype=IndexType.get(),
-                    fold=start.fold() and stop.fold() and step.fold() and fold)
+                    fold=False)
 
 
 ########################

--- a/python/mlir_structured/runtime/refbackend.py
+++ b/python/mlir_structured/runtime/refbackend.py
@@ -1,0 +1,198 @@
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+# Also available under a BSD-style license. See LICENSE.
+
+from __future__ import annotations
+
+import ctypes
+import os
+from typing import Optional, Callable
+
+import numpy as np
+
+from mlir_structured.execution_engine import ExecutionEngine
+
+from mlir_structured.runtime import (
+    UnrankedMemRefDescriptor,
+    get_ranked_memref_descriptor,
+    get_unranked_memref_descriptor,
+)
+from mlir_structured.ir import Module, UnitAttr
+from mlir_structured.runtime.util import run_pipeline, find_ops
+
+
+def assert_arg_type_is_supported(ty):
+  SUPPORTED = [
+      np.float16,
+      np.float32,
+      np.float64,
+      np.uint8,
+      np.int8,
+      np.int32,
+      np.int64,
+      np.bool_,
+  ]
+  assert (
+      ty in SUPPORTED
+  ), f"Only numpy arrays with dtypes in {SUPPORTED} are supported, but got {ty}"
+
+
+memref_type_to_np_dtype = {
+    "mrf16": np.float16,
+    "mrf32": np.float32,
+    "mrf64": np.float64,
+    "mri1": np.bool_,
+    "mri8": np.int8,
+    "mri32": np.int32,
+    "mri64": np.int64,
+}
+elemental_type_to_ctype = {
+    "i1": ctypes.c_bool,
+    "i8": ctypes.c_byte,
+    "i64": ctypes.c_int,
+    "f32": ctypes.c_float,
+    "f64": ctypes.c_double,
+}
+
+CONSUME_RETURN_FUNC_PREFIX = "refbackend_consume_func_return_"
+
+
+def get_return_funcs(module):
+  return_prefix_len = len(CONSUME_RETURN_FUNC_PREFIX)
+  return_funcs = []
+  with module.context:
+    for func in module.body:
+      # Returns strings of the form `"refbackend.."` so `"` is deleted.
+      func_name = str(func.attributes["sym_name"]).replace('"', "")
+      if func_name[:return_prefix_len] == CONSUME_RETURN_FUNC_PREFIX:
+        return_funcs.append(func_name)
+
+  return return_funcs
+
+
+def get_ctype_func(func_name):
+  return_prefix_len = len(CONSUME_RETURN_FUNC_PREFIX)
+  ret_types = func_name[return_prefix_len:].split("_")
+  ctypes_arg = [None]
+  for type in ret_types:
+    if type in elemental_type_to_ctype:
+      ctypes_arg.append(elemental_type_to_ctype[type])
+    elif type in memref_type_to_np_dtype:
+      ctypes_arg.append(ctypes.POINTER(UnrankedMemRefDescriptor))
+    else:
+      assert False, f"Not supported type: {type}"
+
+  return ctypes.CFUNCTYPE(*ctypes_arg), ret_types
+
+
+# https://stackoverflow.com/a/68198336/9045206
+CData = ctypes._SimpleCData.__mro__[-2]
+
+_MLIR_RUNNER_UTILS_LIB_ENV = "MLIR_RUNNER_UTILS_LIB"
+_MLIR_C_RUNNER_UTILS_LIB_ENV = "MLIR_C_RUNNER_UTILS_LIB"
+_MLIR_ASYNC_RUNTIME_LIB_ENV = "MLIR_ASYNC_RUNTIME_LIB"
+
+
+class LLVMJITBackendInvoker:
+  return_func: Optional[Callable] = None
+
+  def __init__(self,
+               module,
+               consume_return_func=None,
+               opt_level=2,
+               shared_libs=None):
+    if shared_libs is None:
+      shared_libs = [
+          os.environ[_MLIR_RUNNER_UTILS_LIB_ENV],
+          os.environ[_MLIR_C_RUNNER_UTILS_LIB_ENV],
+          os.environ[_MLIR_ASYNC_RUNTIME_LIB_ENV],
+      ]
+    self.ee = ExecutionEngine(module,
+                              opt_level=opt_level,
+                              shared_libs=shared_libs)
+    if consume_return_func is not None:
+      return_funcs = get_return_funcs(module)
+      assert len(return_funcs) == 1, f"multiple return funcs not supported"
+      self.return_func = return_funcs[0]
+      ctype_wrapper, ret_types = get_ctype_func(self.return_func)
+      self.ret_types = ret_types
+      self.ee.register_runtime(self.return_func,
+                               ctype_wrapper(consume_return_func))
+
+  def __getattr__(self, function_name: str):
+    _get = super().__getattribute__
+
+    def invoke(*args):
+      ffi_args = []
+      for arg in args:
+        if isinstance(arg, CData):
+          ffi_args.append(arg)
+        else:
+          assert_arg_type_is_supported(arg.dtype)
+          ffi_args.append(
+              ctypes.pointer(
+                  # TODO(max): this is a hack to handle refbackend
+                  # in principle this has nothing to do with anything
+                  # refbackend related
+                  ctypes.pointer(get_unranked_memref_descriptor(arg))
+                  if _get("return_func") is not None else ctypes.
+                  pointer(get_ranked_memref_descriptor(arg))))
+
+      self.ee.invoke(function_name, *ffi_args)
+
+    return invoke
+
+
+class LLVMJITBackend:
+
+  def __init__(
+      self,
+      shared_libs: Optional[list[str]] = None,
+  ):
+    if shared_libs is None:
+      shared_libs = [
+          os.environ[_MLIR_C_RUNNER_UTILS_LIB_ENV],
+          os.environ[_MLIR_RUNNER_UTILS_LIB_ENV],
+      ]
+    self.shared_libs = shared_libs
+
+  def compile(
+      self,
+      module: Module,
+      pipeline: str,
+      kernel_name="main",
+      enable_ir_printing=False,
+  ):
+
+    def cb(op):
+      try:
+        return kernel_name == op.sym_name.value
+      except:
+        return False
+
+    needs_cface = "to-llvm" in pipeline
+    pipeline_str = pipeline
+
+    if needs_cface:
+      kernel_func = find_ops(module.operation, cb)
+      assert len(kernel_func) == 1, f"kernel func {kernel_func} not found"
+      kernel_func[0].attributes["llvm.emit_c_interface"] = UnitAttr.get()
+
+    return run_pipeline(
+        module,
+        pipeline=pipeline_str,
+        description="Lowering IR",
+        enable_ir_printing=enable_ir_printing,
+    )
+
+  def load(self,
+           module,
+           consume_return_func=None,
+           opt_level=2) -> LLVMJITBackendInvoker:
+    return LLVMJITBackendInvoker(
+        module,
+        opt_level=opt_level,
+        shared_libs=self.shared_libs,
+        consume_return_func=consume_return_func,
+    )

--- a/python/mlir_structured/runtime/util.py
+++ b/python/mlir_structured/runtime/util.py
@@ -1,15 +1,23 @@
 import contextlib
 import inspect
-from typing import Optional
+import os
+import sys
+import tempfile
+from contextlib import ExitStack
+from io import StringIO
+from typing import Optional, Callable
 
+from mlir_structured.dialects import scf
+from mlir_structured.dialects.indexing import constant, maybe_cast, _update_caller_vars
 from mlir_structured.ir import (
     Context,
     Module,
     InsertionPoint,
     Location,
+    StringAttr,
+    OpView,
 )
-from mlir_structured.dialects.indexing import constant, maybe_cast, _update_caller_vars
-from mlir_structured.dialects import scf
+from mlir_structured.passmanager import PassManager
 
 
 @contextlib.contextmanager
@@ -52,7 +60,9 @@ def scf_range(start, stop=None, step=1, iter_args=None):
     if len(iter_args):
       previous_frame = inspect.currentframe().f_back
       _update_caller_vars(previous_frame, iter_args, for_op.inner_iter_args)
+      print("before")
       yield iv, for_op.result
+      print("after")
     else:
       yield iv
       scf.YieldOp([])
@@ -60,3 +70,100 @@ def scf_range(start, stop=None, step=1, iter_args=None):
 
 def scf_yield(*val):
   scf.YieldOp(val)
+
+
+class IndexingCompilerError(Exception):
+
+  def __init__(self, value: str):
+    super().__init__()
+    self.value = value
+
+  def __str__(self) -> str:
+    return self.value
+
+
+@contextlib.contextmanager
+def disable_multithreading(context=None):
+  if context is None:
+    context = Context.current
+
+  context.enable_multithreading(False)
+  yield
+  context.enable_multithreading(True)
+
+
+def get_module_name_for_debug_dump(module):
+  if not "indexing.debug_module_name" in module.operation.attributes:
+    return "UnnammedModule"
+  return StringAttr(
+      module.operation.attributes["nelli.debug_module_name"]).value
+
+
+def run_pipeline(
+    module,
+    pipeline: str,
+    description: Optional[str] = None,
+    enable_ir_printing=False,
+    print_pipeline=False,
+):
+  """Runs `pipeline` on `module`, with a nice repro report if it fails."""
+  module_name = get_module_name_for_debug_dump(module)
+  try:
+    original_stderr = sys.stderr
+    sys.stderr = StringIO()
+    # Lower module in place to make it ready for compiler backends.
+    with ExitStack() as stack:
+      stack.enter_context(module.context)
+      asm_for_error_report = module.operation.get_asm(
+          large_elements_limit=10,
+          enable_debug_info=True,
+      )
+      pm = PassManager.parse(pipeline)
+      if print_pipeline:
+        print(pm)
+      if enable_ir_printing:
+        stack.enter_context(disable_multithreading())
+        pm.enable_ir_printing()
+
+      pm.run(module.operation)
+  except Exception as e:
+    print(e, file=sys.stderr)
+    filename = os.path.join(tempfile.gettempdir(), module_name + ".mlir")
+    with open(filename, "w") as f:
+      f.write(asm_for_error_report)
+    debug_options = "-mlir-print-ir-after-all -mlir-disable-threading"
+    # Put something descriptive here even if description is empty.
+    description = description or f"{module_name} compile"
+
+    message = f"""\
+            {description} failed with the following diagnostics:
+            
+            {'*' * 80}
+            {sys.stderr.getvalue().strip()}
+            {'*' * 80}
+
+            For developers, the error can be reproduced with:
+            $ mlir-opt {debug_options} -pass-pipeline='{pipeline}' {filename}
+            """
+    trimmed_message = "\n".join([m.lstrip() for m in message.split("\n")])
+    raise IndexingCompilerError(trimmed_message) from None
+  finally:
+    sys.stderr = original_stderr
+
+  return module
+
+
+def find_ops(op, pred: Callable[[OpView], bool]):
+  matching = []
+
+  def find(op):
+    for r in op.regions:
+      for b in r.blocks:
+        for o in b.operations:
+          if pred(o):
+            matching.append(o)
+          find(o)
+
+  find(op)
+
+  return matching

--- a/test/Dialect/Indexing/basic.mlir
+++ b/test/Dialect/Indexing/basic.mlir
@@ -9,7 +9,7 @@
 // CHECK:             %[[VAL_5:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_6:.*]] = arith.constant 100 : index
 // CHECK:             %[[VAL_7:.*]] = arith.constant 2 : index
-// CHECK:             %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) : tensor<?x1xindex>
+// CHECK:             %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) : tensor<?xindex>
 // CHECK:             return
 // CHECK:           }
 // CHECK:         }
@@ -23,7 +23,7 @@ module {
     %c0_index = arith.constant 0 : index
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
-    %4 = indexing.arange(start = %c0_index, stop = %c100_index, step = %c2_index) : tensor<?x1xindex>
+    %4 = indexing.arange(start = %c0_index, stop = %c100_index, step = %c2_index) : tensor<?xindex>
     return
   }
 }
@@ -34,28 +34,28 @@ module {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
 // CHECK:         }
 
 module {
   %0 = arith.constant 0 : index
   %1 = arith.constant 100 : index
   %2 = arith.constant 2 : index
-  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : index} : (index, index) -> tensor<?x1xindex>
-  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : index} : (index, index) -> tensor<?x1xindex>
-  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : index, stepAttr = 2 : index} : (index) -> tensor<?x1xindex>
-  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : index} : (index, index) -> tensor<?xindex>
+  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : index} : (index, index) -> tensor<?xindex>
+  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : index, stepAttr = 2 : index} : (index) -> tensor<?xindex>
+  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50xindex>
 }
 
 // -----
@@ -64,26 +64,26 @@ module {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
 // CHECK:         }
 
 module {
   %c0 = arith.constant 0 : index
   %c100 = arith.constant 100 : index
   %c2 = arith.constant 2 : index
-  %0 = indexing.arange(start = %c0, stop = %c100, step = %c2) : tensor<?x1xindex>
-  %1 = indexing.arange(start = 0, stop = %c100, step = %c2) : tensor<?x1xindex>
-  %2 = indexing.arange(start = %c0, stop = 100, step = %c2) : tensor<?x1xindex>
-  %3 = indexing.arange(start = %c0, stop = %c100, step = 2) : tensor<?x1xindex>
-  %4 = indexing.arange(start = 0, stop = 100, step = %c2) : tensor<?x1xindex>
-  %5 = indexing.arange(start = 0, stop = %c100, step = 2) : tensor<?x1xindex>
-  %6 = indexing.arange(start = %c0, stop = 100, step = 2) : tensor<?x1xindex>
-  %7 = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+  %0 = indexing.arange(start = %c0, stop = %c100, step = %c2) : tensor<?xindex>
+  %1 = indexing.arange(start = 0, stop = %c100, step = %c2) : tensor<?xindex>
+  %2 = indexing.arange(start = %c0, stop = 100, step = %c2) : tensor<?xindex>
+  %3 = indexing.arange(start = %c0, stop = %c100, step = 2) : tensor<?xindex>
+  %4 = indexing.arange(start = 0, stop = 100, step = %c2) : tensor<?xindex>
+  %5 = indexing.arange(start = 0, stop = %c100, step = 2) : tensor<?xindex>
+  %6 = indexing.arange(start = %c0, stop = 100, step = 2) : tensor<?xindex>
+  %7 = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
 }

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -5,16 +5,16 @@
 // CHECK:           %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
 // CHECK:           %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
 // CHECK:           %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
-// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:           "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:           "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-// CHECK:           "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:           "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:           "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+// CHECK:           "use1"(%[[VAL_3]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+// CHECK:           "use2"(%[[VAL_4]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+// CHECK:           "use3"(%[[VAL_5]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+// CHECK:           "use4"(%[[VAL_6]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+// CHECK:           "use5"(%[[VAL_7]]) : (tensor<?xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
 // CHECK:       }) : () -> ()
@@ -28,20 +28,20 @@ module {
     %c100_index_dyn = "c100_index_dyn"() : () -> (index)
     %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use1"(%10) : (tensor<?x1xindex>) -> ()
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use1"(%10) : (tensor<?xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use2"(%11) : (tensor<?x1xindex>) -> ()
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use2"(%11) : (tensor<?xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use3"(%12) : (tensor<?x1xindex>) -> ()
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use3"(%12) : (tensor<?xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_index_dyn) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
-    "use4"(%13) : (tensor<?x1xindex>) -> ()
+    %13 = "indexing.arange"(%c0_index_dyn) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
+    "use4"(%13) : (tensor<?xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {nofold, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
-    "use5"(%14) : (tensor<?x1xindex>) -> ()
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {nofold, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?xindex>
+    "use5"(%14) : (tensor<?xindex>) -> ()
 
     return
   }
@@ -51,13 +51,14 @@ module {
 
 // CHECK-LABEL: "builtin.module"() ({
 // CHECK:         "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
-// CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
-// CHECK:           "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
-// CHECK:           "use3"(%[[VAL_1]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
-// CHECK:           "use4"(%[[VAL_2]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98]> : tensor<50xindex>}> : () -> tensor<50xindex>
+// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<?xindex>
+// CHECK:           "use1"(%[[VAL_1]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<?xindex>
+// CHECK:           "use2"(%[[VAL_2]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<?xindex>
+// CHECK:           "use3"(%[[VAL_3]]) : (tensor<?xindex>) -> ()
+// CHECK:           "use4"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
 // CHECK:       }) : () -> ()
@@ -68,14 +69,14 @@ module {
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use1"(%4) : (tensor<?x1xindex>) -> ()
-    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
-    "use2"(%5) : (tensor<?x1xindex>) -> ()
-    %si = "indexing.arange"(%c0_index) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
-    "use3"(%si) : (tensor<?x1xindex>) -> ()
-    %se = "indexing.arange"() {nofold, startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
-    "use4"(%se) : (tensor<50x1xindex>) -> ()
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use1"(%4) : (tensor<?xindex>) -> ()
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?xindex>
+    "use2"(%5) : (tensor<?xindex>) -> ()
+    %si = "indexing.arange"(%c0_index) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
+    "use3"(%si) : (tensor<?xindex>) -> ()
+    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50xindex>
+    "use4"(%se) : (tensor<50xindex>) -> ()
 
     return
   }

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -5,15 +5,15 @@
 // CHECK:           %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
 // CHECK:           %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
 // CHECK:           %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
-// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
 // CHECK:           "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
 // CHECK:           "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
 // CHECK:           "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
 // CHECK:           "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
 // CHECK:           "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
@@ -28,19 +28,19 @@ module {
     %c100_index_dyn = "c100_index_dyn"() : () -> (index)
     %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%10) : (tensor<?x1xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use2"(%11) : (tensor<?x1xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use3"(%12) : (tensor<?x1xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_index_dyn) {foldAttr = false, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %13 = "indexing.arange"(%c0_index_dyn) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use4"(%13) : (tensor<?x1xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {foldAttr = false, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {nofold, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
     "use5"(%14) : (tensor<?x1xindex>) -> ()
 
     return
@@ -54,9 +54,9 @@ module {
 // CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
 // CHECK:           "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
 // CHECK:           "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
 // CHECK:           "use3"(%[[VAL_1]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
 // CHECK:           "use4"(%[[VAL_2]]) : (tensor<50x1xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
@@ -68,13 +68,13 @@ module {
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {foldAttr = true, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%4) : (tensor<?x1xindex>) -> ()
-    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, foldAttr = true, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
     "use2"(%5) : (tensor<?x1xindex>) -> ()
-    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %si = "indexing.arange"(%c0_index) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use3"(%si) : (tensor<?x1xindex>) -> ()
-    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
+    %se = "indexing.arange"() {nofold, startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
     "use4"(%se) : (tensor<50x1xindex>) -> ()
 
     return

--- a/test/Dialect/Indexing/convert-gather-to-extract-slice.mlir
+++ b/test/Dialect/Indexing/convert-gather-to-extract-slice.mlir
@@ -1,0 +1,60 @@
+// RUN: structured-opt -allow-unregistered-dialect -canonicalize -gather-to-extract-slice -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: module {
+// CHECK:         func.func @test_convert_gather_to_extract() {
+// CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+// CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 0, stop = 22, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_2:.*]] = indexing.meshgrid(%[[VAL_1]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_3:.*]] = tensor.extract_slice %[[VAL_0]][0, 0, 0, 0] [7, 11, 330, 4400] [1, 2, 1, 1] : tensor<7x22x330x4400xf32> to tensor<7x11x330x4400xf32>
+// CHECK:           %[[VAL_4:.*]] = "use1"(%[[VAL_3]]) : (tensor<7x11x330x4400xf32>) -> tensor<7x11x330x4400xf32>
+// CHECK:           %[[VAL_5:.*]] = indexing.scatter %[[VAL_4]] into %[[VAL_0]]{{\[}}%[[VAL_2]]] scatter_dims([1]) unique : (tensor<7x11x330x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x22x330x4400xf32>
+// CHECK:           "use1"(%[[VAL_5]]) : (tensor<7x22x330x4400xf32>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+
+module {
+  func.func @test_convert_gather_to_extract() {
+    %0 = tensor.empty() : tensor<7x22x330x4400xf32>
+    %c0 = arith.constant 0 : index
+    %c22 = arith.constant 22 : index
+    %c2 = arith.constant 2 : index
+    %1 = indexing.arange(start = %c0, stop = %c22, step = %c2) : tensor<?xindex>
+    %5 = indexing.meshgrid(%1) : (tensor<?xindex>) -> tensor<?x1xindex>
+    %2 = indexing.gather %0[%5] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x11x330x4400xf32>
+    %3 = "use1"(%2) : (tensor<7x11x330x4400xf32>) -> (tensor<7x11x330x4400xf32>)
+    %4 = indexing.scatter %3 into %0[%5] scatter_dims([1]) unique : (tensor<7x11x330x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x22x330x4400xf32>
+    "use1"(%4) : (tensor<7x22x330x4400xf32>) -> ()
+
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: module {
+// CHECK:         func.func @test_convert_gather_to_extract_with_concat() {
+// CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+// CHECK:           %[[VAL_1:.*]] = tensor.extract_slice %[[VAL_0]][0, 0, 0, 0] [7, 11, 11, 4400] [1, 2, 30, 1] : tensor<7x22x330x4400xf32> to tensor<7x11x11x4400xf32>
+// CHECK:           "use1"(%[[VAL_1]]) : (tensor<7x11x11x4400xf32>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+
+module {
+  func.func @test_convert_gather_to_extract_with_concat() {
+    %0 = tensor.empty() : tensor<7x22x330x4400xf32>
+    %c0 = arith.constant 0 : index
+    %c22 = arith.constant 22 : index
+    %c2 = arith.constant 2 : index
+    %1 = indexing.arange(start = %c0, stop = %c22, step = %c2) : tensor<?xindex>
+    %c330 = arith.constant 330 : index
+    %c30 = arith.constant 30 : index
+    %4 = indexing.arange(start = %c0, stop = %c330, step = %c30) : tensor<?xindex>
+    %5 = indexing.meshgrid(%1, %4) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+    %6 = indexing.gather %0[%5] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<7x?x?x4400xf32>
+    "use1"(%6) : (tensor<7x?x?x4400xf32>) -> ()
+
+    return
+  }
+}

--- a/test/Dialect/Indexing/convert-scatter-to-insert-slice.mlir
+++ b/test/Dialect/Indexing/convert-scatter-to-insert-slice.mlir
@@ -1,0 +1,67 @@
+// RUN: structured-opt -allow-unregistered-dialect -canonicalize -scatter-to-insert-slice -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: module {
+// CHECK:         func.func @test_convert_scatter_to_insert() {
+// CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+// CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 0, stop = 22, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_2:.*]] = indexing.meshgrid(%[[VAL_1]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_2]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x11x330x4400xf32>
+// CHECK:           %[[VAL_4:.*]] = "use1"(%[[VAL_3]]) : (tensor<7x11x330x4400xf32>) -> tensor<7x11x330x4400xf32>
+// CHECK:           %[[VAL_5:.*]] = tensor.insert_slice %[[VAL_4]] into %[[VAL_0]][0, 0, 0, 0] [7, 11, 330, 4400] [1, 2, 1, 1] : tensor<7x11x330x4400xf32> into tensor<7x22x330x4400xf32>
+// CHECK:           "use2"(%[[VAL_5]]) : (tensor<7x22x330x4400xf32>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+
+module {
+  func.func @test_convert_scatter_to_insert() {
+    %0 = tensor.empty() : tensor<7x22x330x4400xf32>
+    %c0 = arith.constant 0 : index
+    %c22 = arith.constant 22 : index
+    %c2 = arith.constant 2 : index
+    %1 = indexing.arange(start = %c0, stop = %c22, step = %c2) : tensor<?xindex>
+    %5 = indexing.meshgrid(%1) : (tensor<?xindex>) -> tensor<?x1xindex>
+    %2 = indexing.gather %0[%5] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x11x330x4400xf32>
+    %3 = "use1"(%2) : (tensor<7x11x330x4400xf32>) -> (tensor<7x11x330x4400xf32>)
+    %4 = indexing.scatter %3 into %0[%5] scatter_dims([1]) unique : (tensor<7x11x330x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x22x330x4400xf32>
+    "use2"(%4) : (tensor<7x22x330x4400xf32>) -> ()
+
+    return
+  }
+}
+
+// -----
+
+// CHECK-LABEL: module {
+// CHECK:         func.func @test_convert_gather_to_extract_with_concat() {
+// CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+// CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 0, stop = 22, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_2:.*]] = indexing.arange(start = 0, stop = 330, step = 30) : tensor<?xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.meshgrid(%[[VAL_1]], %[[VAL_2]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_3]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<7x?x?x4400xf32>
+// CHECK:           %[[VAL_5:.*]] = "use1"(%[[VAL_4]]) : (tensor<7x?x?x4400xf32>) -> tensor<7x11x11x4400xf32>
+// CHECK:           %[[VAL_6:.*]] = tensor.insert_slice %[[VAL_5]] into %[[VAL_0]][0, 0, 0, 0] [7, 11, 11, 4400] [1, 2, 30, 1] : tensor<7x11x11x4400xf32> into tensor<7x22x330x4400xf32>
+// CHECK:           "use2"(%[[VAL_6]]) : (tensor<7x22x330x4400xf32>) -> ()
+// CHECK:           return
+// CHECK:         }
+// CHECK:       }
+
+module {
+  func.func @test_convert_gather_to_extract_with_concat() {
+    %0 = tensor.empty() : tensor<7x22x330x4400xf32>
+    %c0 = arith.constant 0 : index
+    %c22 = arith.constant 22 : index
+    %c2 = arith.constant 2 : index
+    %1 = indexing.arange(start = %c0, stop = %c22, step = %c2) : tensor<?xindex>
+    %c330 = arith.constant 330 : index
+    %c30 = arith.constant 30 : index
+    %4 = indexing.arange(start = %c0, stop = %c330, step = %c30) : tensor<?xindex>
+    %10 = indexing.meshgrid(%1, %4) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+    %6 = indexing.gather %0[%10] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<7x?x?x4400xf32>
+    %7 = "use1"(%6) : (tensor<7x?x?x4400xf32>) -> (tensor<7x11x11x4400xf32>)
+    %9 = indexing.scatter %7 into %0[%10] scatter_dims([1, 2]) unique : (tensor<7x11x11x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<7x22x330x4400xf32>
+    "use2"(%9) : (tensor<7x22x330x4400xf32>) -> ()
+
+    return
+  }
+}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -61,9 +61,24 @@ if "LLVM_SYMBOLIZER_PATH" in os.environ:
   config.environment["LLVM_SYMBOLIZER_PATH"] = \
       os.environ["LLVM_SYMBOLIZER_PATH"]
 
+
+def add_runtime(name):
+  for prefix in ['', 'lib']:
+    path = os.path.join(config.mlir_lib_dir,
+                        f'{prefix}{name}{config.llvm_shlib_ext}')
+    if os.path.isfile(path):
+      break
+  return path
+
+
+config.environment["MLIR_RUNNER_UTILS_LIB"] = add_runtime('mlir_runner_utils')
+config.environment["MLIR_C_RUNNER_UTILS_LIB"] = add_runtime(
+    'mlir_c_runner_utils')
+config.environment["MLIR_ASYNC_RUNTIME_LIB"] = add_runtime('mlir_async_runtime')
+
 llvm_config.add_tool_substitutions(tools, tool_dirs)
 
 structured_python_path = os.path.join(config.structured_build_root,
-                                     'python_packages')
+                                      'python_packages')
 llvm_config.with_environment('PYTHONPATH', [structured_python_path],
                              append_path=True)

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -923,6 +923,27 @@ def testArithPythonValues():
   module.operation.verify()
 
 
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals0
+@run
+def testArbitrarySlicingLiterals0():
+  f32 = F32Type.get()
+  with mlir_mod_ctx() as module:
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[0:7:2]
+
+  module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 7 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([0]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x22x330x4400xf32>
+  # CHECK:       }
+  print(module)
+
+
 # CHECK-LABEL: TEST: testArbitrarySlicingLiterals1
 @run
 def testArbitrarySlicingLiterals1():
@@ -938,7 +959,7 @@ def testArbitrarySlicingLiterals1():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
   # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
   # CHECK:       }
   print(module)
@@ -958,14 +979,12 @@ def testArbitrarySlicingLiterals2():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x4400xf32>
+  # CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+  # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x4400xf32>
   # CHECK:       }
   print(module)
 
@@ -985,19 +1004,16 @@ def testArbitrarySlicingLiterals3():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_11:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_12:.*]] = arith.constant 4400 : index
-  # CHECK:         %[[VAL_13:.*]] = arith.constant 400 : index
-  # CHECK:         %[[VAL_14:.*]] = indexing.arange(start = %[[VAL_11]], stop = %[[VAL_12]], step = %[[VAL_13]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_15:.*]] = tensor.expand_shape %[[VAL_14]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_16:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]], %[[VAL_15]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x3xindex>
-  # CHECK:         %[[VAL_17:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_16]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<?x7xf32>
+  # CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_9:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_10:.*]] = arith.constant 4400 : index
+  # CHECK:         %[[VAL_11:.*]] = arith.constant 400 : index
+  # CHECK:         %[[VAL_12:.*]] = indexing.arange(start = %[[VAL_9]], stop = %[[VAL_10]], step = %[[VAL_11]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_13:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]], %[[VAL_12]]) : (tensor<?xindex>, tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x?x3xindex>
+  # CHECK:         %[[VAL_14:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_13]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x?x3xindex>) -> tensor<?x?x?x7xf32>
   # CHECK:       }
   print(module)
 
@@ -1017,14 +1033,12 @@ def testArbitrarySlicingLiterals4():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 200 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 5 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_6:.*]] = arith.constant 1000 : index
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 2000 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 50 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x22xf32>
+  # CHECK:         %[[VAL_5:.*]] = arith.constant 1000 : index
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 2000 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 50 : index
+  # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+  # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x22xf32>
   # CHECK:       }
   print(module)
 
@@ -1056,10 +1070,10 @@ def testArbitrarySlicingDyn():
   # CHECK:         func.func @test_dyn_indices() -> (tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>) {
   # CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
   # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
-  # CHECK:           %[[VAL_2:.*]] = tensor.expand_shape %[[VAL_1]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_2:.*]] = indexing.meshgrid(%[[VAL_1]]) : (tensor<?xindex>) -> tensor<?x1xindex>
   # CHECK:           %[[VAL_3:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_2]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
   # CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
-  # CHECK:           %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
   # CHECK:           %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
   # CHECK:           return %[[VAL_3]], %[[VAL_6]] : tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>
   # CHECK:         }
@@ -1263,96 +1277,137 @@ def testWholeSliceScatter():
 def testStaticSliceScatter():
   f32 = F32Type.get()
   with mlir_mod_ctx() as module:
-    ten = Tensor.empty((7, 22, 330, 4400), f32)
 
-    w = ten[:, 0:22:2]
-    ten[:, 0:22:2] = w
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter1():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, 0:22:2]
+      ten[:, 0:22:2] = w
 
-    w = ten[:, 0:22:2, 0:330:30]
-    ten[:, 0:22:2, 0:330:30] = w
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter1() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+    # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter1.func_op)
 
-    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
-    ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter2():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, 0:22:2, 0:330:30]
+      ten[:, 0:22:2, 0:330:30] = w
 
-    w = ten[:, :, 100:200:5, 1000:2000:50]
-    ten[:, :, 100:200:5, 1000:2000:50] = w
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter2() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = arith.constant 330 : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 30 : index
+    # CHECK:         %[[VAL_7:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_5]], step = %[[VAL_6]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_8:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_7]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+    # CHECK:         %[[VAL_9:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_8]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x4400xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter2.func_op)
+
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter3():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
+      ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
+
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter3() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = arith.constant 330 : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 30 : index
+    # CHECK:         %[[VAL_7:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_5]], step = %[[VAL_6]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_8:.*]] = arith.constant 4400 : index
+    # CHECK:         %[[VAL_9:.*]] = arith.constant 400 : index
+    # CHECK:         %[[VAL_10:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_8]], step = %[[VAL_9]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_11:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_7]], %[[VAL_10]]) : (tensor<?xindex>, tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x?x3xindex>
+    # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x?x3xindex>) -> tensor<?x?x?x7xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter3.func_op)
+
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter4():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, :, 100:200:5, 1000:2000:50]
+      ten[:, :, 100:200:5, 1000:2000:50] = w
+
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter4() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 200 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 5 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = arith.constant 1000 : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 2000 : index
+    # CHECK:         %[[VAL_7:.*]] = arith.constant 50 : index
+    # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+    # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x22xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter4.func_op)
 
   module.operation.verify()
-
-  pm = PassManager.parse('builtin.module(cse)')
-  pm.run(module.operation)
-  # CHECK-LABEL: module {
-  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_1:.*]] = arith.constant dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20]]> : tensor<11x1xindex>
-  # CHECK:         %[[VAL_2:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_1]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<11x1xindex>) -> tensor<11x7x330x4400xf32>
-  # CHECK:         %[[VAL_3:.*]] = indexing.scatter %[[VAL_2]] into %[[VAL_0]]{{\[}}%[[VAL_1]]] scatter_dims([1]) unique : (tensor<11x7x330x4400xf32>, tensor<7x22x330x4400xf32>, tensor<11x1xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_4:.*]] = arith.constant dense<{{\[\[}}0, 0], [2, 30], [4, 60], [6, 90], [8, 120], [10, 150], [12, 180], [14, 210], [16, 240], [18, 270], [20, 300]]> : tensor<11x2xindex>
-  # CHECK:         %[[VAL_5:.*]] = indexing.gather %[[VAL_3]]{{\[}}%[[VAL_4]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<11x2xindex>) -> tensor<11x7x4400xf32>
-  # CHECK:         %[[VAL_6:.*]] = indexing.scatter %[[VAL_5]] into %[[VAL_3]]{{\[}}%[[VAL_4]]] scatter_dims([1, 2]) unique : (tensor<11x7x4400xf32>, tensor<7x22x330x4400xf32>, tensor<11x2xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_7:.*]] = arith.constant dense<{{\[\[}}0, 0, 0], [2, 30, 400], [4, 60, 800], [6, 90, 1200], [8, 120, 1600], [10, 150, 2000], [12, 180, 2400], [14, 210, 2800], [16, 240, 3200], [18, 270, 3600], [20, 300, 4000]]> : tensor<11x3xindex>
-  # CHECK:         %[[VAL_8:.*]] = indexing.gather %[[VAL_6]]{{\[}}%[[VAL_7]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<11x3xindex>) -> tensor<11x7xf32>
-  # CHECK:         %[[VAL_9:.*]] = indexing.scatter %[[VAL_8]] into %[[VAL_6]]{{\[}}%[[VAL_7]]] scatter_dims([1, 2, 3]) unique : (tensor<11x7xf32>, tensor<7x22x330x4400xf32>, tensor<11x3xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_10:.*]] = arith.constant dense<{{\[\[}}100, 1000], [105, 1050], [110, 1100], [115, 1150], [120, 1200], [125, 1250], [130, 1300], [135, 1350], [140, 1400], [145, 1450], [150, 1500], [155, 1550], [160, 1600], [165, 1650], [170, 1700], [175, 1750], [180, 1800], [185, 1850], [190, 1900], [195, 1950]]> : tensor<20x2xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.gather %[[VAL_9]]{{\[}}%[[VAL_10]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<20x2xindex>) -> tensor<20x7x22xf32>
-  # CHECK:       }
-  print(module)
 
 
 # CHECK-LABEL: TEST: testDynSliceScatter
 @run
 def testDynSliceScatter():
   f32 = F32Type.get()
+  index = IndexType.get()
   with mlir_mod_ctx() as module:
-    ten = Tensor.empty((7, 22, 330, 4400), f32)
 
-    w = ten[:, 0:22:2]
-    ten[:, 0:22:2] = w
+    @func.FuncOp.from_py_func(*[])
+    def dyn_slice_scatter1():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      one = Scalar(1, dtype=index, fold=False)
+      zero = 0 * one
+      two = 2 * one
+      twenty_two = 22 * one
+      w = ten[:, zero:twenty_two:two]
+      ten[:, zero:twenty_two:two] = w
 
-    w = ten[:, 0:22:2, 0:330:30]
-    ten[:, 0:22:2, 0:330:30] = w
-
-    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
-    ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
-
-    w = ten[:, :, 100:200:5, 1000:2000:50]
-    ten[:, :, 100:200:5, 1000:2000:50] = w
-
-  module.operation.verify()
-
-  pm = PassManager.parse('builtin.module(cse)')
-  pm.run(module.operation)
-  # CHECK-LABEL: module {
-  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
-  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
-  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_5:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_4]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
-  # CHECK:         %[[VAL_6:.*]] = indexing.scatter %[[VAL_5]] into %[[VAL_0]]{{\[}}%[[VAL_4]]] scatter_dims([1]) unique : (tensor<?x7x330x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_7]], step = %[[VAL_8]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_10:.*]] = indexing.concatenate(%[[VAL_4]], %[[VAL_9]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.gather %[[VAL_6]]{{\[}}%[[VAL_10]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x4400xf32>
-  # CHECK:         %[[VAL_12:.*]] = indexing.scatter %[[VAL_11]] into %[[VAL_6]]{{\[}}%[[VAL_10]]] scatter_dims([1, 2]) unique : (tensor<?x7x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_13:.*]] = arith.constant 4400 : index
-  # CHECK:         %[[VAL_14:.*]] = arith.constant 400 : index
-  # CHECK:         %[[VAL_15:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_13]], step = %[[VAL_14]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_16:.*]] = indexing.concatenate(%[[VAL_4]], %[[VAL_9]], %[[VAL_15]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x3xindex>
-  # CHECK:         %[[VAL_17:.*]] = indexing.gather %[[VAL_12]]{{\[}}%[[VAL_16]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<?x7xf32>
-  # CHECK:         %[[VAL_18:.*]] = indexing.scatter %[[VAL_17]] into %[[VAL_12]]{{\[}}%[[VAL_16]]] scatter_dims([1, 2, 3]) unique : (tensor<?x7xf32>, tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_19:.*]] = arith.constant 100 : index
-  # CHECK:         %[[VAL_20:.*]] = arith.constant 200 : index
-  # CHECK:         %[[VAL_21:.*]] = arith.constant 5 : index
-  # CHECK:         %[[VAL_22:.*]] = indexing.arange(start = %[[VAL_19]], stop = %[[VAL_20]], step = %[[VAL_21]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_23:.*]] = arith.constant 1000 : index
-  # CHECK:         %[[VAL_24:.*]] = arith.constant 2000 : index
-  # CHECK:         %[[VAL_25:.*]] = arith.constant 50 : index
-  # CHECK:         %[[VAL_26:.*]] = indexing.arange(start = %[[VAL_23]], stop = %[[VAL_24]], step = %[[VAL_25]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_27:.*]] = indexing.concatenate(%[[VAL_22]], %[[VAL_26]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_28:.*]] = indexing.gather %[[VAL_18]]{{\[}}%[[VAL_27]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x22xf32>
-  # CHECK:       }
-  print(module)
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @dyn_slice_scatter1() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 1 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.muli %[[VAL_1]], %[[VAL_2]] : index
+    # CHECK:         %[[VAL_4:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_5:.*]] = arith.muli %[[VAL_1]], %[[VAL_4]] : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_7:.*]] = arith.muli %[[VAL_1]], %[[VAL_6]] : index
+    # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_3]], stop = %[[VAL_7]], step = %[[VAL_5]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_8]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+    # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(dyn_slice_scatter1.func_op)
 
 
 # CHECK-LABEL: TEST: testForLoopSugarNoIterArgs

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -677,8 +677,8 @@ def testARangeOpBasics():
     # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
     print(ara.owner)
 
-    ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, fold=True))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2, fold = true) : tensor<50x1xindex>
+    ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, nofold=True))
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) nofold : tensor<50x1xindex>
     print(ara.owner)
 
   module.operation.verify()
@@ -696,7 +696,7 @@ def testARangeFun():
     # CHECK: Value(%[[C2:.*]] = arith.constant 2 : index)
     print(ara.owner.operands[2])
 
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) nofold : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(0, 100, fold=False)
@@ -704,13 +704,13 @@ def testARangeFun():
     print(ara.owner.operands[0])
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[1])
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(100, fold=False)
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[0])
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(0, 100, 2, fold=True)
@@ -1042,7 +1042,7 @@ def testArbitrarySlicingDyn():
       print(step.owner)
 
       w = ten[:, :, start:stop:step]
-      # CHECK: %[[VAL_8:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+      # CHECK: %[[VAL_8:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
       print(w.owner.operands[1].owner)
       # CHECK: %[[VAL_9:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_8]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
       print(w.owner)
@@ -1050,7 +1050,7 @@ def testArbitrarySlicingDyn():
       w = ten[:, :, start:stop:5]
       # CHECK: %[[VAL_10:.*]] = "arith.constant"() <{value = 5 : index}> : () -> index
       print(w.owner.operands[1].owner.operands[2])
-      # CHECK: %[[VAL_11:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_10]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+      # CHECK: %[[VAL_11:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_10]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
       print(w.owner.operands[1].owner)
       # CHECK: %[[VAL_12:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_11]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
       print(w.owner)
@@ -1064,7 +1064,7 @@ def testArbitrarySlicingDyn():
   # CHECK-LABEL: module {
   # CHECK:         func.func @test_dyn_indices() -> tensor<?x7x22x4400xf32> {
   # CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) : tensor<20x1xindex>
+  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<20x1xindex>
   # CHECK:           %[[VAL_2:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_1]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<20x1xindex>) -> tensor<?x7x22x4400xf32>
   # CHECK:           return %[[VAL_2]] : tensor<?x7x22x4400xf32>
   # CHECK:         }

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -646,39 +646,39 @@ def testARangeOpBasics():
     print(step.get_name())
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=stop, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=100, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=stop, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=100, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, nofold=True))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) nofold : tensor<50x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) nofold : tensor<50xindex>
     print(ara.owner)
 
   module.operation.verify()
@@ -696,7 +696,7 @@ def testARangeFun():
     # CHECK: Value(%[[C2:.*]] = arith.constant 2 : index)
     print(ara.owner.operands[2])
 
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) nofold : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) nofold : tensor<?xindex>
     print(ara.owner)
 
     ara = arange(0, 100, fold=False)
@@ -704,25 +704,25 @@ def testARangeFun():
     print(ara.owner.operands[0])
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[1])
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) nofold : tensor<?xindex>
     print(ara.owner)
 
     ara = arange(100, fold=False)
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[0])
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) nofold : tensor<?xindex>
     print(ara.owner)
 
     ara = arange(0, 100, 2, fold=True)
-    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [2], [4], [6], [8], {{.*}}, [98]]> : tensor<50x1xindex>
+    # CHECK: %{{.*}} = arith.constant dense<[0, 2, 4, 6, 8, {{.*}}, 98]> : tensor<50xindex>
     print(ara.owner)
 
     ara = arange(0, 100, fold=True)
-    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
+    # CHECK: %{{.*}} = arith.constant dense<[0, 1, 2, 3, 4, {{.*}}, 99]> : tensor<100xindex>
     print(ara.owner)
 
     ara = arange(100, fold=True)
-    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
+    # CHECK: %{{.*}} = arith.constant dense<[0, 1, 2, 3, 4, {{.*}}, 99]> : tensor<100xindex>
     print(ara.owner)
 
   module.operation.verify()
@@ -754,13 +754,13 @@ def testARangeOpSemantics():
       step = np.random.randint(1, 100)
 
       ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=step))
-      r = np.arange(start, stop, step)[:, np.newaxis]
+      r = np.arange(start, stop, step)
 
       if len(r) != (stop - start) // step + 1:
         assert (stop - start) % step == 0
         assert len(r) == (stop - start) // step
 
-      assert r.shape == ara.shape
+      assert r.shape == ara.shape, f"{r.shape=} {ara.shape=}"
 
 
 # CHECK-LABEL: TEST: testNoneIndices
@@ -885,124 +885,148 @@ def testArithPythonValues():
     # CHECK: %[[VAL_15:.*]] = arith.mulf %[[VAL_13]], %[[VAL_14]] : tensor<2x2xf64>
     print(two_times_ten.owner)
 
-    two_times_ten = ten * 2.0
-    # CHECK: %[[VAL_16:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    three_times_ten = ten * 3.0
+    # CHECK: %[[VAL_16:.*]] = arith.constant dense<3.000000e+00> : tensor<2x2xf64>
+    print(three_times_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_17:.*]] = arith.mulf %[[VAL_13]], %[[VAL_16]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(three_times_ten.owner)
 
-    two_times_ten = 2.0 * ten
-    # CHECK: %[[VAL_18:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    four_times_ten = 4.0 * ten
+    # CHECK: %[[VAL_18:.*]] = arith.constant dense<4.000000e+00> : tensor<2x2xf64>
+    print(four_times_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_19:.*]] = arith.mulf %[[VAL_13]], %[[VAL_18]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(four_times_ten.owner)
 
-    two_times_ten = ten + 2.0
-    # CHECK: %[[VAL_20:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    five_plus_ten = ten + 5.0
+    # CHECK: %[[VAL_20:.*]] = arith.constant dense<5.000000e+00> : tensor<2x2xf64>
+    print(five_plus_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_21:.*]] = arith.addf %[[VAL_13]], %[[VAL_20]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(five_plus_ten.owner)
 
-    two_times_ten = 2.0 + ten
-    # CHECK: %[[VAL_22:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    two_rplus_ten = 2.0 + ten
+    # CHECK: %[[VAL_22:.*]] = arith.constant dense<2.000000e+00> : tensor<2x2xf64>
+    print(two_rplus_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_23:.*]] = arith.addf %[[VAL_13]], %[[VAL_22]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(two_rplus_ten.owner)
 
-    two_times_ten = ten - 2.0
-    # CHECK: %[[VAL_24:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    two_sub_ten = ten - 2.0
+    # CHECK: %[[VAL_24:.*]] = arith.constant dense<2.000000e+00> : tensor<2x2xf64>
+    print(two_sub_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_25:.*]] = arith.subf %[[VAL_13]], %[[VAL_24]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(two_sub_ten.owner)
 
-    two_times_ten = 2.0 - ten
-    # CHECK: %[[VAL_26:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    two_rsub_ten = 2.0 - ten
+    # CHECK: %[[VAL_26:.*]] = arith.constant dense<2.000000e+00> : tensor<2x2xf64>
+    print(two_rsub_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_27:.*]] = arith.subf %[[VAL_13]], %[[VAL_26]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(two_rsub_ten.owner)
 
   module.operation.verify()
 
 
-# CHECK-LABEL: TEST: testArbitrarySlicingLiterals
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals1
 @run
-def testArbitrarySlicingLiterals():
-  index = IndexType.get()
+def testArbitrarySlicingLiterals1():
   f32 = F32Type.get()
   with mlir_mod_ctx() as module:
     ten = Tensor.empty((7, 22, 330, 4400), f32)
-    # CHECK: Tensor(%[[TEN:.*]], tensor<7x22x330x4400xf32>)
-    print(ten)
-
-    w = ten[:, arange(start=0, stop=22, step=2, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20]]> : tensor<11x1xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<11x1xindex>) -> tensor<11x7x330x4400xf32>
-    print(w.owner)
-
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[0, 0], [2, 30], [4, 60], [6, 90], [8, 120], [10, 150], [12, 180], [14, 210], [16, 240], [18, 270], [20, 300]]> : tensor<11x2xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<11x2xindex>) -> tensor<11x7x4400xf32>
-    print(w.owner)
-
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True),
-            arange(start=0, stop=4400, step=400, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[0, 0, 0], [2, 30, 400], [4, 60, 800], [6, 90, 1200], [8, 120, 1600], [10, 150, 2000], [12, 180, 2400], [14, 210, 2800], [16, 240, 3200], [18, 270, 3600], [20, 300, 4000]]> : tensor<11x3xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<11x3xindex>) -> tensor<11x7xf32>
-    print(w.owner)
-
-    w = ten[:, :,
-            arange(start=100, stop=200, step=5, fold=True),
-            arange(start=1000, stop=2000, step=50, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[100, 1000], [105, 1050], [110, 1100], [115, 1150], [120, 1200], [125, 1250], [130, 1300], [135, 1350], [140, 1400], [145, 1450], [150, 1500], [155, 1550], [160, 1600], [165, 1650], [170, 1700], [175, 1750], [180, 1800], [185, 1850], [190, 1900], [195, 1950]]> : tensor<20x2xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<20x2xindex>) -> tensor<20x7x22xf32>
-    print(w.owner)
+    w = ten[:, 0:22:2]
 
   module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
+  # CHECK:       }
+  print(module)
 
 
-# CHECK-LABEL: TEST: testArithFolding
 @run
-def testArithFolding():
-  index = IndexType.get()
+def testArbitrarySlicingLiterals2():
   f32 = F32Type.get()
   with mlir_mod_ctx() as module:
-
-    @func.FuncOp.from_py_func(*[])
-    def test_fold():
-      ten = Tensor.empty((7, 22, 330, 4400), f32)
-
-      idx1 = arange(100, 200, 5, fold=True)
-      idx2 = arange(1000, 2000, 50, fold=True)
-      w = ten[:, :, idx1, idx2]
-      idx_tensor = Tensor(w.owner.operands[1], fold=False)
-      pid = 42
-      pid_tensor = Tensor(pid * np.ones(idx_tensor.shape, dtype=np.intp),
-                          dtype=index,
-                          fold=False)
-      new_idx_tensor = pid_tensor + idx_tensor
-      w = ten[:, :, new_idx_tensor]
-      return w
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[:, 0:22:2, 0:330:30]
 
   module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
+  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x4400xf32>
+  # CHECK:       }
+  print(module)
 
-  pm = PassManager.parse('builtin.module(canonicalize)')
-  pm.run(module.operation)
-  # CHECK: module {
-  # CHECK:   func.func @test_fold() -> tensor<20x7x22xf32> {
-  # CHECK:     %[[ARA:.*]] = arith.constant dense<{{\[}}[142, 1042], [147, 1092], [152, 1142], [157, 1192], [162, 1242], [167, 1292], [172, 1342], [177, 1392], [182, 1442], [187, 1492], [192, 1542], [197, 1592], [202, 1642], [207, 1692], [212, 1742], [217, 1792], [222, 1842], [227, 1892], [232, 1942], [237, 1992]]> : tensor<20x2xindex>
-  # CHECK:     %[[TEN:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:     %[[GATHERED:.*]] = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([2, 3]) : (tensor<7x22x330x4400xf32>, tensor<20x2xindex>) -> tensor<20x7x22xf32>
-  # CHECK:     return %[[GATHERED]] : tensor<20x7x22xf32>
-  # CHECK:   }
-  # CHECK: }
+
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals3
+@run
+def testArbitrarySlicingLiterals3():
+  f32 = F32Type.get()
+  with mlir_mod_ctx() as module:
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
+
+  module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_11:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_12:.*]] = arith.constant 4400 : index
+  # CHECK:         %[[VAL_13:.*]] = arith.constant 400 : index
+  # CHECK:         %[[VAL_14:.*]] = indexing.arange(start = %[[VAL_11]], stop = %[[VAL_12]], step = %[[VAL_13]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_15:.*]] = tensor.expand_shape %[[VAL_14]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_16:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]], %[[VAL_15]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x3xindex>
+  # CHECK:         %[[VAL_17:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_16]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<?x7xf32>
+  # CHECK:       }
+  print(module)
+
+
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals4
+@run
+def testArbitrarySlicingLiterals4():
+  f32 = F32Type.get()
+  with mlir_mod_ctx() as module:
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[:, :, 100:200:5, 1000:2000:50]
+
+  module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 200 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 5 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 1000 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 2000 : index
+  # CHECK:         %[[VAL_8:.*]] = arith.constant 50 : index
+  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
+  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x22xf32>
+  # CHECK:       }
   print(module)
 
 
@@ -1016,57 +1040,29 @@ def testArbitrarySlicingDyn():
     @func.FuncOp.from_py_func(*[])
     def test_dyn_indices():
       ten = Tensor.empty((7, 22, 330, 4400), f32)
-      # CHECK: %[[VAL_0:.*]] = "tensor.empty"() : () -> tensor<7x22x330x4400xf32>
-      print(ten.owner)
-
       one = Scalar(1, dtype=index, fold=False)
-      # CHECK: %[[VAL_1:.*]] = "arith.constant"() <{value = 1 : index}> : () -> index
-      print(one.owner)
-
       start = 100 * one
-      # CHECK: %[[VAL_2:.*]] = "arith.constant"() <{value = 100 : index}> : () -> index
-      print(start.owner.operands[1].owner)
-      # CHECK: %[[VAL_3:.*]] = "arith.muli"(%[[VAL_1]], %[[VAL_2]]) : (index, index) -> index
-      print(start.owner)
-
       stop = 200 * one
-      # CHECK: %[[VAL_4:.*]] = "arith.constant"() <{value = 200 : index}> : () -> index
-      print(stop.owner.operands[1].owner)
-      # CHECK: %[[VAL_5:.*]] = "arith.muli"(%[[VAL_1]], %[[VAL_4]]) : (index, index) -> index
-      print(stop.owner)
-
       step = 5 * one
-      # CHECK: %[[VAL_6:.*]] = "arith.constant"() <{value = 5 : index}> : () -> index
-      print(step.owner.operands[1].owner)
-      # CHECK: %[[VAL_7:.*]] = "arith.muli"(%[[VAL_1]], %[[VAL_6]]) : (index, index) -> index
-      print(step.owner)
+      w1 = ten[:, :, start:stop:step]
+      w2 = ten[:, :, start:stop:5]
 
-      w = ten[:, :, start:stop:step]
-      # CHECK: %[[VAL_8:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-      print(w.owner.operands[1].owner)
-      # CHECK: %[[VAL_9:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_8]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
-      print(w.owner)
-
-      w = ten[:, :, start:stop:5]
-      # CHECK: %[[VAL_10:.*]] = "arith.constant"() <{value = 5 : index}> : () -> index
-      print(w.owner.operands[1].owner.operands[2])
-      # CHECK: %[[VAL_11:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_10]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-      print(w.owner.operands[1].owner)
-      # CHECK: %[[VAL_12:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_11]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
-      print(w.owner)
-
-      return w
+      return w1, w2
 
   module.operation.verify()
 
   pm = PassManager.parse('builtin.module(canonicalize)')
   pm.run(module.operation)
   # CHECK-LABEL: module {
-  # CHECK:         func.func @test_dyn_indices() -> tensor<?x7x22x4400xf32> {
+  # CHECK:         func.func @test_dyn_indices() -> (tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>) {
   # CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<20x1xindex>
-  # CHECK:           %[[VAL_2:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_1]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<20x1xindex>) -> tensor<?x7x22x4400xf32>
-  # CHECK:           return %[[VAL_2]] : tensor<?x7x22x4400xf32>
+  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
+  # CHECK:           %[[VAL_2:.*]] = tensor.expand_shape %[[VAL_1]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_3:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_2]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
+  # CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
+  # CHECK:           %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
+  # CHECK:           return %[[VAL_3]], %[[VAL_6]] : tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>
   # CHECK:         }
   # CHECK:       }
   print(module)
@@ -1202,31 +1198,17 @@ def testStaticSliceScatter():
   with mlir_mod_ctx() as module:
     ten = Tensor.empty((7, 22, 330, 4400), f32)
 
-    w = ten[:, arange(start=0, stop=22, step=2, fold=True)]
-    ten[:, arange(start=0, stop=22, step=2, fold=True)] = w
+    w = ten[:, 0:22:2]
+    ten[:, 0:22:2] = w
 
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True)]
-    ten[:,
-        arange(start=0, stop=22, step=2, fold=True),
-        arange(start=0, stop=330, step=30, fold=True)] = w
+    w = ten[:, 0:22:2, 0:330:30]
+    ten[:, 0:22:2, 0:330:30] = w
 
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True),
-            arange(start=0, stop=4400, step=400, fold=True)]
-    ten[:,
-        arange(start=0, stop=22, step=2, fold=True),
-        arange(start=0, stop=330, step=30, fold=True),
-        arange(start=0, stop=4400, step=400, fold=True)] = w
+    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
+    ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
 
-    w = ten[:, :,
-            arange(start=100, stop=200, step=5, fold=True),
-            arange(start=1000, stop=2000, step=50, fold=True)]
-    ten[:, :,
-        arange(start=100, stop=200, step=5, fold=True),
-        arange(start=1000, stop=2000, step=50, fold=True)] = w
+    w = ten[:, :, 100:200:5, 1000:2000:50]
+    ten[:, :, 100:200:5, 1000:2000:50] = w
 
   module.operation.verify()
 

--- a/tools/structured-opt/structured-opt.cpp
+++ b/tools/structured-opt/structured-opt.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Tools/mlir-opt/MlirOptMain.h"
 #include "structured/Conversion/Passes.h"
 #include "structured/Dialect/Indexing/IR/Indexing.h"
+#include "structured/Dialect/Indexing/Transforms/Passes.h"
 #include "structured/Dialect/Iterators/IR/Iterators.h"
 #include "structured/Dialect/Iterators/Transforms/Passes.h"
 #include "structured/Dialect/Tabular/IR/Tabular.h"
@@ -69,6 +70,7 @@ int main(int argc, char **argv) {
   registerAllPasses();
   registerStructuredConversionPasses();
   registerIteratorsPasses();
+  registerIndexingPasses();
   registerTuplePasses();
   registerTritonPasses();
   registerTritonGPUPasses();


### PR DESCRIPTION
Depends on https://github.com/iree-org/iree-llvm-sandbox/pull/744

This PR adds the infra necessary for generating target code (through LLVM JIT/ExecutionEngine) and passing buffers between; e.g. this now passes:

```python
  @func.FuncOp.from_py_func(A.type, B.type, C.type)
  def test_matmul_no_fill(A, B, C):
    A = Tensor(A)
    B = Tensor(B)
    C = Tensor(C)
    # tile size
    ts = 5
    for i, r1 in scf_range(0, 10, ts, iter_args=[C]):
      for j, r2 in scf_range(0, 30, ts, iter_args=[C]):
        for k, r3 in scf_range(0, 20, ts, iter_args=[C]):
          a = A[i:i + ts, k:k + ts]
          b = B[k:k + ts, j:j + ts]
          C[i:i + ts, j:j + ts] += a @ b

          scf_yield(C)
        scf_yield(r3)
      scf_yield(r2)

    return r1

  backend = LLVMJITBackend()
  module = backend.compile(
      module,
      kernel_name="test_matmul_no_fill",
      pipeline=
      "builtin.module(...)",
  )

  A = np.random.randint(low=0, high=10, size=(M, K)).astype(np.float32)
  B = np.random.randint(low=0, high=10, size=(K, N)).astype(np.float32)
  C = np.zeros((M, N)).astype(np.float32)
  ...
  invoker = backend.load(module, consume_return_func=callback)
  invoker.test_matmul_no_fill(A, B, C)
  assert result is not None and np.allclose(A @ B, result)
```

cc @kylechard @ianfoster