### PR TITLE
Replace all occurrences of llvm::Optional with std::optional. (NFC)

### DIFF
--- a/include/structured/Conversion/TabularToLLVM/TabularToLLVM.h
+++ b/include/structured/Conversion/TabularToLLVM/TabularToLLVM.h
@@ -28,7 +28,7 @@ public:
 
   /// Maps a TabularViewType to an LLVMStruct of pointers, i.e., to a "struct of
   /// arrays".
-  static Optional<Type> convertTabularViewType(Type type);
+  static std::optional<Type> convertTabularViewType(Type type);
 
 private:
   LLVMTypeConverter llvmTypeConverter;

--- a/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
+++ b/lib/Conversion/IteratorsToLLVM/IteratorsToLLVM.cpp
@@ -2097,7 +2097,7 @@ void ConvertIteratorsToLLVMPass::runOnOperation() {
   auto addUnrealizedCast = [](OpBuilder &builder, Type type, ValueRange inputs,
                               Location loc) {
     auto cast = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
-    return Optional<Value>(cast.getResult(0));
+    return std::optional<Value>(cast.getResult(0));
   };
   typeConverter.addSourceMaterialization(addUnrealizedCast);
   typeConverter.addTargetMaterialization(addUnrealizedCast);

--- a/lib/Conversion/StatesToLLVM/StatesToLLVM.cpp
+++ b/lib/Conversion/StatesToLLVM/StatesToLLVM.cpp
@@ -43,7 +43,7 @@ public:
 
 private:
   /// Maps an iterator state type to a corresponding LLVMStructType.
-  Optional<Type> convertIteratorStateType(Type type) {
+  std::optional<Type> convertIteratorStateType(Type type) {
     if (auto stateType = type.dyn_cast<StateType>()) {
       llvm::SmallVector<Type> fieldTypes(stateType.getFieldTypes().begin(),
                                          stateType.getFieldTypes().end());
@@ -168,7 +168,7 @@ void ConvertStatesToLLVMPass::runOnOperation() {
   auto addUnrealizedCast = [](OpBuilder &builder, Type type, ValueRange inputs,
                               Location loc) {
     auto cast = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
-    return Optional<Value>(cast.getResult(0));
+    return std::optional<Value>(cast.getResult(0));
   };
   typeConverter.addSourceMaterialization(addUnrealizedCast);
   typeConverter.addTargetMaterialization(addUnrealizedCast);

--- a/lib/Conversion/TabularToLLVM/TabularToLLVM.cpp
+++ b/lib/Conversion/TabularToLLVM/TabularToLLVM.cpp
@@ -41,14 +41,14 @@ TabularTypeConverter::TabularTypeConverter(LLVMTypeConverter &llvmTypeConverter)
   addConversion(convertTabularViewType);
 
   // Convert MemRefType using LLVMTypeConverter.
-  addConversion([&](Type type) -> llvm::Optional<Type> {
+  addConversion([&](Type type) -> std::optional<Type> {
     if (type.isa<MemRefType>())
       return llvmTypeConverter.convertType(type);
     return std::nullopt;
   });
 }
 
-Optional<Type> TabularTypeConverter::convertTabularViewType(Type type) {
+std::optional<Type> TabularTypeConverter::convertTabularViewType(Type type) {
   if (auto viewType = type.dyn_cast<TabularViewType>()) {
     MLIRContext *context = type.getContext();
     Type dynamicSize = IntegerType::get(context, /*width=*/64);
@@ -165,7 +165,7 @@ void ConvertTabularToLLVMPass::runOnOperation() {
   auto addUnrealizedCast = [](OpBuilder &builder, Type type, ValueRange inputs,
                               Location loc) {
     auto cast = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
-    return Optional<Value>(cast.getResult(0));
+    return std::optional<Value>(cast.getResult(0));
   };
   typeConverter.addSourceMaterialization(addUnrealizedCast);
   typeConverter.addTargetMaterialization(addUnrealizedCast);

--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -225,7 +225,7 @@ void ConvertTritonToLLVMPass::runOnOperation() {
   auto addUnrealizedCast = [](OpBuilder &builder, Type type, ValueRange inputs,
                               Location loc) {
     auto cast = builder.create<UnrealizedConversionCastOp>(loc, type, inputs);
-    return Optional<Value>(cast.getResult(0));
+    return std::optional<Value>(cast.getResult(0));
   };
   typeConverter.addSourceMaterialization(addUnrealizedCast);
   typeConverter.addTargetMaterialization(addUnrealizedCast);

--- a/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
+++ b/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
@@ -39,8 +39,8 @@ public:
 
 private:
   /// Maps a StateType to the types of its fields.
-  Optional<LogicalResult> decomposeStateType(StateType type,
-                                             SmallVectorImpl<Type> &results) {
+  std::optional<LogicalResult>
+  decomposeStateType(StateType type, SmallVectorImpl<Type> &results) {
     for (Type fieldType : type.getFieldTypes()) {
       if (failed(convertTypes(fieldType, results)))
         return failure();


### PR DESCRIPTION
The former has been a typedef of the latter for a while but upstream LLVM removes that typedef. We'll have to do this change at the latest in order to update our LLVM dependency; this PR anticipates the change.