### PR TITLE
[Indexing] Fix `arange` again

### DIFF
--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -142,4 +142,20 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
   let hasFolder = 1;
 }
 
+def Indexing_MeshGridOp : Indexing_Op<"meshgrid",
+    [Pure, SameOperandsAndResultElementType,
+     DeclareOpInterfaceMethods<InferTypeOpInterface>]> {
+  let summary = "Return coordinate matrices from coordinate vectors.";
+  let arguments = (ins
+    Variadic<1DTensorOf<[Index]>>:$inputs
+  );
+
+  let results = (outs AnyRankedTensor);
+
+  let assemblyFormat = [{
+     `(` $inputs `)` attr-dict `:` functional-type(operands, results)
+  }];
+  let hasVerifier = 1;
+}
+
 #endif // STRUCTURED_DIALECT_INDEXING_IR_INDEXINGOPS

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -115,7 +115,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
                        OptionalAttr<IndexAttr>:$startAttr,
                        OptionalAttr<IndexAttr>:$stopAttr,
                        OptionalAttr<IndexAttr>:$stepAttr,
-                       DefaultValuedAttr<BoolAttr, "false">:$foldAttr);
+                       UnitAttr:$nofold);
   let results = (outs 2DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
@@ -126,8 +126,8 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
         `stop` `=` ($stop^) : ($stopAttr)?
         `,`
         `step` `=` ($step^) : ($stepAttr)?
-        (`,` `fold` `=` $foldAttr^)?
-    `)` attr-dict `:` type($result)
+
+    `)` (`nofold` $nofold^)? attr-dict `:` type($result)
   }];
 
   let extraClassDeclaration = [{

--- a/include/structured/Dialect/Indexing/IR/IndexingOps.td
+++ b/include/structured/Dialect/Indexing/IR/IndexingOps.td
@@ -116,7 +116,7 @@ def Indexing_ARangeOp : Indexing_Op<"arange", [
                        OptionalAttr<IndexAttr>:$stopAttr,
                        OptionalAttr<IndexAttr>:$stepAttr,
                        UnitAttr:$nofold);
-  let results = (outs 2DTensorOf<[Index]>:$result);
+  let results = (outs 1DTensorOf<[Index]>:$result);
   // the reason for the extra double backtick in (```start
   // is because otherwise an extraneous space is emitted in the pretty print
   let assemblyFormat = [{

--- a/lib/Dialect/Indexing/IR/Indexing.cpp
+++ b/lib/Dialect/Indexing/IR/Indexing.cpp
@@ -141,7 +141,7 @@ LogicalResult ARangeOp::inferReturnTypes(
     RegionRange regions, SmallVectorImpl<mlir::Type> &inferredReturnTypes) {
   if (!operands.empty()) {
     inferredReturnTypes.assign({RankedTensorType::get(
-        {ShapedType::kDynamic, 1}, IndexType::get(context))});
+        {ShapedType::kDynamic}, IndexType::get(context))});
   } else if (!attributes.empty() &&
              attributes.contains(ARangeOp::getStartAttrAttrName(context)) &&
              attributes.contains(ARangeOp::getStopAttrAttrName(context)) &&
@@ -156,7 +156,7 @@ LogicalResult ARangeOp::inferReturnTypes(
                     .cast<IntegerAttr>()
                     .getInt();
     inferredReturnTypes.assign({RankedTensorType::get(
-        {getARangeLen(start, stop, step), 1}, IndexType::get(context))});
+        {getARangeLen(start, stop, step)}, IndexType::get(context))});
   } else {
     return failure();
   }
@@ -267,7 +267,8 @@ struct ARangeOpPattern : public RewritePattern {
     if (arangeOp.getNofold())
       attributes.push_back(
           {arangeOp.getNofoldAttrName(), arangeOp.getNofoldAttr()});
-    rewriter.replaceOpWithNewOp<ARangeOp>(arangeOp, operands, attributes);
+    rewriter.replaceOpWithNewOp<ARangeOp>(arangeOp, arangeOp->getResultTypes(),
+                                          operands, attributes);
   }
 };
 
@@ -291,7 +292,7 @@ OpFoldResult ARangeOp::fold(FoldAdaptor adaptor) {
   for (int64_t i = start; i < stop; i += step) {
     arange.push_back(i);
   }
-  auto type = RankedTensorType::get({len, 1}, IndexType::get(getContext()));
+  auto type = RankedTensorType::get({len}, IndexType::get(getContext()));
   return DenseElementsAttr::get(type, ArrayRef(arange));
 }
 

--- a/lib/Dialect/Indexing/IR/Indexing.cpp
+++ b/lib/Dialect/Indexing/IR/Indexing.cpp
@@ -264,8 +264,9 @@ struct ARangeOpPattern : public RewritePattern {
 
     auto attr = rewriter.getDenseI32ArrayAttr(segmentSizes);
     attributes.push_back({arangeOp.getOperandSegmentSizesAttrName(), attr});
-    attributes.push_back(
-        {arangeOp.getFoldAttrAttrName(), arangeOp.getFoldAttrAttr()});
+    if (arangeOp.getNofold())
+      attributes.push_back(
+          {arangeOp.getNofoldAttrName(), arangeOp.getNofoldAttr()});
     rewriter.replaceOpWithNewOp<ARangeOp>(arangeOp, operands, attributes);
   }
 };
@@ -279,7 +280,7 @@ void ARangeOp::getCanonicalizationPatterns(RewritePatternSet &results,
 
 OpFoldResult ARangeOp::fold(FoldAdaptor adaptor) {
   if (!adaptor.getStartAttr() || !adaptor.getStopAttr() ||
-      !adaptor.getStepAttr() || !adaptor.getFoldAttr())
+      !adaptor.getStepAttr() || adaptor.getNofold())
     return {};
 
   int64_t start = adaptor.getStartAttr().value().getSExtValue(),

--- a/python/mlir_structured/dialects/_indexing_ops_ext.py
+++ b/python/mlir_structured/dialects/_indexing_ops_ext.py
@@ -21,7 +21,7 @@ class ARangeOp:
                start=None,
                stop=None,
                step=None,
-               fold=None,
+               nofold=None,
                loc=None,
                ip=None):
     operands = []
@@ -79,12 +79,8 @@ class ARangeOp:
                                  not ir.AttrBuilder.contains('IndexAttr')) else
                                 ir.AttrBuilder.get('IndexAttr')(
                                     stepAttr, context=_ods_context))
