### PR TITLE
[Substrait] Add Substrait dialect stub.

### DIFF
--- a/include/structured/Dialect/CMakeLists.txt
+++ b/include/structured/Dialect/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Iterators)
+add_subdirectory(Substrait)
 add_subdirectory(Tabular)
 add_subdirectory(Tuple)

--- a/include/structured/Dialect/Substrait/CMakeLists.txt
+++ b/include/structured/Dialect/Substrait/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/include/structured/Dialect/Substrait/IR/CMakeLists.txt
+++ b/include/structured/Dialect/Substrait/IR/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_mlir_dialect(SubstraitOps substrait)
+add_dependencies(MLIRSubstraitDialect MLIRSubstraitOpsIncGen)
+
+add_dependencies(mlir-headers
+  MLIRSubstraitOpsIncGen
+)

--- a/include/structured/Dialect/Substrait/IR/Substrait.h
+++ b/include/structured/Dialect/Substrait/IR/Substrait.h
@@ -1,0 +1,26 @@
+//===-- Substrait.h - Substrait dialect -------------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef STRUCTURED_DIALECT_SUBSTRAIT_IR_SUBSTRAIT_H
+#define STRUCTURED_DIALECT_SUBSTRAIT_IR_SUBSTRAIT_H
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"         // IWYU: keep
+#include "mlir/IR/Dialect.h"                      // IWYU: keep
+#include "mlir/IR/OpImplementation.h"             // IWYU: keep
+#include "mlir/IR/SymbolTable.h"                  // IWYU: keep
+#include "mlir/Interfaces/InferTypeOpInterface.h" // IWYU: keep
+
+#include "structured/Dialect/Substrait/IR/SubstraitOpsDialect.h.inc" // IWYU: export
+
+#define GET_TYPEDEF_CLASSES
+#include "structured/Dialect/Substrait/IR/SubstraitOpsTypes.h.inc" // IWYU: export
+
+#define GET_OP_CLASSES
+#include "structured/Dialect/Substrait/IR/SubstraitOps.h.inc" // IWYU: export
+
+#endif // STRUCTURED_DIALECT_SUBSTRAIT_IR_SUBSTRAIT_H

--- a/include/structured/Dialect/Substrait/IR/SubstraitDialect.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitDialect.td
@@ -1,0 +1,32 @@
+//===-- SubstraitDialect.td - Substrait dialect ------------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITDIALECT
+#define SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITDIALECT
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// Dialect definition
+//===----------------------------------------------------------------------===//
+
+def Substrait_Dialect : Dialect {
+  let name = "substrait";
+  let cppNamespace = "::mlir::substrait";
+  let summary = "Dialect for representing Substrait plans in MLIR.";
+  let description = [{
+    This dialect is intented to represent [Substrait](https://substrait.io/)
+    query plans for relational algebra in MLIR. This may be useful for both
+    producers and consumers, which may use this dialect as a result or input
+    dialect of an MLIR-based pipeline, respectively, or for implementing
+    rewrites on Substrait that optimize or legalize plans between existing
+    Substraits producers and consumers.
+  }];
+}
+
+#endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITDIALECT

--- a/include/structured/Dialect/Substrait/IR/SubstraitDialect.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitDialect.td
@@ -26,6 +26,13 @@ def Substrait_Dialect : Dialect {
     dialect of an MLIR-based pipeline, respectively, or for implementing
     rewrites on Substrait that optimize or legalize plans between existing
     Substraits producers and consumers.
+
+    The ops and types in this dialect have an approximate one-to-one
+    correspondance with the specification and the
+    [protobuf](https://github.com/substrait-io/substrait/tree/main/proto/substrait)
+    message types. The correspondance is only approximate since it is often
+    more natural in MLIR to represent several message types as a single op and
+    express message sub-types with interfaces instead.
   }];
 }
 

--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -42,6 +42,10 @@ class AnyOf<list<Constraint> opTypes, string summary = ""> : Constraint<
 //===----------------------------------------------------------------------===//
 // Plan
 //===----------------------------------------------------------------------===//
