### PR TITLE
[Triton][CI] Use lld for building Triton in CI to speed up linking.

### DIFF
--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -94,6 +94,7 @@ jobs:
         CMAKE_CXX_COMPILER_LAUNCHER: ccache
         CMAKE_C_COMPILER_LAUNCHER: ccache
         MAX_JOBS: 1
+        TRITON_BUILD_WITH_CLANG_LLD: 1
       run: |
         cd ${STRUCTURED_MAIN_SRC_DIR}/third_party/triton/python
         pip install -v .


### PR DESCRIPTION
This was suggested here
https://github.com/openai/triton/issues/1743#issuecomment-1578351564 and results in a significant speed up of this CI step.