-    if fold is not None:
-      attributes["foldAttr"] = (fold if
-                                (issubclass(type(fold), ir.Attribute) or
-                                 not ir.AttrBuilder.contains('BoolAttr')) else
-                                ir.AttrBuilder.get('BoolAttr')(
-                                    fold, context=_ods_context))
+    if bool(nofold):
+      attributes["nofold"] = ir.UnitAttr.get(_ods_context)
 
     results = ir.InferTypeOpInterface(ARangeOp).inferReturnTypes(
         operands=operands,

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -710,6 +710,10 @@ def expand_dims(inp, newaxis_dims, reshape=None) -> Tensor:
   raise NotImplementedError(inp, newaxis_dims)
 
 
+def meshgrid(*xi: Tuple[Tensor]) -> Tensor:
+  return Tensor(MeshGridOp(inputs=xi))
+
+
 ########################
 # advanced indexing impl
 ########################

--- a/python/mlir_structured/dialects/indexing.py
+++ b/python/mlir_structured/dialects/indexing.py
@@ -615,9 +615,9 @@ def arange(start: Union[Scalar, int],
                     dtype=IndexType.get(),
                     fold=True)
     else:
-      return Tensor(ARangeOp(start=start, stop=stop, step=1),
+      return Tensor(ARangeOp(start=start, stop=stop, step=1, nofold=True),
                     dtype=IndexType.get(),
-                    fold=stop.fold() and fold)
+                    fold=False)
   else:
     if isinstance(stop, int):
       stop = Scalar(stop, dtype=index)
@@ -630,9 +630,9 @@ def arange(start: Union[Scalar, int],
                       dtype=IndexType.get(),
                       fold=True)
       else:
-        return Tensor(ARangeOp(start=start, stop=stop, step=1),
+        return Tensor(ARangeOp(start=start, stop=stop, step=1, nofold=True),
                       dtype=IndexType.get(),
-                      fold=start.fold() and stop.fold() and fold)
+                      fold=False)
     if isinstance(step, int):
       step = Scalar(step, dtype=index)
     if start.fold() and stop.fold() and step.fold() and fold:
@@ -642,9 +642,9 @@ def arange(start: Union[Scalar, int],
                     dtype=IndexType.get(),
                     fold=True)
     else:
-      return Tensor(ARangeOp(start=start, stop=stop, step=step),
+      return Tensor(ARangeOp(start=start, stop=stop, step=step, nofold=True),
                     dtype=IndexType.get(),
-                    fold=start.fold() and stop.fold() and step.fold() and fold)
+                    fold=False)
 
 
 ########################

--- a/test/Dialect/Indexing/basic.mlir
+++ b/test/Dialect/Indexing/basic.mlir
@@ -9,7 +9,7 @@
 // CHECK:             %[[VAL_5:.*]] = arith.constant 0 : index
 // CHECK:             %[[VAL_6:.*]] = arith.constant 100 : index
 // CHECK:             %[[VAL_7:.*]] = arith.constant 2 : index
-// CHECK:             %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) : tensor<?x1xindex>
+// CHECK:             %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) : tensor<?xindex>
 // CHECK:             return
 // CHECK:           }
 // CHECK:         }
@@ -23,7 +23,7 @@ module {
     %c0_index = arith.constant 0 : index
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
-    %4 = indexing.arange(start = %c0_index, stop = %c100_index, step = %c2_index) : tensor<?x1xindex>
+    %4 = indexing.arange(start = %c0_index, stop = %c100_index, step = %c2_index) : tensor<?xindex>
     return
   }
 }