+// The definitions in this section are related to the top-level `Plan` message.
+// See https://substrait.io/serialization/binary_serialization/ and
+// https://github.com/substrait-io/substrait/blob/main/proto/substrait/plan.proto.
+//===----------------------------------------------------------------------===//
 
 def PlanBodyOp : AnyOf<[
     IsOp<"::mlir::substrait::PlanRelOp">

--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -1,0 +1,96 @@
+//===-- SubstraitOps.td - Substrait operations definitions -*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITOPS
+#define SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITOPS
+
+include "structured/Dialect/Substrait/IR/SubstraitDialect.td"
+include "structured/Dialect/Substrait/IR/SubstraitTypes.td"
+include "mlir/IR/CommonAttrConstraints.td"
+include "mlir/IR/OpBase.td"
+
+class Substrait_Op<string mnemonic, list<Trait> traits = []> :
+  Op<Substrait_Dialect, mnemonic, traits> {
+}
+
+//===----------------------------------------------------------------------===//
+// Constraints
+//===----------------------------------------------------------------------===//
+
+class RegionOf<Constraint condition> : Region<
+  Concat<"::llvm::all_of($_self.getOps(), [](::mlir::Operation &op) { "
+         "return ",
+         SubstLeaves<"$_self", "op", condition.predicate>,
+         "; })">,
+  "region where each child op is " # condition.summary>;
+
+class IsOp<string opType> : Constraint<
+  CPred<"::llvm::isa<" # opType # ">($_self)">,
+  "op of type '" # opType # "'">;
+
+class AnyOf<list<Constraint> opTypes, string summary = ""> : Constraint<
+  Or<!foreach(opType, opTypes, opType.predicate)>,
+     !if(!eq(summary, ""),
+        !interleave(!foreach(t, opTypes, t.summary), " or "),
+        summary)>;
+
+//===----------------------------------------------------------------------===//
+// Plan
+//===----------------------------------------------------------------------===//
+
+def PlanBodyOp : AnyOf<[
+    IsOp<"::mlir::substrait::PlanRelOp">
+  ]>;
+
+def Substrait_PlanOp : Substrait_Op<"plan", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    NoTerminator, NoRegionArguments, SingleBlock
+  ]> {
+  let summary = "Represents a Substrait plan";
+  let description = [{
+    This op represents the `Plan` message type of Substrait. It carries the
+    version information inline as attributes, so it also subsumes the `Version`
+    message type. The body of the op consists of the `relation`s and (once
+    implemented) the extensions and types as well as their URLs defined in the
+    plan.
+  }];
+  let arguments = (ins
+    UI32Attr:$major_number,
+    UI32Attr:$minor_number,
+    UI32Attr:$patch_number,
+    DefaultValuedAttr<StrAttr, "\"\"">:$git_hash,
+    DefaultValuedAttr<StrAttr, "\"\"">:$producer
+  );
+  let regions = (region RegionOf<PlanBodyOp>:$body);
+  let assemblyFormat = [{
+    `version` $major_number `:` $minor_number `:` $patch_number
+    (`git_hash` $git_hash^)? (`producer` $producer^)?
+    attr-dict-with-keyword $body
+  }];
+  let builders = [
+      OpBuilder<(ins "uint32_t":$major, "uint32_t":$minor, "uint32_t":$patch), [{
+        build($_builder, $_state, major, minor, patch,
+              StringAttr(), StringAttr());
+      }]>
+    ];
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    ::llvm::StringRef $cppClass::getDefaultDialect() {
+      return SubstraitDialect::getDialectNamespace();
+    }
+  }];
+}
+
+def Substrait_PlanRelOp : Substrait_Op<"relation", [
+    HasParent<"::mlir::substrait::PlanOp">
+  ]> {
+  let summary = "Represents the result of a Substrait plan";
+  let assemblyFormat = "attr-dict";
+}
+
+#endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITOPS

--- a/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
@@ -1,0 +1,24 @@
+//===-- SubstraitTypes.td - Substrait dialect types --------*- tablegen -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITTYPES
+#define SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITTYPES
+
+include "structured/Dialect/Substrait/IR/SubstraitDialect.td"
+include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/OpBase.td"
+
+// Base class for Substrait dialect types.
+class Substrait_Type<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<Substrait_Dialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+#endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITTYPES

--- a/lib/Dialect/CMakeLists.txt
+++ b/lib/Dialect/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(Iterators)
+add_subdirectory(Substrait)
 add_subdirectory(Tabular)
 add_subdirectory(Tuple)

--- a/lib/Dialect/Substrait/CMakeLists.txt
+++ b/lib/Dialect/Substrait/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(IR)

--- a/lib/Dialect/Substrait/IR/CMakeLists.txt
+++ b/lib/Dialect/Substrait/IR/CMakeLists.txt
@@ -1,0 +1,9 @@
+add_mlir_dialect_library(MLIRSubstraitDialect
+  Substrait.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+
+  DEPENDS
+  MLIRTabularOpsIncGen
+)

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -1,0 +1,48 @@
+//===-- Substrait.cpp - Substrait dialect -----------------------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "structured/Dialect/Substrait/IR/Substrait.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/Support/LogicalResult.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace mlir::substrait;
+
+//===----------------------------------------------------------------------===//
+// Substrait dialect
+//===----------------------------------------------------------------------===//
+
+#include "structured/Dialect/Substrait/IR/SubstraitOpsDialect.cpp.inc"
+
+void SubstraitDialect::initialize() {
+#define GET_OP_LIST
+  addOperations<
+#include "structured/Dialect/Substrait/IR/SubstraitOps.cpp.inc"
+      >();
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "structured/Dialect/Substrait/IR/SubstraitOpsTypes.cpp.inc"
+      >();
+}
+
+//===----------------------------------------------------------------------===//
+// Substrait operations
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "structured/Dialect/Substrait/IR/SubstraitOps.cpp.inc"
+
+//===----------------------------------------------------------------------===//
+// Substrait types
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "structured/Dialect/Substrait/IR/SubstraitOpsTypes.cpp.inc"

