### PR TITLE
[CI] Upgrade Python version from 3.9 to 3.11.

### DIFF
--- a/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
+++ b/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Checkout project
       uses: actions/checkout@v3

--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@13ae5bb136fac2878aff31522b9efb785519f984 # v4.3.0
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Checkout project
       uses: actions/checkout@v3


### PR DESCRIPTION
Among other things, this enables the `|` for types, which is useful for some type annotations that I might use. I also believe that the example of the indexing dialect uses some features that are not yet available in Python v3.9.