@@ -34,28 +34,28 @@ module {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
 // CHECK:         }
 
 module {
   %0 = arith.constant 0 : index
   %1 = arith.constant 100 : index
   %2 = arith.constant 2 : index
-  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : index} : (index, index) -> tensor<?x1xindex>
-  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : index} : (index, index) -> tensor<?x1xindex>
-  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : index, stepAttr = 2 : index} : (index) -> tensor<?x1xindex>
-  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+  %3 = "indexing.arange"(%0, %1, %2) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+  %4 = "indexing.arange"(%1, %2) {operand_segment_sizes = array<i32: 0, 1, 1>, startAttr = 0 : index} : (index, index) -> tensor<?xindex>
+  %5 = "indexing.arange"(%0, %2) {operand_segment_sizes = array<i32: 1, 0, 1>, stopAttr = 100 : index} : (index, index) -> tensor<?xindex>
+  %6 = "indexing.arange"(%0, %1) {operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+  %7 = "indexing.arange"(%2) {operand_segment_sizes = array<i32: 0, 0, 1>, startAttr = 0 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+  %8 = "indexing.arange"(%1) {operand_segment_sizes = array<i32: 0, 1, 0>, startAttr = 0 : index, stepAttr = 2 : index} : (index) -> tensor<?xindex>
+  %9 = "indexing.arange"(%0) {operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+  %10 = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50xindex>
 }
 
 // -----
@@ -64,26 +64,26 @@ module {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 0 : index
 // CHECK:           %[[VAL_1:.*]] = arith.constant 100 : index
 // CHECK:           %[[VAL_2:.*]] = arith.constant 2 : index
-// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?x1xindex>
-// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?x1xindex>
-// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+// CHECK:           %[[VAL_3:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_5:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_6:.*]] = indexing.arange(start = %[[VAL_0]], stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_7:.*]] = indexing.arange(start = 0, stop = 100, step = %[[VAL_2]]) : tensor<?xindex>
+// CHECK:           %[[VAL_8:.*]] = indexing.arange(start = 0, stop = %[[VAL_1]], step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_0]], stop = 100, step = 2) : tensor<?xindex>
+// CHECK:           %[[VAL_10:.*]] = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
 // CHECK:         }
 
 module {
   %c0 = arith.constant 0 : index
   %c100 = arith.constant 100 : index
   %c2 = arith.constant 2 : index
-  %0 = indexing.arange(start = %c0, stop = %c100, step = %c2) : tensor<?x1xindex>
-  %1 = indexing.arange(start = 0, stop = %c100, step = %c2) : tensor<?x1xindex>
-  %2 = indexing.arange(start = %c0, stop = 100, step = %c2) : tensor<?x1xindex>
-  %3 = indexing.arange(start = %c0, stop = %c100, step = 2) : tensor<?x1xindex>
-  %4 = indexing.arange(start = 0, stop = 100, step = %c2) : tensor<?x1xindex>
-  %5 = indexing.arange(start = 0, stop = %c100, step = 2) : tensor<?x1xindex>
-  %6 = indexing.arange(start = %c0, stop = 100, step = 2) : tensor<?x1xindex>
-  %7 = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+  %0 = indexing.arange(start = %c0, stop = %c100, step = %c2) : tensor<?xindex>
+  %1 = indexing.arange(start = 0, stop = %c100, step = %c2) : tensor<?xindex>
+  %2 = indexing.arange(start = %c0, stop = 100, step = %c2) : tensor<?xindex>
+  %3 = indexing.arange(start = %c0, stop = %c100, step = 2) : tensor<?xindex>
+  %4 = indexing.arange(start = 0, stop = 100, step = %c2) : tensor<?xindex>
+  %5 = indexing.arange(start = 0, stop = %c100, step = 2) : tensor<?xindex>
+  %6 = indexing.arange(start = %c0, stop = 100, step = 2) : tensor<?xindex>
+  %7 = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
 }

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -5,16 +5,16 @@
 // CHECK:           %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
 // CHECK:           %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
 // CHECK:           %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
-// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:           "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:           "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-// CHECK:           "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
-// CHECK:           "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
-// CHECK:           "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+// CHECK:           "use1"(%[[VAL_3]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+// CHECK:           "use2"(%[[VAL_4]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+// CHECK:           "use3"(%[[VAL_5]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?xindex>
+// CHECK:           "use4"(%[[VAL_6]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?xindex>
+// CHECK:           "use5"(%[[VAL_7]]) : (tensor<?xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
 // CHECK:       }) : () -> ()
@@ -28,20 +28,20 @@ module {
     %c100_index_dyn = "c100_index_dyn"() : () -> (index)
     %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use1"(%10) : (tensor<?x1xindex>) -> ()
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use1"(%10) : (tensor<?xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use2"(%11) : (tensor<?x1xindex>) -> ()
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use2"(%11) : (tensor<?xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use3"(%12) : (tensor<?x1xindex>) -> ()
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use3"(%12) : (tensor<?xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_index_dyn) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
-    "use4"(%13) : (tensor<?x1xindex>) -> ()
+    %13 = "indexing.arange"(%c0_index_dyn) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
+    "use4"(%13) : (tensor<?xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {nofold, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
-    "use5"(%14) : (tensor<?x1xindex>) -> ()
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {nofold, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?xindex>
+    "use5"(%14) : (tensor<?xindex>) -> ()
 
     return
   }
@@ -51,13 +51,14 @@ module {
 
 // CHECK-LABEL: "builtin.module"() ({
 // CHECK:         "func.func"() <{function_type = () -> (), sym_name = "test_fold"}> ({
-// CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
-// CHECK:           "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
-// CHECK:           "use3"(%[[VAL_1]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
-// CHECK:           "use4"(%[[VAL_2]]) : (tensor<50x1xindex>) -> ()
+// CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<[0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 42, 44, 46, 48, 50, 52, 54, 56, 58, 60, 62, 64, 66, 68, 70, 72, 74, 76, 78, 80, 82, 84, 86, 88, 90, 92, 94, 96, 98]> : tensor<50xindex>}> : () -> tensor<50xindex>
+// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<?xindex>
+// CHECK:           "use1"(%[[VAL_1]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<?xindex>
+// CHECK:           "use2"(%[[VAL_2]]) : (tensor<?xindex>) -> ()
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<?xindex>
+// CHECK:           "use3"(%[[VAL_3]]) : (tensor<?xindex>) -> ()
+// CHECK:           "use4"(%[[VAL_0]]) : (tensor<50xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
 // CHECK:       }) : () -> ()
@@ -68,14 +69,14 @@ module {
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-    "use1"(%4) : (tensor<?x1xindex>) -> ()
-    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
-    "use2"(%5) : (tensor<?x1xindex>) -> ()
-    %si = "indexing.arange"(%c0_index) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
-    "use3"(%si) : (tensor<?x1xindex>) -> ()
-    %se = "indexing.arange"() {nofold, startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
-    "use4"(%se) : (tensor<50x1xindex>) -> ()
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?xindex>
+    "use1"(%4) : (tensor<?xindex>) -> ()
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?xindex>
+    "use2"(%5) : (tensor<?xindex>) -> ()
+    %si = "indexing.arange"(%c0_index) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?xindex>
+    "use3"(%si) : (tensor<?xindex>) -> ()
+    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50xindex>
+    "use4"(%se) : (tensor<50xindex>) -> ()
 
     return
   }

--- a/test/Dialect/Indexing/canonicalize.mlir
+++ b/test/Dialect/Indexing/canonicalize.mlir
@@ -5,15 +5,15 @@
 // CHECK:           %[[VAL_0:.*]] = "c0_index_dyn"() : () -> index
 // CHECK:           %[[VAL_1:.*]] = "c100_index_dyn"() : () -> index
 // CHECK:           %[[VAL_2:.*]] = "c2_index_dyn"() : () -> index
-// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_3:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
 // CHECK:           "use1"(%[[VAL_3]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_4:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
 // CHECK:           "use2"(%[[VAL_4]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_5:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
 // CHECK:           "use3"(%[[VAL_5]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_6:.*]] = "indexing.arange"(%[[VAL_0]]) {nofold, operand_segment_sizes = array<i32: 1, 0, 0>, stepAttr = 2 : index, stopAttr = 100 : index} : (index) -> tensor<?x1xindex>
 // CHECK:           "use4"(%[[VAL_6]]) : (tensor<?x1xindex>) -> ()
-// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
+// CHECK:           %[[VAL_7:.*]] = "indexing.arange"(%[[VAL_0]], %[[VAL_1]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 0>, stepAttr = 2 : index} : (index, index) -> tensor<?x1xindex>
 // CHECK:           "use5"(%[[VAL_7]]) : (tensor<?x1xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
@@ -28,19 +28,19 @@ module {
     %c100_index_dyn = "c100_index_dyn"() : () -> (index)
     %c2_index_dyn = "c2_index_dyn"() : () -> (index)
 
-    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %10 = "indexing.arange"(%c0_index_dyn, %c100_index, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%10) : (tensor<?x1xindex>) -> ()
 
-    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %11 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use2"(%11) : (tensor<?x1xindex>) -> ()
 
-    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %12 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn, %c2_index_dyn) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use3"(%12) : (tensor<?x1xindex>) -> ()
 
-    %13 = "indexing.arange"(%c0_index_dyn) {foldAttr = false, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %13 = "indexing.arange"(%c0_index_dyn) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use4"(%13) : (tensor<?x1xindex>) -> ()
 
-    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {foldAttr = false, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
+    %14 = "indexing.arange"(%c0_index_dyn, %c100_index_dyn) {nofold, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 1, 0>} : (index, index) -> tensor<?x1xindex>
     "use5"(%14) : (tensor<?x1xindex>) -> ()
 
     return
@@ -54,9 +54,9 @@ module {
 // CHECK:           %[[VAL_0:.*]] = "arith.constant"() <{value = dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20], [22], [24], [26], [28], [30], [32], [34], [36], [38], [40], [42], [44], [46], [48], [50], [52], [54], [56], [58], [60], [62], [64], [66], [68], [70], [72], [74], [76], [78], [80], [82], [84], [86], [88], [90], [92], [94], [96], [98]]> : tensor<50x1xindex>}> : () -> tensor<50x1xindex>
 // CHECK:           "use1"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
 // CHECK:           "use2"(%[[VAL_0]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           %[[VAL_1:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
 // CHECK:           "use3"(%[[VAL_1]]) : (tensor<50x1xindex>) -> ()
-// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
+// CHECK:           %[[VAL_2:.*]] = "indexing.arange"() {nofold, operand_segment_sizes = array<i32: 0, 0, 0>, startAttr = 0 : index, stepAttr = 2 : index, stopAttr = 100 : index} : () -> tensor<50x1xindex>
 // CHECK:           "use4"(%[[VAL_2]]) : (tensor<50x1xindex>) -> ()
 // CHECK:           "func.return"() : () -> ()
 // CHECK:         }) : () -> ()
@@ -68,13 +68,13 @@ module {
     %c100_index = arith.constant 100 : index
     %c2_index = arith.constant 2 : index
 
-    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {foldAttr = true, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+    %4 = "indexing.arange"(%c0_index, %c100_index, %c2_index) {operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
     "use1"(%4) : (tensor<?x1xindex>) -> ()
-    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, foldAttr = true, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
+    %5 = "indexing.arange"(%c0_index, %c2_index) {stopAttr = 100 : index, operand_segment_sizes = array<i32: 1, 0, 1>} : (index, index) -> tensor<?x1xindex>
     "use2"(%5) : (tensor<?x1xindex>) -> ()
-    %si = "indexing.arange"(%c0_index) {stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
+    %si = "indexing.arange"(%c0_index) {nofold, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 1, 0, 0>} : (index) -> tensor<?x1xindex>
     "use3"(%si) : (tensor<?x1xindex>) -> ()
-    %se = "indexing.arange"() {startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, foldAttr = false, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
+    %se = "indexing.arange"() {nofold, startAttr = 0 : index, stopAttr = 100 : index, stepAttr = 2 : index, operand_segment_sizes = array<i32: 0, 0, 0>} : () -> tensor<50x1xindex>
     "use4"(%se) : (tensor<50x1xindex>) -> ()
 
     return

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -923,6 +923,27 @@ def testArithPythonValues():
   module.operation.verify()
 
 
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals0
+@run
+def testArbitrarySlicingLiterals0():
+  f32 = F32Type.get()
+  with mlir_mod_ctx() as module:
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[0:7:2]
+
+  module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 7 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([0]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x22x330x4400xf32>
+  # CHECK:       }
+  print(module)
+
+
 # CHECK-LABEL: TEST: testArbitrarySlicingLiterals1
 @run
 def testArbitrarySlicingLiterals1():
@@ -938,7 +959,7 @@ def testArbitrarySlicingLiterals1():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
   # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
   # CHECK:       }
   print(module)
@@ -958,14 +979,12 @@ def testArbitrarySlicingLiterals2():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x4400xf32>
+  # CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+  # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x4400xf32>
   # CHECK:       }
   print(module)
 
@@ -985,19 +1004,16 @@ def testArbitrarySlicingLiterals3():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_11:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_12:.*]] = arith.constant 4400 : index
-  # CHECK:         %[[VAL_13:.*]] = arith.constant 400 : index
-  # CHECK:         %[[VAL_14:.*]] = indexing.arange(start = %[[VAL_11]], stop = %[[VAL_12]], step = %[[VAL_13]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_15:.*]] = tensor.expand_shape %[[VAL_14]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_16:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]], %[[VAL_15]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x3xindex>
-  # CHECK:         %[[VAL_17:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_16]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<?x7xf32>
+  # CHECK:         %[[VAL_5:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_9:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_10:.*]] = arith.constant 4400 : index
+  # CHECK:         %[[VAL_11:.*]] = arith.constant 400 : index
+  # CHECK:         %[[VAL_12:.*]] = indexing.arange(start = %[[VAL_9]], stop = %[[VAL_10]], step = %[[VAL_11]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_13:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]], %[[VAL_12]]) : (tensor<?xindex>, tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x?x3xindex>
+  # CHECK:         %[[VAL_14:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_13]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x?x3xindex>) -> tensor<?x?x?x7xf32>
   # CHECK:       }
   print(module)
 
@@ -1017,14 +1033,12 @@ def testArbitrarySlicingLiterals4():
   # CHECK:         %[[VAL_2:.*]] = arith.constant 200 : index
   # CHECK:         %[[VAL_3:.*]] = arith.constant 5 : index
   # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_6:.*]] = arith.constant 1000 : index
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 2000 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 50 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
-  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x22xf32>
+  # CHECK:         %[[VAL_5:.*]] = arith.constant 1000 : index
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 2000 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 50 : index
+  # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+  # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x22xf32>
   # CHECK:       }
   print(module)
 
@@ -1056,10 +1070,10 @@ def testArbitrarySlicingDyn():
   # CHECK:         func.func @test_dyn_indices() -> (tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>) {
   # CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
   # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
-  # CHECK:           %[[VAL_2:.*]] = tensor.expand_shape %[[VAL_1]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_2:.*]] = indexing.meshgrid(%[[VAL_1]]) : (tensor<?xindex>) -> tensor<?x1xindex>
   # CHECK:           %[[VAL_3:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_2]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
   # CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
-  # CHECK:           %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
   # CHECK:           %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
   # CHECK:           return %[[VAL_3]], %[[VAL_6]] : tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>
   # CHECK:         }
@@ -1263,96 +1277,137 @@ def testWholeSliceScatter():
 def testStaticSliceScatter():
   f32 = F32Type.get()
   with mlir_mod_ctx() as module:
-    ten = Tensor.empty((7, 22, 330, 4400), f32)
 
-    w = ten[:, 0:22:2]
-    ten[:, 0:22:2] = w
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter1():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, 0:22:2]
+      ten[:, 0:22:2] = w
 
-    w = ten[:, 0:22:2, 0:330:30]
-    ten[:, 0:22:2, 0:330:30] = w
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter1() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = indexing.meshgrid(%[[VAL_4]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+    # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter1.func_op)
 
-    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
-    ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter2():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, 0:22:2, 0:330:30]
+      ten[:, 0:22:2, 0:330:30] = w
 
-    w = ten[:, :, 100:200:5, 1000:2000:50]
-    ten[:, :, 100:200:5, 1000:2000:50] = w
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter2() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = arith.constant 330 : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 30 : index
+    # CHECK:         %[[VAL_7:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_5]], step = %[[VAL_6]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_8:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_7]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+    # CHECK:         %[[VAL_9:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_8]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x4400xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter2.func_op)
+
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter3():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
+      ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
+
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter3() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = arith.constant 330 : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 30 : index
+    # CHECK:         %[[VAL_7:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_5]], step = %[[VAL_6]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_8:.*]] = arith.constant 4400 : index
+    # CHECK:         %[[VAL_9:.*]] = arith.constant 400 : index
+    # CHECK:         %[[VAL_10:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_8]], step = %[[VAL_9]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_11:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_7]], %[[VAL_10]]) : (tensor<?xindex>, tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x?x3xindex>
+    # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x?x3xindex>) -> tensor<?x?x?x7xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter3.func_op)
+
+    @func.FuncOp.from_py_func(*[])
+    def static_slice_scatter4():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      w = ten[:, :, 100:200:5, 1000:2000:50]
+      ten[:, :, 100:200:5, 1000:2000:50] = w
+
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @static_slice_scatter4() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 200 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.constant 5 : index
+    # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_5:.*]] = arith.constant 1000 : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 2000 : index
+    # CHECK:         %[[VAL_7:.*]] = arith.constant 50 : index
+    # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_5]], stop = %[[VAL_6]], step = %[[VAL_7]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_4]], %[[VAL_8]]) : (tensor<?xindex>, tensor<?xindex>) -> tensor<?x?x2xindex>
+    # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x?x2xindex>) -> tensor<?x?x7x22xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(static_slice_scatter4.func_op)
 
   module.operation.verify()
-
-  pm = PassManager.parse('builtin.module(cse)')
-  pm.run(module.operation)
-  # CHECK-LABEL: module {
-  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_1:.*]] = arith.constant dense<{{\[\[}}0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20]]> : tensor<11x1xindex>
-  # CHECK:         %[[VAL_2:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_1]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<11x1xindex>) -> tensor<11x7x330x4400xf32>
-  # CHECK:         %[[VAL_3:.*]] = indexing.scatter %[[VAL_2]] into %[[VAL_0]]{{\[}}%[[VAL_1]]] scatter_dims([1]) unique : (tensor<11x7x330x4400xf32>, tensor<7x22x330x4400xf32>, tensor<11x1xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_4:.*]] = arith.constant dense<{{\[\[}}0, 0], [2, 30], [4, 60], [6, 90], [8, 120], [10, 150], [12, 180], [14, 210], [16, 240], [18, 270], [20, 300]]> : tensor<11x2xindex>
-  # CHECK:         %[[VAL_5:.*]] = indexing.gather %[[VAL_3]]{{\[}}%[[VAL_4]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<11x2xindex>) -> tensor<11x7x4400xf32>
-  # CHECK:         %[[VAL_6:.*]] = indexing.scatter %[[VAL_5]] into %[[VAL_3]]{{\[}}%[[VAL_4]]] scatter_dims([1, 2]) unique : (tensor<11x7x4400xf32>, tensor<7x22x330x4400xf32>, tensor<11x2xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_7:.*]] = arith.constant dense<{{\[\[}}0, 0, 0], [2, 30, 400], [4, 60, 800], [6, 90, 1200], [8, 120, 1600], [10, 150, 2000], [12, 180, 2400], [14, 210, 2800], [16, 240, 3200], [18, 270, 3600], [20, 300, 4000]]> : tensor<11x3xindex>
-  # CHECK:         %[[VAL_8:.*]] = indexing.gather %[[VAL_6]]{{\[}}%[[VAL_7]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<11x3xindex>) -> tensor<11x7xf32>
-  # CHECK:         %[[VAL_9:.*]] = indexing.scatter %[[VAL_8]] into %[[VAL_6]]{{\[}}%[[VAL_7]]] scatter_dims([1, 2, 3]) unique : (tensor<11x7xf32>, tensor<7x22x330x4400xf32>, tensor<11x3xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_10:.*]] = arith.constant dense<{{\[\[}}100, 1000], [105, 1050], [110, 1100], [115, 1150], [120, 1200], [125, 1250], [130, 1300], [135, 1350], [140, 1400], [145, 1450], [150, 1500], [155, 1550], [160, 1600], [165, 1650], [170, 1700], [175, 1750], [180, 1800], [185, 1850], [190, 1900], [195, 1950]]> : tensor<20x2xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.gather %[[VAL_9]]{{\[}}%[[VAL_10]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<20x2xindex>) -> tensor<20x7x22xf32>
-  # CHECK:       }
-  print(module)
 
 
 # CHECK-LABEL: TEST: testDynSliceScatter
 @run
 def testDynSliceScatter():
   f32 = F32Type.get()
+  index = IndexType.get()
   with mlir_mod_ctx() as module:
-    ten = Tensor.empty((7, 22, 330, 4400), f32)
 
-    w = ten[:, 0:22:2]
-    ten[:, 0:22:2] = w
+    @func.FuncOp.from_py_func(*[])
+    def dyn_slice_scatter1():
+      ten = Tensor.empty((7, 22, 330, 4400), f32)
+      one = Scalar(1, dtype=index, fold=False)
+      zero = 0 * one
+      two = 2 * one
+      twenty_two = 22 * one
+      w = ten[:, zero:twenty_two:two]
+      ten[:, zero:twenty_two:two] = w
 
-    w = ten[:, 0:22:2, 0:330:30]
-    ten[:, 0:22:2, 0:330:30] = w
-
-    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
-    ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
-
-    w = ten[:, :, 100:200:5, 1000:2000:50]
-    ten[:, :, 100:200:5, 1000:2000:50] = w
-
-  module.operation.verify()
-
-  pm = PassManager.parse('builtin.module(cse)')
-  pm.run(module.operation)
-  # CHECK-LABEL: module {
-  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
-  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
-  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
-  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_5:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_4]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
-  # CHECK:         %[[VAL_6:.*]] = indexing.scatter %[[VAL_5]] into %[[VAL_0]]{{\[}}%[[VAL_4]]] scatter_dims([1]) unique : (tensor<?x7x330x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
-  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
-  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_7]], step = %[[VAL_8]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_10:.*]] = indexing.concatenate(%[[VAL_4]], %[[VAL_9]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_11:.*]] = indexing.gather %[[VAL_6]]{{\[}}%[[VAL_10]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x4400xf32>
-  # CHECK:         %[[VAL_12:.*]] = indexing.scatter %[[VAL_11]] into %[[VAL_6]]{{\[}}%[[VAL_10]]] scatter_dims([1, 2]) unique : (tensor<?x7x4400xf32>, tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_13:.*]] = arith.constant 4400 : index
-  # CHECK:         %[[VAL_14:.*]] = arith.constant 400 : index
-  # CHECK:         %[[VAL_15:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_13]], step = %[[VAL_14]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_16:.*]] = indexing.concatenate(%[[VAL_4]], %[[VAL_9]], %[[VAL_15]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x3xindex>
-  # CHECK:         %[[VAL_17:.*]] = indexing.gather %[[VAL_12]]{{\[}}%[[VAL_16]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<?x7xf32>
-  # CHECK:         %[[VAL_18:.*]] = indexing.scatter %[[VAL_17]] into %[[VAL_12]]{{\[}}%[[VAL_16]]] scatter_dims([1, 2, 3]) unique : (tensor<?x7xf32>, tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<7x22x330x4400xf32>
-  # CHECK:         %[[VAL_19:.*]] = arith.constant 100 : index
-  # CHECK:         %[[VAL_20:.*]] = arith.constant 200 : index
-  # CHECK:         %[[VAL_21:.*]] = arith.constant 5 : index
-  # CHECK:         %[[VAL_22:.*]] = indexing.arange(start = %[[VAL_19]], stop = %[[VAL_20]], step = %[[VAL_21]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_23:.*]] = arith.constant 1000 : index
-  # CHECK:         %[[VAL_24:.*]] = arith.constant 2000 : index
-  # CHECK:         %[[VAL_25:.*]] = arith.constant 50 : index
-  # CHECK:         %[[VAL_26:.*]] = indexing.arange(start = %[[VAL_23]], stop = %[[VAL_24]], step = %[[VAL_25]]) : tensor<?x1xindex>
-  # CHECK:         %[[VAL_27:.*]] = indexing.concatenate(%[[VAL_22]], %[[VAL_26]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
-  # CHECK:         %[[VAL_28:.*]] = indexing.gather %[[VAL_18]]{{\[}}%[[VAL_27]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x22xf32>
-  # CHECK:       }
-  print(module)
+    pm = PassManager.parse('builtin.module(func.func(cse))')
+    pm.run(module.operation)
+    # CHECK-LABEL: func.func @dyn_slice_scatter1() {
+    # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+    # CHECK:         %[[VAL_1:.*]] = arith.constant 1 : index
+    # CHECK:         %[[VAL_2:.*]] = arith.constant 0 : index
+    # CHECK:         %[[VAL_3:.*]] = arith.muli %[[VAL_1]], %[[VAL_2]] : index
+    # CHECK:         %[[VAL_4:.*]] = arith.constant 2 : index
+    # CHECK:         %[[VAL_5:.*]] = arith.muli %[[VAL_1]], %[[VAL_4]] : index
+    # CHECK:         %[[VAL_6:.*]] = arith.constant 22 : index
+    # CHECK:         %[[VAL_7:.*]] = arith.muli %[[VAL_1]], %[[VAL_6]] : index
+    # CHECK:         %[[VAL_8:.*]] = indexing.arange(start = %[[VAL_3]], stop = %[[VAL_7]], step = %[[VAL_5]]) nofold : tensor<?xindex>
+    # CHECK:         %[[VAL_9:.*]] = indexing.meshgrid(%[[VAL_8]]) : (tensor<?xindex>) -> tensor<?x1xindex>
+    # CHECK:         %[[VAL_10:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_9]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
+    # CHECK:         return
+    # CHECK:       }
+    print(dyn_slice_scatter1.func_op)
 
 
 # CHECK-LABEL: TEST: testForLoopSugarNoIterArgs

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -677,8 +677,8 @@ def testARangeOpBasics():
     # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
     print(ara.owner)
 
-    ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, fold=True))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2, fold = true) : tensor<50x1xindex>
+    ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, nofold=True))
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) nofold : tensor<50x1xindex>
     print(ara.owner)
 
   module.operation.verify()
@@ -696,7 +696,7 @@ def testARangeFun():
     # CHECK: Value(%[[C2:.*]] = arith.constant 2 : index)
     print(ara.owner.operands[2])
 
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) nofold : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(0, 100, fold=False)
@@ -704,13 +704,13 @@ def testARangeFun():
     print(ara.owner.operands[0])
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[1])
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(100, fold=False)
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[0])
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
     print(ara.owner)
 
     ara = arange(0, 100, 2, fold=True)
@@ -1042,7 +1042,7 @@ def testArbitrarySlicingDyn():
       print(step.owner)
 
       w = ten[:, :, start:stop:step]
-      # CHECK: %[[VAL_8:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+      # CHECK: %[[VAL_8:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
       print(w.owner.operands[1].owner)
       # CHECK: %[[VAL_9:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_8]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
       print(w.owner)
@@ -1050,7 +1050,7 @@ def testArbitrarySlicingDyn():
       w = ten[:, :, start:stop:5]
       # CHECK: %[[VAL_10:.*]] = "arith.constant"() <{value = 5 : index}> : () -> index
       print(w.owner.operands[1].owner.operands[2])
-      # CHECK: %[[VAL_11:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_10]]) {foldAttr = false, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
+      # CHECK: %[[VAL_11:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_10]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
       print(w.owner.operands[1].owner)
       # CHECK: %[[VAL_12:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_11]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
       print(w.owner)
@@ -1064,7 +1064,7 @@ def testArbitrarySlicingDyn():
   # CHECK-LABEL: module {
   # CHECK:         func.func @test_dyn_indices() -> tensor<?x7x22x4400xf32> {
   # CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) : tensor<20x1xindex>
+  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<20x1xindex>
   # CHECK:           %[[VAL_2:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_1]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<20x1xindex>) -> tensor<?x7x22x4400xf32>
   # CHECK:           return %[[VAL_2]] : tensor<?x7x22x4400xf32>
   # CHECK:         }

--- a/test/python/dialects/indexing/dialect.py
+++ b/test/python/dialects/indexing/dialect.py
@@ -646,39 +646,39 @@ def testARangeOpBasics():
     print(step.get_name())
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=stop, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=100, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = %[[STOP]], step = 2) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=step))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = %[[STEP]]) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=stop, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[STOP]], step = 2) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=start, stop=100, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[START]], stop = 100, step = 2) : tensor<?xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) : tensor<50xindex>
     print(ara.owner)
 
     ara = Tensor(indexing.ARangeOp(start=0, stop=100, step=2, nofold=True))
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) nofold : tensor<50x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = 100, step = 2) nofold : tensor<50xindex>
     print(ara.owner)
 
   module.operation.verify()
