### PR TITLE
[Triton] Add missing improvement to #767. (NFC)

### DIFF
--- a/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
+++ b/lib/Conversion/TritonToLLVM/TritonToLLVM.cpp
@@ -82,9 +82,7 @@ struct AddPtrOpConversion : public ConvertOpToLLVMPattern<triton::AddPtrOp> {
              "expected int, float, or pointer as pointee types");
 
       // Compute element size in bytes.
-      uint32_t pointerBitwidth =
-          reinterpret_cast<LLVMTypeConverter *>(typeConverter)
-              ->getPointerBitwidth();
+      uint32_t pointerBitwidth = getTypeConverter()->getPointerBitwidth();
       uint32_t elementBitWidth = llvmElementType.isIntOrFloat()
                                      ? llvmElementType.getIntOrFloatBitWidth()
                                      : pointerBitwidth;


### PR DESCRIPTION
This was the whole reason to do #768, the introduction of ConvertOpToLLVMPattern; I just forgot to amend the commit before pushing and merging it.