### PR TITLE
[CI] Make sure failing benchmark test fail CI and fix current issue.

### DIFF
--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -105,6 +105,7 @@ jobs:
         cmake --build ${STRUCTURED_MAIN_BINARY_DIR} --target check-structured
 
     - name: Run benchmarks
+      shell: bash # This enables the `-eo pipefail` flag to propagate script failures.
       run: |
         ${GITHUB_WORKSPACE}/sandbox/benchmarks/inner_product/run.sh test | tee /tmp/result.jsonl
         ${GITHUB_WORKSPACE}/sandbox/benchmarks/inner_product/plot.sh -i /tmp/result.jsonl

--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -21,6 +21,8 @@ jobs:
         echo "STRUCTURED_MAIN_SRC_DIR=${GITHUB_WORKSPACE}/sandbox" | tee -a $GITHUB_ENV
         echo "STRUCTURED_MAIN_BINARY_DIR=${GITHUB_WORKSPACE}/sandbox/build" | tee -a $GITHUB_ENV
         echo "LLVM_SYSPATH=${GITHUB_WORKSPACE}/sandbox/build" | tee -a $GITHUB_ENV
+        echo "MLIR_RUNNER_UTILS_LIB=${GITHUB_WORKSPACE}/sandbox/build/lib/libmlir_runner_utils.so" | tee -a $GITHUB_ENV
+        echo "MLIR_C_RUNNER_UTILS_LIB=${GITHUB_WORKSPACE}/sandbox/build/lib/libmlir_c_runner_utils.so" | tee -a $GITHUB_ENV
 
     - name: Free disk space
       uses: jlumbroso/free-disk-space@76866dbe54312617f00798d1762df7f43def6e5c # v1.2.0

--- a/benchmarks/inner_product/run.py
+++ b/benchmarks/inner_product/run.py
@@ -277,10 +277,12 @@ class IteratorsMethod(Method):
 
 
 # Registry of methods that can be benchmarked.
-METHODS = {cls.name: cls for cls in [
-    IteratorsMethod,
-    NumpyMethod,
-]}
+METHODS = {
+    cls.name: cls for cls in [
+        IteratorsMethod,
+        NumpyMethod,
+    ]
+}
 
 
 def parse_args():

--- a/benchmarks/inner_product/run.py
+++ b/benchmarks/inner_product/run.py
@@ -18,8 +18,6 @@ from mlir_structured.dialects import arith, func, memref, scf
 from mlir_structured.execution_engine import ExecutionEngine
 from mlir_structured.ir import (
     Context,  # (Comment preserves formatting.)
-    DictAttr,
-    IndexType,
     IntegerType,
     InsertionPoint,
     Location,


### PR DESCRIPTION
One command in the CI step that test the benchmarks uses a pipe. Without the `-eo pipefail` options, the exit code of a pipe statement is that of the last of the commands, which means that failures in the previous commands pass unnoticed. This actually happened for that CI step, which has been failing for a long time.