@@ -696,7 +696,7 @@ def testARangeFun():
     # CHECK: Value(%[[C2:.*]] = arith.constant 2 : index)
     print(ara.owner.operands[2])
 
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) nofold : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = %[[C2]]) nofold : tensor<?xindex>
     print(ara.owner)
 
     ara = arange(0, 100, fold=False)
@@ -704,25 +704,25 @@ def testARangeFun():
     print(ara.owner.operands[0])
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[1])
-    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = %[[C0]], stop = %[[C100]], step = 1) nofold : tensor<?xindex>
     print(ara.owner)
 
     ara = arange(100, fold=False)
     # CHECK: Value(%[[C100:.*]] = arith.constant 100 : index)
     print(ara.owner.operands[0])
-    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) nofold : tensor<?x1xindex>
+    # CHECK: %{{.*}} = indexing.arange(start = 0, stop = %[[C100]], step = 1) nofold : tensor<?xindex>
     print(ara.owner)
 
     ara = arange(0, 100, 2, fold=True)
-    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [2], [4], [6], [8], {{.*}}, [98]]> : tensor<50x1xindex>
+    # CHECK: %{{.*}} = arith.constant dense<[0, 2, 4, 6, 8, {{.*}}, 98]> : tensor<50xindex>
     print(ara.owner)
 
     ara = arange(0, 100, fold=True)
