### PR TITLE
[CMake] Change definition order of conversion tablegen targets.

### DIFF
--- a/include/structured/Conversion/CMakeLists.txt
+++ b/include/structured/Conversion/CMakeLists.txt
@@ -1,9 +1,3 @@
-set(LLVM_TARGET_DEFINITIONS Passes.td)
-mlir_tablegen(Passes.h.inc -gen-pass-decls -name StructuredConversion)
-mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix StructuredConversion)
-mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix StructuredConversion)
-add_public_tablegen_target(MLIRStructuredConversionIncGen)
-
 set(LLVM_TARGET_DEFINITIONS TritonConversions.td)
 mlir_tablegen(TritonConversions.h.inc -gen-pass-decls -name TritonConversion)
 mlir_tablegen(TritonConversions.capi.h.inc -gen-pass-capi-header --prefix TritonConversion)
@@ -14,3 +8,10 @@ set(LLVM_TARGET_DEFINITIONS TritonTransforms.td)
 mlir_tablegen(TritonTransforms.capi.h.inc -gen-pass-capi-header --prefix TritonTransform)
 mlir_tablegen(TritonTransforms.capi.cpp.inc -gen-pass-capi-impl --prefix TritonTransform)
 add_public_tablegen_target(MLIRTritonTransformIncGen)
+
+# This is last such that (implicitly) depends on the previous two.
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name StructuredConversion)
+mlir_tablegen(Passes.capi.h.inc -gen-pass-capi-header --prefix StructuredConversion)
+mlir_tablegen(Passes.capi.cpp.inc -gen-pass-capi-impl --prefix StructuredConversion)
+add_public_tablegen_target(MLIRStructuredConversionIncGen)


### PR DESCRIPTION
Previously, we were missing a dependency from various uses of the Triton-related tablegen files to the targets that produce them. To add them, it is sufficient to change the order of the conversion tablegen targets of this project. Curiously, the way to define these targets with add_public_tablegen_target implicitly creates a dependencie of the new target to the previous targets defined previously (in that file?). We thus define the target MLIRStructuredConversionIncGen last such that all targets already depending on it now also depend on the Triton-related ones.