### PR TITLE
[Triton] Use ConvertOpToLLVMPattern where appropriate.

### DIFF
--- a/include/structured/Conversion/TritonToLLVM/TritonToLLVM.h
+++ b/include/structured/Conversion/TritonToLLVM/TritonToLLVM.h
@@ -16,11 +16,11 @@ class ModuleOp;
 template <typename T>
 class OperationPass;
 class RewritePatternSet;
-class TypeConverter;
+class LLVMTypeConverter;
 
 /// Populate the given list with patterns that convert from Triton to LLVM.
 void populateTritonToLLVMConversionPatterns(RewritePatternSet &patterns,
-                                            TypeConverter &typeConverter);
+                                            LLVMTypeConverter &typeConverter);
 
 /// Create a pass to convert Triton operations to the LLVM dialect.
 std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonToLLVMPass();


### PR DESCRIPTION
In ConvertTritonToLLVM, some patterns need to deal with types that get converted to LLVM. This PR turns these patterns into ConvertOpToLLVMPatterns, which makes the LLVMTypeConverter available there (instead of the TypeConverter base). While this isn't used in the implementations yet, #767 will require it, plus, I believe that this distinction makes sense even conceptually.