-    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
+    # CHECK: %{{.*}} = arith.constant dense<[0, 1, 2, 3, 4, {{.*}}, 99]> : tensor<100xindex>
     print(ara.owner)
 
     ara = arange(100, fold=True)
-    # CHECK: %{{.*}} = arith.constant dense<{{\[}}[0], [1], [2], [3], [4], {{.*}}, [99]]> : tensor<100x1xindex>
+    # CHECK: %{{.*}} = arith.constant dense<[0, 1, 2, 3, 4, {{.*}}, 99]> : tensor<100xindex>
     print(ara.owner)
 
   module.operation.verify()
@@ -754,13 +754,13 @@ def testARangeOpSemantics():
       step = np.random.randint(1, 100)
 
       ara = Tensor(indexing.ARangeOp(start=start, stop=stop, step=step))
-      r = np.arange(start, stop, step)[:, np.newaxis]
+      r = np.arange(start, stop, step)
 
       if len(r) != (stop - start) // step + 1:
         assert (stop - start) % step == 0
         assert len(r) == (stop - start) // step
 
-      assert r.shape == ara.shape
+      assert r.shape == ara.shape, f"{r.shape=} {ara.shape=}"
 
 
 # CHECK-LABEL: TEST: testNoneIndices
@@ -885,124 +885,148 @@ def testArithPythonValues():
     # CHECK: %[[VAL_15:.*]] = arith.mulf %[[VAL_13]], %[[VAL_14]] : tensor<2x2xf64>
     print(two_times_ten.owner)
 
