### PR TITLE
[LLVM] Update submodule to latest version from Feb. 15 (e769fb86).

### DIFF
--- a/benchmarks/inner_product/iterators.mlir
+++ b/benchmarks/inner_product/iterators.mlir
@@ -48,7 +48,7 @@ func.func private @sum_float(%lhs : !float_type, %rhs : !float_type) -> !float_t
 // Main program.
 //
 func.func @main(%input: !tabular.tabular_view<!element_type,!element_type>,
-                %output: !llvm.ptr<!element_type>)
+                %output: !llvm.ptr)
     attributes { llvm.emit_c_interface } {
   %stream = iterators.tabular_view_to_stream %input
     to !iterators.stream<!tuple_type>
@@ -57,6 +57,6 @@ func.func @main(%input: !tabular.tabular_view<!element_type,!element_type>,
   %reduced = "iterators.reduce"(%summed) {reduceFuncRef = @sum_int}
     : (!iterators.stream<!element_type>) -> (!iterators.stream<!element_type>)
   %result:2 = iterators.stream_to_value %reduced : !iterators.stream<!element_type>
-  llvm.store %result#0, %output : !llvm.ptr<!element_type>
+  llvm.store %result#0, %output : !element_type, !llvm.ptr
   return
 }

--- a/include/structured/Conversion/TabularToLLVM/TabularToLLVM.h
+++ b/include/structured/Conversion/TabularToLLVM/TabularToLLVM.h
@@ -24,14 +24,14 @@ namespace tabular {
 /// Maps types from the Tabular dialect to corresponding types in LLVM.
 class TabularTypeConverter : public TypeConverter {
 public:
-  TabularTypeConverter(LLVMTypeConverter &llvmTypeConverter);
+  TabularTypeConverter(LLVMTypeConverter *llvmTypeConverter);
 
   /// Maps a TabularViewType to an LLVMStruct of pointers, i.e., to a "struct of
   /// arrays".
   static std::optional<Type> convertTabularViewType(Type type);
 
 private:
-  LLVMTypeConverter llvmTypeConverter;
+  LLVMTypeConverter *llvmTypeConverter;
 };
 
 /// Populate the given list with patterns that convert from Tabular to LLVM.

--- a/lib/Conversion/StatesToLLVM/StatesToLLVM.cpp
+++ b/lib/Conversion/StatesToLLVM/StatesToLLVM.cpp
@@ -12,7 +12,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/FuncConversions.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Transforms/DialectConversion.h"
 #include "structured/Dialect/Iterators/IR/Iterators.h"

--- a/lib/Dialect/Iterators/IR/Iterators.cpp
+++ b/lib/Dialect/Iterators/IR/Iterators.cpp
@@ -83,7 +83,8 @@ LogicalResult ExtractValueOp::inferReturnTypes(
     DictionaryAttr attributes, OpaqueProperties properties, RegionRange regions,
     SmallVectorImpl<Type> &inferredReturnTypes) {
   auto stateType = operands[0].getType().cast<StateType>();
-  auto indexAttr = attributes.getAs<IntegerAttr>("index");
+  auto typedProperties = properties.as<ExtractValueOp::Properties *>();
+  auto indexAttr = typedProperties->getIndex();
   int64_t index = indexAttr.getValue().getSExtValue();
   Type fieldType = stateType.getFieldTypes()[index];
   inferredReturnTypes.assign({fieldType});

--- a/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
+++ b/lib/Dialect/Iterators/Transforms/DecomposeIteratorStates.cpp
@@ -11,7 +11,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Func/Transforms/OneToNFuncConversions.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/OneToNTypeConversion.h"

--- a/lib/Dialect/Tuple/Transforms/DecomposeTuples.cpp
+++ b/lib/Dialect/Tuple/Transforms/DecomposeTuples.cpp
@@ -9,7 +9,7 @@
 #include "structured/Dialect/Tuple/Transforms/DecomposeTuples.h"
 
 #include "mlir/Dialect/Func/Transforms/OneToNFuncConversions.h"
-#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/Transforms/Patterns.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/OneToNTypeConversion.h"
 #include "structured/Dialect/Tuple/IR/Tuple.h"

--- a/python/mlir_structured/dialects/IteratorsOps.td
+++ b/python/mlir_structured/dialects/IteratorsOps.td
@@ -7,7 +7,6 @@
 #ifndef PYTHON_BINDINGS_ITERATORS_OPS
 #define PYTHON_BINDINGS_ITERATORS_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "structured/Dialect/Iterators/IR/IteratorsOps.td"
 
 #endif // PYTHON_BINDINGS_ITERATORS_OPS

--- a/python/mlir_structured/dialects/TabularOps.td
+++ b/python/mlir_structured/dialects/TabularOps.td
@@ -7,7 +7,6 @@
 #ifndef PYTHON_BINDINGS_TABULAR_OPS
 #define PYTHON_BINDINGS_TABULAR_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "structured/Dialect/Tabular/IR/TabularOps.td"
 
 #endif // PYTHON_BINDINGS_TABULAR_OPS

--- a/python/mlir_structured/dialects/TupleOps.td
+++ b/python/mlir_structured/dialects/TupleOps.td
@@ -7,7 +7,6 @@
 #ifndef PYTHON_BINDINGS_TUPLE_OPS
 #define PYTHON_BINDINGS_TUPLE_OPS
 
-include "mlir/Bindings/Python/Attributes.td"
 include "structured/Dialect/Tuple/IR/TupleOps.td"
 
 #endif // PYTHON_BINDINGS_TUPLE_OPS

--- a/test/Conversion/IteratorsToLLVM/printconstant.mlir
+++ b/test/Conversion/IteratorsToLLVM/printconstant.mlir
@@ -18,7 +18,7 @@ func.func @main() {
   // CHECK-DAG:      %[[V6:.*]] = llvm.getelementptr %[[V4]][0] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-DAG:      %[[V7:.*]] = tuple.to_elements %[[V3]] : tuple<i32>
   // CHECK-DAG:      %[[Vb:.*]] = arith.extui %[[V7]] : i32 to i64
-  // CHECK-NEXT:     %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[Vb]]) : (!llvm.ptr, i64) -> i32
+  // CHECK-NEXT:     %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[Vb]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i64) -> i32
 
   %three_field_tuple = "iterators.constanttuple"() { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
   // CHECK-DAG:      %[[V5:.*]] = arith.constant 1 : i32

--- a/test/Conversion/IteratorsToLLVM/sink.mlir
+++ b/test/Conversion/IteratorsToLLVM/sink.mlir
@@ -15,13 +15,13 @@ func.func @main() {
   // CHECK-DAG:       %[[V6:.*]] = llvm.getelementptr %[[V4]][0] : (!llvm.ptr) -> !llvm.ptr, i8
   // CHECK-DAG:       %[[V7:.*]] = tuple.to_elements %[[arg2:.*]] : tuple<i32>
   // CHECK-DAG:       %[[V9:.*]] = arith.extui %[[V7]] : i32 to i64
-  // CHECK-NEXT:      %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[V9]]) : (!llvm.ptr, i64) -> i32
+  // CHECK-NEXT:      %[[V8:.*]] = llvm.call @printf(%[[V6]], %[[V9]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr, i64) -> i32
   // CHECK-NEXT:      scf.yield %[[arg1]] : [[rootStateType]]
   // CHECK-NEXT:    }
   // CHECK-NEXT:    %[[V3:.*]] = call @[[rootIteratorName]].close.{{[0-9]+}}(%[[V2]]#0) : ([[rootStateType]]) -> [[rootStateType]]
   // CHECK-DAG:     %[[Va:.*]] = llvm.mlir.addressof @iterators.frmt_spec.0 : !llvm.ptr
   // CHECK-DAG:     %[[Vc:.*]] = llvm.getelementptr %[[Va]][0] : (!llvm.ptr) -> !llvm.ptr, i8
-  // CHECK-NEXT:    %[[Vd:.*]] = llvm.call @printf(%[[Vc]]) : (!llvm.ptr) -> i32
+  // CHECK-NEXT:    %[[Vd:.*]] = llvm.call @printf(%[[Vc]]) vararg(!llvm.func<i32 (ptr, ...)>) : (!llvm.ptr) -> i32
   return
   // CHECK-NEXT:   return
 }

--- a/test/Dialect/Iterators/constant-stream.mlir
+++ b/test/Dialect/Iterators/constant-stream.mlir
@@ -5,16 +5,16 @@ func.func @main() {
 // CHECK-LABEL: func.func @main() {
   %empty = "iterators.constantstream"() { value = [] } :
                () -> (!iterators.stream<tuple<i32>>)
-// CHECK-NEXT:    %[[V0:constantstream.*]] = "iterators.constantstream"() {value = []} : () -> !iterators.stream<tuple<i32>>
+// CHECK-NEXT:    %[[V0:constantstream.*]] = "iterators.constantstream"() <{value = []}> : () -> !iterators.stream<tuple<i32>>
   %i32 = "iterators.constantstream"() { value = [[42 : i32]] } :
              () -> (!iterators.stream<tuple<i32>>)
-// CHECK-NEXT:    %[[V1:constantstream.*]] = "iterators.constantstream"() {value = {{\[}}[42 : i32]]} : () -> !iterators.stream<tuple<i32>>
+// CHECK-NEXT:    %[[V1:constantstream.*]] = "iterators.constantstream"() <{value = {{\[}}[42 : i32]]}> : () -> !iterators.stream<tuple<i32>>
   %f32 = "iterators.constantstream"() { value = [[42. : f32]] } :
              () -> (!iterators.stream<tuple<f32>>)
-// CHECK-NEXT:    %[[V2:constantstream.*]] = "iterators.constantstream"() {value = {{\[}}[4.200000e+01 : f32]]} : () -> !iterators.stream<tuple<f32>>
+// CHECK-NEXT:    %[[V2:constantstream.*]] = "iterators.constantstream"() <{value = {{\[}}[4.200000e+01 : f32]]}> : () -> !iterators.stream<tuple<f32>>
   %i32i64 = "iterators.constantstream"() { value = [[42 : i32, 1337 : i64]] } :
                 () -> (!iterators.stream<tuple<i32, i64>>)
-// CHECK-NEXT:    %[[V3:constantstream.*]] = "iterators.constantstream"() {value = {{\[}}[42 : i32, 1337]]} : () -> !iterators.stream<tuple<i32, i64>>
+// CHECK-NEXT:    %[[V3:constantstream.*]] = "iterators.constantstream"() <{value = {{\[}}[42 : i32, 1337]]}> : () -> !iterators.stream<tuple<i32, i64>>
   return
 // CHECK-NEXT:    return
 }

--- a/test/Dialect/Iterators/constant.mlir
+++ b/test/Dialect/Iterators/constant.mlir
@@ -4,13 +4,13 @@
 func.func @main() {
 // CHECK-LABEL: func.func @main() {
   %empty_tuple = "iterators.constanttuple"() { values = [] } : () -> tuple<>
-// CHECK-NEXT:    %[[V0:tuple.*]] = "iterators.constanttuple"() {values = []} : () -> tuple<>
+// CHECK-NEXT:    %[[V0:tuple.*]] = "iterators.constanttuple"() <{values = []}> : () -> tuple<>
   %one_field_tuple = "iterators.constanttuple"()
       { values = [1 : i32] } : () -> tuple<i32>
-// CHECK-NEXT:    %[[V0:tuple.*]] = "iterators.constanttuple"() {values = [1 : i32]} : () -> tuple<i32>
+// CHECK-NEXT:    %[[V0:tuple.*]] = "iterators.constanttuple"() <{values = [1 : i32]}> : () -> tuple<i32>
   %three_field_tuple = "iterators.constanttuple"()
       { values = [1 : i32, 2 : i32, 3 : i32] } : () -> tuple<i32, i32, i32>
-// CHECK-NEXT:    %[[V0:tuple.*]] = "iterators.constanttuple"() {values = [1 : i32, 2 : i32, 3 : i32]} : () -> tuple<i32, i32, i32>
+// CHECK-NEXT:    %[[V0:tuple.*]] = "iterators.constanttuple"() <{values = [1 : i32, 2 : i32, 3 : i32]}> : () -> tuple<i32, i32, i32>
   return
 // CHECK-NEXT:    return
 }

--- a/test/Dialect/Iterators/filter.mlir
+++ b/test/Dialect/Iterators/filter.mlir
@@ -17,7 +17,7 @@ func.func @main() {
   %filtered = "iterators.filter"(%input) {predicateRef = @is_positive_tuple} :
                   (!iterators.stream<tuple<i32>>) ->
                       (!iterators.stream<tuple<i32>>)
-// CHECK-NEXT:    %[[V1:filtered.*]] = "iterators.filter"(%[[V0]]) {predicateRef = @is_positive_tuple} : (!iterators.stream<tuple<i32>>) -> !iterators.stream<tuple<i32>>
+// CHECK-NEXT:    %[[V1:filtered.*]] = "iterators.filter"(%[[V0]]) <{predicateRef = @is_positive_tuple}> : (!iterators.stream<tuple<i32>>) -> !iterators.stream<tuple<i32>>
   return
 // CHECK-NEXT:    return
 }

--- a/test/Dialect/Iterators/map.mlir
+++ b/test/Dialect/Iterators/map.mlir
@@ -13,7 +13,7 @@ func.func @main() {
 // CHECK-NEXT:    %[[V0:.*]] = "iterators.constantstream"{{.*}}
   %unpacked = "iterators.map"(%input) {mapFuncRef = @unpack_i32} :
                   (!iterators.stream<tuple<i32>>) -> (!iterators.stream<i32>)
-// CHECK-NEXT:    %[[V1:mapped.*]] = "iterators.map"(%[[V0]]) {mapFuncRef = @unpack_i32} : (!iterators.stream<tuple<i32>>) -> !iterators.stream<i32>
+// CHECK-NEXT:    %[[V1:mapped.*]] = "iterators.map"(%[[V0]]) <{mapFuncRef = @unpack_i32}> : (!iterators.stream<tuple<i32>>) -> !iterators.stream<i32>
   return
 // CHECK-NEXT:    return
 }

--- a/test/Dialect/Iterators/reduce.mlir
+++ b/test/Dialect/Iterators/reduce.mlir
@@ -17,7 +17,7 @@ func.func @main() {
   %reduced = "iterators.reduce"(%input) {reduceFuncRef = @sum_tuple} :
                  (!iterators.stream<tuple<i32>>) ->
                      (!iterators.stream<tuple<i32>>)
-// CHECK-NEXT:    %[[V1:reduced.*]] = "iterators.reduce"(%[[V0]]) {reduceFuncRef = @sum_tuple} : (!iterators.stream<tuple<i32>>) -> !iterators.stream<tuple<i32>>
+// CHECK-NEXT:    %[[V1:reduced.*]] = "iterators.reduce"(%[[V0]]) <{reduceFuncRef = @sum_tuple}> : (!iterators.stream<tuple<i32>>) -> !iterators.stream<tuple<i32>>
   return
 // CHECK-NEXT:    return
 }

--- a/test/python/dialects/iterators/dialect.py
+++ b/test/python/dialects/iterators/dialect.py
@@ -40,7 +40,7 @@ def testParse():
       '%0 = "iterators.constantstream"() {value = []} : () -> (!iterators.stream<tuple<i32>>)'
   )
   # CHECK:      module {
-  # CHECK-NEXT:   %[[V0:.*]] = "iterators.constantstream"() {value = []} : () -> !iterators.stream<tuple<i32>>
+  # CHECK-NEXT:   %[[V0:.*]] = "iterators.constantstream"() <{value = []}> : () -> !iterators.stream<tuple<i32>>
   # CHECK-NEXT: }
   print(mod)
 

--- a/tools/structured-opt/structured-opt.cpp
+++ b/tools/structured-opt/structured-opt.cpp
@@ -48,7 +48,6 @@ int main(int argc, char **argv) {
   llvm::sys::PrintStackTraceOnErrorSignal(executable);
 #endif
 
-  llvm::InitLLVM y(argc, argv);
   registerAllPasses();
   registerStructuredConversionPasses();
   registerIteratorsPasses();


### PR DESCRIPTION
This PR depends on and, therefor, includes #793 (which removes the indexing dialect).

~~The PR is still missing changes to make the indexing dialect work with the upstream changes:~~

- [x] Make indexing dialect work. @makslevental Could you take a look?