--- a/test/Dialect/Substrait/plan-version.mlir
+++ b/test/Dialect/Substrait/plan-version.mlir
@@ -1,0 +1,31 @@
+// RUN: structured-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK:      substrait.plan version 0 : 42 : 1
+// CHECK-SAME:   git_hash "hash" producer "producer" {
+// CHECK-NEXT: }
+substrait.plan
+  version 0 : 42 : 1
+  git_hash "hash"
+  producer "producer"
+  {}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK-NEXT: }
+substrait.plan version 0 : 42 : 1 {
+  relation
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK-NEXT:   relation
+// CHECK-NEXT: }
+substrait.plan version 0 : 42 : 1 {
+  relation
+  relation
+}

--- a/tools/structured-lsp-server/structured-lsp-server.cpp
+++ b/tools/structured-lsp-server/structured-lsp-server.cpp
@@ -43,11 +43,7 @@ static void registerIteratorDialects(DialectRegistry &registry) {
 }
 
 static void registerSubstraitDialects(DialectRegistry &registry) {
-  registry.insert<
-      // clang-format off
-      mlir::substrait::SubstraitDialect
-      // clang-format on
-      >();
+  registry.insert<mlir::substrait::SubstraitDialect>();
 }
 
 int main(int argc, char **argv) {

--- a/tools/structured-lsp-server/structured-lsp-server.cpp
+++ b/tools/structured-lsp-server/structured-lsp-server.cpp
@@ -23,6 +23,7 @@
 #include "structured/Conversion/Passes.h"
 #include "structured/Dialect/Iterators/IR/Iterators.h"
 #include "structured/Dialect/Iterators/Transforms/Passes.h"
+#include "structured/Dialect/Substrait/IR/Substrait.h"
 #include "structured/Dialect/Tabular/IR/Tabular.h"
 #include "structured/Dialect/Tuple/IR/Tuple.h"
 #include "structured/Dialect/Tuple/Transforms/Passes.h"
@@ -37,6 +38,14 @@ static void registerIteratorDialects(DialectRegistry &registry) {
       mlir::iterators::IteratorsDialect,
       mlir::tabular::TabularDialect,
       mlir::tuple::TupleDialect
+      // clang-format on
+      >();
+}
+
+static void registerSubstraitDialects(DialectRegistry &registry) {
+  registry.insert<
+      // clang-format off
+      mlir::substrait::SubstraitDialect
       // clang-format on
       >();
 }
@@ -57,6 +66,7 @@ int main(int argc, char **argv) {
   registerAllDialects(registry);
   registerAllExtensions(registry);
   registerIteratorDialects(registry);
+  registerSubstraitDialects(registry);
 
   return mlir::failed(mlir::MlirLspServerMain(argc, argv, registry));
 }

--- a/tools/structured-opt/structured-opt.cpp
+++ b/tools/structured-opt/structured-opt.cpp
@@ -43,11 +43,7 @@ static void registerIteratorDialects(DialectRegistry &registry) {
 }
 
 static void registerSubstraitDialects(DialectRegistry &registry) {
-  registry.insert<
-      // clang-format off
-      mlir::substrait::SubstraitDialect
-      // clang-format on
-      >();
+  registry.insert<mlir::substrait::SubstraitDialect>();
 }
 
 int main(int argc, char **argv) {

--- a/tools/structured-opt/structured-opt.cpp
+++ b/tools/structured-opt/structured-opt.cpp
@@ -19,6 +19,7 @@
 #include "structured/Conversion/Passes.h"
 #include "structured/Dialect/Iterators/IR/Iterators.h"
 #include "structured/Dialect/Iterators/Transforms/Passes.h"
+#include "structured/Dialect/Substrait/IR/Substrait.h"
 #include "structured/Dialect/Tabular/IR/Tabular.h"
 #include "structured/Dialect/Tuple/IR/Tuple.h"
 #include "structured/Dialect/Tuple/Transforms/Passes.h"
@@ -41,6 +42,14 @@ static void registerIteratorDialects(DialectRegistry &registry) {
       >();
 }
 
+static void registerSubstraitDialects(DialectRegistry &registry) {
+  registry.insert<
+      // clang-format off
+      mlir::substrait::SubstraitDialect
+      // clang-format on
+      >();
+}
+
 int main(int argc, char **argv) {
 #ifndef NDEBUG
   static std::string executable =
@@ -57,6 +66,7 @@ int main(int argc, char **argv) {
   registerAllDialects(registry);
   registerAllExtensions(registry);
   registerIteratorDialects(registry);
+  registerSubstraitDialects(registry);
 
   return failed(
       MlirOptMain(argc, argv, "MLIR modular optimizer driver\n", registry));


### PR DESCRIPTION
This PR adds an initial stub of a dialect for representing [Substrait](https://substrait.io/) plans. The initial stub essentially consists of implementing the [`Plan` protobuf message type](https://substrait.io/serialization/binary_serialization/) without support for extensions or types. This isn't particularly useful yet but puts the code structure in place.