-    two_times_ten = ten * 2.0
-    # CHECK: %[[VAL_16:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    three_times_ten = ten * 3.0
+    # CHECK: %[[VAL_16:.*]] = arith.constant dense<3.000000e+00> : tensor<2x2xf64>
+    print(three_times_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_17:.*]] = arith.mulf %[[VAL_13]], %[[VAL_16]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(three_times_ten.owner)
 
-    two_times_ten = 2.0 * ten
-    # CHECK: %[[VAL_18:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    four_times_ten = 4.0 * ten
+    # CHECK: %[[VAL_18:.*]] = arith.constant dense<4.000000e+00> : tensor<2x2xf64>
+    print(four_times_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_19:.*]] = arith.mulf %[[VAL_13]], %[[VAL_18]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(four_times_ten.owner)
 
-    two_times_ten = ten + 2.0
-    # CHECK: %[[VAL_20:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    five_plus_ten = ten + 5.0
+    # CHECK: %[[VAL_20:.*]] = arith.constant dense<5.000000e+00> : tensor<2x2xf64>
+    print(five_plus_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_21:.*]] = arith.addf %[[VAL_13]], %[[VAL_20]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(five_plus_ten.owner)
 
-    two_times_ten = 2.0 + ten
-    # CHECK: %[[VAL_22:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    two_rplus_ten = 2.0 + ten
+    # CHECK: %[[VAL_22:.*]] = arith.constant dense<2.000000e+00> : tensor<2x2xf64>
+    print(two_rplus_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_23:.*]] = arith.addf %[[VAL_13]], %[[VAL_22]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(two_rplus_ten.owner)
 
-    two_times_ten = ten - 2.0
-    # CHECK: %[[VAL_24:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    two_sub_ten = ten - 2.0
+    # CHECK: %[[VAL_24:.*]] = arith.constant dense<2.000000e+00> : tensor<2x2xf64>
+    print(two_sub_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_25:.*]] = arith.subf %[[VAL_13]], %[[VAL_24]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(two_sub_ten.owner)
 
-    two_times_ten = 2.0 - ten
-    # CHECK: %[[VAL_26:.*]] = arith.constant dense<1.000000e+00> : tensor<2x2xf64>
-    print(two_times_ten.owner.operands[1].owner)
+    two_rsub_ten = 2.0 - ten
+    # CHECK: %[[VAL_26:.*]] = arith.constant dense<2.000000e+00> : tensor<2x2xf64>
+    print(two_rsub_ten.owner.operands[1].owner)
     # CHECK: %[[VAL_27:.*]] = arith.subf %[[VAL_13]], %[[VAL_26]] : tensor<2x2xf64>
-    print(two_times_ten.owner)
+    print(two_rsub_ten.owner)
 
   module.operation.verify()
 
 
-# CHECK-LABEL: TEST: testArbitrarySlicingLiterals
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals1
 @run
-def testArbitrarySlicingLiterals():
-  index = IndexType.get()
+def testArbitrarySlicingLiterals1():
   f32 = F32Type.get()
   with mlir_mod_ctx() as module:
     ten = Tensor.empty((7, 22, 330, 4400), f32)
-    # CHECK: Tensor(%[[TEN:.*]], tensor<7x22x330x4400xf32>)
-    print(ten)
-
-    w = ten[:, arange(start=0, stop=22, step=2, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[0], [2], [4], [6], [8], [10], [12], [14], [16], [18], [20]]> : tensor<11x1xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<11x1xindex>) -> tensor<11x7x330x4400xf32>
-    print(w.owner)
-
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[0, 0], [2, 30], [4, 60], [6, 90], [8, 120], [10, 150], [12, 180], [14, 210], [16, 240], [18, 270], [20, 300]]> : tensor<11x2xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<11x2xindex>) -> tensor<11x7x4400xf32>
-    print(w.owner)
-
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True),
-            arange(start=0, stop=4400, step=400, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[0, 0, 0], [2, 30, 400], [4, 60, 800], [6, 90, 1200], [8, 120, 1600], [10, 150, 2000], [12, 180, 2400], [14, 210, 2800], [16, 240, 3200], [18, 270, 3600], [20, 300, 4000]]> : tensor<11x3xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<11x3xindex>) -> tensor<11x7xf32>
-    print(w.owner)
-
-    w = ten[:, :,
-            arange(start=100, stop=200, step=5, fold=True),
-            arange(start=1000, stop=2000, step=50, fold=True)]
-    # CHECK: %[[ARA:.*]] = arith.constant dense<{{\[}}[100, 1000], [105, 1050], [110, 1100], [115, 1150], [120, 1200], [125, 1250], [130, 1300], [135, 1350], [140, 1400], [145, 1450], [150, 1500], [155, 1550], [160, 1600], [165, 1650], [170, 1700], [175, 1750], [180, 1800], [185, 1850], [190, 1900], [195, 1950]]> : tensor<20x2xindex>
-    print(w.owner.operands[1].owner)
-    # CHECK: %{{.*}} = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<20x2xindex>) -> tensor<20x7x22xf32>
-    print(w.owner)
+    w = ten[:, 0:22:2]
 
   module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([1]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x330x4400xf32>
+  # CHECK:       }
+  print(module)
 
 
-# CHECK-LABEL: TEST: testArithFolding
 @run
-def testArithFolding():
-  index = IndexType.get()
+def testArbitrarySlicingLiterals2():
   f32 = F32Type.get()
   with mlir_mod_ctx() as module:
-
-    @func.FuncOp.from_py_func(*[])
-    def test_fold():
-      ten = Tensor.empty((7, 22, 330, 4400), f32)
-
-      idx1 = arange(100, 200, 5, fold=True)
-      idx2 = arange(1000, 2000, 50, fold=True)
-      w = ten[:, :, idx1, idx2]
-      idx_tensor = Tensor(w.owner.operands[1], fold=False)
-      pid = 42
-      pid_tensor = Tensor(pid * np.ones(idx_tensor.shape, dtype=np.intp),
-                          dtype=index,
-                          fold=False)
-      new_idx_tensor = pid_tensor + idx_tensor
-      w = ten[:, :, new_idx_tensor]
-      return w
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[:, 0:22:2, 0:330:30]
 
   module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
+  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([1, 2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x4400xf32>
+  # CHECK:       }
+  print(module)
 
-  pm = PassManager.parse('builtin.module(canonicalize)')
-  pm.run(module.operation)
-  # CHECK: module {
-  # CHECK:   func.func @test_fold() -> tensor<20x7x22xf32> {
-  # CHECK:     %[[ARA:.*]] = arith.constant dense<{{\[}}[142, 1042], [147, 1092], [152, 1142], [157, 1192], [162, 1242], [167, 1292], [172, 1342], [177, 1392], [182, 1442], [187, 1492], [192, 1542], [197, 1592], [202, 1642], [207, 1692], [212, 1742], [217, 1792], [222, 1842], [227, 1892], [232, 1942], [237, 1992]]> : tensor<20x2xindex>
-  # CHECK:     %[[TEN:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:     %[[GATHERED:.*]] = indexing.gather %[[TEN]][%[[ARA]]] gather_dims([2, 3]) : (tensor<7x22x330x4400xf32>, tensor<20x2xindex>) -> tensor<20x7x22xf32>
-  # CHECK:     return %[[GATHERED]] : tensor<20x7x22xf32>
-  # CHECK:   }
-  # CHECK: }
+
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals3
+@run
+def testArbitrarySlicingLiterals3():
+  f32 = F32Type.get()
+  with mlir_mod_ctx() as module:
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
+
+  module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 22 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 2 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 330 : index
+  # CHECK:         %[[VAL_8:.*]] = arith.constant 30 : index
+  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_11:.*]] = arith.constant 0 : index
+  # CHECK:         %[[VAL_12:.*]] = arith.constant 4400 : index
+  # CHECK:         %[[VAL_13:.*]] = arith.constant 400 : index
+  # CHECK:         %[[VAL_14:.*]] = indexing.arange(start = %[[VAL_11]], stop = %[[VAL_12]], step = %[[VAL_13]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_15:.*]] = tensor.expand_shape %[[VAL_14]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_16:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]], %[[VAL_15]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x3xindex>
+  # CHECK:         %[[VAL_17:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_16]]] gather_dims([1, 2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x3xindex>) -> tensor<?x7xf32>
+  # CHECK:       }
+  print(module)
+
+
+# CHECK-LABEL: TEST: testArbitrarySlicingLiterals4
+@run
+def testArbitrarySlicingLiterals4():
+  f32 = F32Type.get()
+  with mlir_mod_ctx() as module:
+    ten = Tensor.empty((7, 22, 330, 4400), f32)
+    w = ten[:, :, 100:200:5, 1000:2000:50]
+
+  module.operation.verify()
+  # CHECK-LABEL: module {
+  # CHECK:         %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
+  # CHECK:         %[[VAL_1:.*]] = arith.constant 100 : index
+  # CHECK:         %[[VAL_2:.*]] = arith.constant 200 : index
+  # CHECK:         %[[VAL_3:.*]] = arith.constant 5 : index
+  # CHECK:         %[[VAL_4:.*]] = indexing.arange(start = %[[VAL_1]], stop = %[[VAL_2]], step = %[[VAL_3]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_6:.*]] = arith.constant 1000 : index
+  # CHECK:         %[[VAL_7:.*]] = arith.constant 2000 : index
+  # CHECK:         %[[VAL_8:.*]] = arith.constant 50 : index
+  # CHECK:         %[[VAL_9:.*]] = indexing.arange(start = %[[VAL_6]], stop = %[[VAL_7]], step = %[[VAL_8]]) nofold : tensor<?xindex>
+  # CHECK:         %[[VAL_10:.*]] = tensor.expand_shape %[[VAL_9]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:         %[[VAL_11:.*]] = indexing.concatenate(%[[VAL_5]], %[[VAL_10]]) {dim = 1} : (tensor<?x1xindex>, tensor<?x1xindex>) -> tensor<?x2xindex>
+  # CHECK:         %[[VAL_12:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_11]]] gather_dims([2, 3]) unique : (tensor<7x22x330x4400xf32>, tensor<?x2xindex>) -> tensor<?x7x22xf32>
+  # CHECK:       }
   print(module)
 
 
@@ -1016,57 +1040,29 @@ def testArbitrarySlicingDyn():
     @func.FuncOp.from_py_func(*[])
     def test_dyn_indices():
       ten = Tensor.empty((7, 22, 330, 4400), f32)
-      # CHECK: %[[VAL_0:.*]] = "tensor.empty"() : () -> tensor<7x22x330x4400xf32>
-      print(ten.owner)
-
       one = Scalar(1, dtype=index, fold=False)
-      # CHECK: %[[VAL_1:.*]] = "arith.constant"() <{value = 1 : index}> : () -> index
-      print(one.owner)
-
       start = 100 * one
-      # CHECK: %[[VAL_2:.*]] = "arith.constant"() <{value = 100 : index}> : () -> index
-      print(start.owner.operands[1].owner)
-      # CHECK: %[[VAL_3:.*]] = "arith.muli"(%[[VAL_1]], %[[VAL_2]]) : (index, index) -> index
-      print(start.owner)
-
       stop = 200 * one
-      # CHECK: %[[VAL_4:.*]] = "arith.constant"() <{value = 200 : index}> : () -> index
-      print(stop.owner.operands[1].owner)
-      # CHECK: %[[VAL_5:.*]] = "arith.muli"(%[[VAL_1]], %[[VAL_4]]) : (index, index) -> index
-      print(stop.owner)
-
       step = 5 * one
-      # CHECK: %[[VAL_6:.*]] = "arith.constant"() <{value = 5 : index}> : () -> index
-      print(step.owner.operands[1].owner)
-      # CHECK: %[[VAL_7:.*]] = "arith.muli"(%[[VAL_1]], %[[VAL_6]]) : (index, index) -> index
-      print(step.owner)
+      w1 = ten[:, :, start:stop:step]
+      w2 = ten[:, :, start:stop:5]
 
-      w = ten[:, :, start:stop:step]
-      # CHECK: %[[VAL_8:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_7]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-      print(w.owner.operands[1].owner)
-      # CHECK: %[[VAL_9:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_8]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
-      print(w.owner)
-
-      w = ten[:, :, start:stop:5]
-      # CHECK: %[[VAL_10:.*]] = "arith.constant"() <{value = 5 : index}> : () -> index
-      print(w.owner.operands[1].owner.operands[2])
-      # CHECK: %[[VAL_11:.*]] = "indexing.arange"(%[[VAL_3]], %[[VAL_5]], %[[VAL_10]]) {nofold, operand_segment_sizes = array<i32: 1, 1, 1>} : (index, index, index) -> tensor<?x1xindex>
-      print(w.owner.operands[1].owner)
-      # CHECK: %[[VAL_12:.*]] = "indexing.gather"(%[[VAL_0]], %[[VAL_11]]) {gather_dims = array<i64: 2>, unique} : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
-      print(w.owner)
-
-      return w
+      return w1, w2
 
   module.operation.verify()
 
   pm = PassManager.parse('builtin.module(canonicalize)')
   pm.run(module.operation)
   # CHECK-LABEL: module {
-  # CHECK:         func.func @test_dyn_indices() -> tensor<?x7x22x4400xf32> {
+  # CHECK:         func.func @test_dyn_indices() -> (tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>) {
   # CHECK:           %[[VAL_0:.*]] = tensor.empty() : tensor<7x22x330x4400xf32>
-  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<20x1xindex>
-  # CHECK:           %[[VAL_2:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_1]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<20x1xindex>) -> tensor<?x7x22x4400xf32>
-  # CHECK:           return %[[VAL_2]] : tensor<?x7x22x4400xf32>
+  # CHECK:           %[[VAL_1:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
+  # CHECK:           %[[VAL_2:.*]] = tensor.expand_shape %[[VAL_1]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_3:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_2]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
+  # CHECK:           %[[VAL_4:.*]] = indexing.arange(start = 100, stop = 200, step = 5) nofold : tensor<?xindex>
+  # CHECK:           %[[VAL_5:.*]] = tensor.expand_shape %[[VAL_4]] {{\[\[}}0, 1]] : tensor<?xindex> into tensor<?x1xindex>
+  # CHECK:           %[[VAL_6:.*]] = indexing.gather %[[VAL_0]]{{\[}}%[[VAL_5]]] gather_dims([2]) unique : (tensor<7x22x330x4400xf32>, tensor<?x1xindex>) -> tensor<?x7x22x4400xf32>
+  # CHECK:           return %[[VAL_3]], %[[VAL_6]] : tensor<?x7x22x4400xf32>, tensor<?x7x22x4400xf32>
   # CHECK:         }
   # CHECK:       }
   print(module)
@@ -1202,31 +1198,17 @@ def testStaticSliceScatter():
   with mlir_mod_ctx() as module:
     ten = Tensor.empty((7, 22, 330, 4400), f32)
 
-    w = ten[:, arange(start=0, stop=22, step=2, fold=True)]
-    ten[:, arange(start=0, stop=22, step=2, fold=True)] = w
+    w = ten[:, 0:22:2]
+    ten[:, 0:22:2] = w
 
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True)]
-    ten[:,
-        arange(start=0, stop=22, step=2, fold=True),
-        arange(start=0, stop=330, step=30, fold=True)] = w
+    w = ten[:, 0:22:2, 0:330:30]
+    ten[:, 0:22:2, 0:330:30] = w
 
