### PR TITLE
[Triton] Make calling kernels from other kernels work.

### DIFF
--- a/python/mlir_structured/triton/jit.py
+++ b/python/mlir_structured/triton/jit.py
@@ -5,6 +5,9 @@
 # 3. Changing a few variables of the eval scope of function that eventually
 #    calls the compiler such that (1) there is no CUDA dependency and (2) our
 #    compile function is used to produce the compiled kernel.
+# 4. Have the `JITFunction` class of this file inherit from the `JITFunction`
+#    class of the original package such that `instanceof` tests in other parts
+#    of Triton continue to work.
 
 from __future__ import annotations, division
 
@@ -19,6 +22,7 @@ from collections import defaultdict, namedtuple
 from typing import Callable, Generic, Iterable, Optional, TypeVar, Union, cast, overload
 
 import triton
+import triton.runtime.jit
 
 from .compiler import compile
 
@@ -147,7 +151,7 @@ class KernelInterface(Generic[T]):
     return cast(T, functools.partial(cast(Callable, self.run), grid=grid))
 
 
-class JITFunction(KernelInterface[T]):
+class JITFunction(triton.runtime.jit.JITFunction):
 
   # Hook for inspecting compiled functions and modules
   cache_hook = None

--- a/test/python/dialects/triton/jit.py
+++ b/test/python/dialects/triton/jit.py
@@ -30,6 +30,28 @@ def addptr_scalar():
   print(X)
 
 
+@jit
+def times_two(x):
+  return x + x
+
+
+# CHECK-LABEL: TEST: call_other_kernel
+@run
+def call_other_kernel():
+
+  @jit
+  def kernel(ptr):
+    x = tl.load(ptr)
+    x = times_two(x)
+    tl.store(ptr, x)
+
+  X = torch.tensor([21], dtype=torch.int32)
+  kernel[(1,)](X)
+
+  # CHECK-NEXT: tensor([42], dtype=torch.int32)
+  print(X)
+
+
 # CHECK-LABEL: TEST: load_store_scalar
 @run
 def load_store_scalar():


### PR DESCRIPTION
It is possible in Triton to call a jitted function from other jitted function. In this case, the called function seems to be pulled into the MLIR module of the calling function. To do that, the AST visitor does an `isinstance(JITFunction)` test. However, before this commit, that test failed because the `JITFunction` we use in our copied code is a different Python class than the one that is tested for with the same name. This commit thus changes the copied code such that that class inherits from the original one (and then overwrites all of its content).