-    w = ten[:,
-            arange(start=0, stop=22, step=2, fold=True),
-            arange(start=0, stop=330, step=30, fold=True),
-            arange(start=0, stop=4400, step=400, fold=True)]
-    ten[:,
-        arange(start=0, stop=22, step=2, fold=True),
-        arange(start=0, stop=330, step=30, fold=True),
-        arange(start=0, stop=4400, step=400, fold=True)] = w
+    w = ten[:, 0:22:2, 0:330:30, 0:4400:400]
+    ten[:, 0:22:2, 0:330:30, 0:4400:400] = w
 
-    w = ten[:, :,
-            arange(start=100, stop=200, step=5, fold=True),
-            arange(start=1000, stop=2000, step=50, fold=True)]
-    ten[:, :,
-        arange(start=100, stop=200, step=5, fold=True),
-        arange(start=1000, stop=2000, step=50, fold=True)] = w
+    w = ten[:, :, 100:200:5, 1000:2000:50]
+    ten[:, :, 100:200:5, 1000:2000:50] = w
 
   module.operation.verify()
 


### PR DESCRIPTION
During our last call it became apparent that I had actually implemented the wrong slicing semantics (recall my slices were being zipped instead of cartesian-product'ed). For once I can claim it's not my fault! Well at least not entirely; here are the semantics supported by numpy and jax/stablehlo:

```python
x = np.zeros((10, 10))
r = [
  x[0, 1],
  x[:10, :10],
  x[:10:2, :10:2],
  x[:10:2, 1],
  x[:10:2, [1, 2]],
  x[[1, 2], [3, 4]],
  x[np.arange(10), np.arange(10)],
]
for rr in r:
  print(rr.shape)
```
prints
```
()
(10, 10)
(5, 5)
(5,)
(5, 2)
(2,) <----- 🤮
(10,) <----- 🤮
```

and so we see that anything combined with a python `slice` object leads to cartesian product but otherwise lists are zipped, **including lists produced by `np.arange`**. So called advanced indexers (n-d arrays of index elements) are also zipped:

```python
x = np.empty((20, 20, 20, 20, 20))
idx1 = np.random.randint(0, 10, (5, 5))
idx2 = np.random.randint(0, 10, (5, 5))
y = x[:, idx1, ...]
print(y.shape)
>>> (20, 5, 5, 20, 20, 20)
y = x[idx1, :, idx2]
print(y.shape)
>>> (5, 5, 20, 20, 20) <----- 🤮
```
where in the last example it is evident that `idx1` and `idx2` have been zipped because the resulting shape has 2 collapsed dims (numpy brings to the front such complex zips).

My solution is manifold (no pun intended):

1. Undo my shortcut of `arange` produces `?x1xindex` tensors (`arange` now produces 1-d tensors).
2. Make `indexing.arange` fold by default - at the python level this means the operation will be materialized into a 1-d array/tensor and anyone using such an object as an index to a tensor will get the semantics that numpy/jax promises - ie multiple thereof will be zipped (though I'm sure that will almost no one will ever do this).
3. Add a `indexing.MeshGridOp` operation that combines the semantics of `np.meshgrid` and `np.stack(..., -1)`: 
    ```python
    r1 = np.arange(0, 50, 5)
    r2 = np.arange(50, 100, 10)
    xx, yy = np.meshgrid(r1, r2, indexing="ij")
    ss = np.stack([xx, yy], -1)
    print(ss.shape)
    >>> (10, 5, 2)
    ```
    i.e., it takes the cartesian product and expands dim at the same time. 
4. Make any combination with/of python `slice` objects result in such a `meshgrid` op being emitted into the IR[^1].
5. In the subsequent stacked PRs, for the lowering to `tensor.insert_slice`/`tensor.extract_slice`, I will change the pass to match on `indexing.meshgrid`.

This PR is 4 stacked commits that incrementally implement this change even though we've been practicing single commit PRs. I prefer not to split them up into their own PRs because of how intimately related they are.

I plan to go over this with a fine-toothed comb so all comments/questions/concerns are more than welcome!

[^1]: by building `arange(..., fold=False)` and then `meshgrid`ing them together.