### PR TITLE
[Substrait] Implement stub of structured-translate and Substrait target.

### DIFF
--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -35,6 +35,10 @@ jobs:
         path: sandbox/.git
         key: git-folder
 
+    - name: Install protobuf
+      run: |
+        sudo apt install -y protobuf-compiler libprotobuf-dev
+
     - name: Checkout project
       uses: actions/checkout@v3
       with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "experimental/iterators/third_party/llvm-project"]
 	path = third_party/llvm-project
 	url = https://github.com/llvm/llvm-project.git
+[submodule "third_party/substrait"]
+	path = third_party/substrait
+	url = https://github.com/substrait-io/substrait.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,15 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 endif()
 
 ################################################################################
+# Set up dependencies
+################################################################################
+
+# Required for Substrait. v3.6.1 provided by Ubuntu 20.04 did not work due to
+# an incompatibility with `-fno-rtti`, which LLVM uses, while v3.12.4 provided
+# by Ubuntu 22.04 worked. Possibly some versions inbetween work as well.
+find_package(Protobuf 3.12.0 REQUIRED)
+
+################################################################################
 # Set some variables
 ################################################################################
 set(MLIR_MAIN_SRC_DIR ${LLVM_MAIN_SRC_DIR}/../mlir)

--- a/include/structured/Target/SubstraitPB/Export.h
+++ b/include/structured/Target/SubstraitPB/Export.h
@@ -1,0 +1,26 @@
+//===-- Export.h - Export Substrait dialect to protobuf ---------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef STRUCTURED_TARGET_SUBSTRAITPB_EXPORT_H
+#define STRUCTURED_TARGET_SUBSTRAITPB_EXPORT_H
+
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir {
+class Operation;
+class LogicalResult;
+
+namespace substrait {
+
+LogicalResult translateSubstraitToProtobuf(Operation *op,
+                                           llvm::raw_ostream &output);
+
+} // namespace substrait
+} // namespace mlir
+
+#endif // STRUCTURED_TARGET_SUBSTRAITPB_EXPORT_H

--- a/include/structured/Target/SubstraitPB/Import.h
+++ b/include/structured/Target/SubstraitPB/Import.h
@@ -1,0 +1,29 @@
+//===-- Import.h - Import protobuf to Substrait dialect ---------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef STRUCTURED_TARGET_SUBSTRAITPB_IMPORT_H
+#define STRUCTURED_TARGET_SUBSTRAITPB_IMPORT_H
+
+#include "llvm/ADT/StringRef.h"
+
+namespace mlir {
+
+class MLIRContext;
+class ModuleOp;
+template <typename T>
+class OwningOpRef;
+
+namespace substrait {
+
+OwningOpRef<ModuleOp> translateProtobufToSubstrait(llvm::StringRef input,
+                                                   MLIRContext *context);
+
+} // namespace substrait
+} // namespace mlir
+
+#endif // STRUCTURED_TARGET_SUBSTRAITPB_IMPORT_H

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,6 @@
 add_subdirectory(CAPI)
 add_subdirectory(Conversion)
 add_subdirectory(Dialect)
+add_subdirectory(Target)
+add_subdirectory(ThirdParty)
 add_subdirectory(Utils)

--- a/lib/Target/CMakeLists.txt
+++ b/lib/Target/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(SubstraitPB)

--- a/lib/Target/SubstraitPB/CMakeLists.txt
+++ b/lib/Target/SubstraitPB/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_mlir_translation_library(MLIRTargetSubstraitPB
+  Export.cpp
+  Import.cpp
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRSubstraitDialect
+  MLIRSupport
+  MLIRTranslateLib
+  Substrait
+  )

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -1,0 +1,107 @@
+//===-- Export.cpp - Export Substrait dialect to protobuf -------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "structured/Target/SubstraitPB/Export.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LogicalResult.h"
+#include "structured/Dialect/Substrait/IR/Substrait.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#include <google/protobuf/text_format.h>
+#include <substrait/plan.pb.h>
+
+using namespace mlir;
+using namespace mlir::substrait;
+
+namespace pb = google::protobuf;
+
+namespace {
+
+// Forward declaration for the export function of the given operation type.
+//
+// We need one such function for most op type that we want to export. The
+// forward declarations are necessary such all export functions are available
+// for the definitions indepedently of the order of these definitions. The
+// `MESSAGE_TYPE` argument corresponds to the protobuf message type returned
+// by the function.
+#define DECLARE_EXPORT_FUNC(OP_TYPE, MESSAGE_TYPE)                             \
+  static FailureOr<std::unique_ptr<::substrait::MESSAGE_TYPE>>                 \
+  exportOperation(OP_TYPE op);
+
+DECLARE_EXPORT_FUNC(ModuleOp, Plan)
+DECLARE_EXPORT_FUNC(PlanOp, Plan)
+
+FailureOr<std::unique_ptr<::substrait::Plan>> exportOperation(ModuleOp op) {
+  if (!op->getAttrs().empty())
+    return failure();
+
+  if (op->getRegions().size() != 1)
+    return failure();
+
+  Region &body = op.getBodyRegion();
+  if (llvm::range_size(body.getOps()) != 1)
+    return failure();
+
+  if (auto plan = llvm::dyn_cast<PlanOp>(&*body.op_begin()))
+    return exportOperation(plan);
+
+  return failure();
+}
+
+FailureOr<std::unique_ptr<::substrait::Plan>> exportOperation(PlanOp op) {
+  // Build `Version` message.
+  auto version = std::make_unique<::substrait::Version>();
+  version->set_major_number(op.getMajorNumber());
+  version->set_minor_number(op.getMinorNumber());
+  version->set_patch_number(op.getPatchNumber());
+  version->set_producer(op.getProducer().str());
+  version->set_git_hash(op.getGitHash().str());
+
+  // Build `Plan` message.
+  auto plan = std::make_unique<::substrait::Plan>();
+  plan->set_allocated_version(version.release());
+
+  // TODO(ingomueller): build plan content once defined.
+
+  return std::move(plan);
+}
+
+FailureOr<std::unique_ptr<pb::Message>> exportOperation(Operation *op) {
+  return llvm::TypeSwitch<Operation *, FailureOr<std::unique_ptr<pb::Message>>>(
+             op)
+      .Case<ModuleOp, PlanOp>(
+          [&](auto op) -> FailureOr<std::unique_ptr<pb::Message>> {
+            auto typedMessage = exportOperation(op);
+            if (failed(typedMessage))
+              return failure();
+            return std::unique_ptr<pb::Message>(typedMessage.value().release());
+          })
+      .Default([](auto) { return failure(); });
+}
+
+} // namespace
+
+namespace mlir {
+namespace substrait {
+
+LogicalResult translateSubstraitToProtobuf(Operation *op,
+                                           llvm::raw_ostream &output) {
+  FailureOr<std::unique_ptr<pb::Message>> result = exportOperation(op);
+  if (failed(result))
+    return failure();
+
+  std::string out;
+  if (!pb::TextFormat::PrintToString(*result.value(), &out))
+    return failure();
+
+  output << out;
+  return success();
+}
+
+} // namespace substrait
+} // namespace mlir

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -40,9 +40,6 @@ FailureOr<std::unique_ptr<::substrait::Plan>> exportOperation(ModuleOp op) {
   if (!op->getAttrs().empty())
     return failure();
 
-  if (op->getRegions().size() != 1)
-    return failure();
-
   Region &body = op.getBodyRegion();
   if (llvm::range_size(body.getOps()) != 1)
     return failure();

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -1,0 +1,101 @@
+//===-- Import.cpp - Import protobuf to Substrait dialect -------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "structured/Target/SubstraitPB/Import.h"
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/OwningOpRef.h"
+#include "structured/Dialect/Substrait/IR/Substrait.h"
+
+#include <google/protobuf/text_format.h>
+#include <substrait/plan.pb.h>
+
+using namespace mlir;
+using namespace mlir::substrait;
+
+namespace pb = google::protobuf;
+
+namespace {
+
+// Forward declaration for the import function of the given message type.
+//
+// We need one such function for most message types that we want to import. The
+// forward declarations are necessary such all import functions are available
+// for the definitions indepedently of the order of these definitions. The
+// message type passed to the function (specified by `MESSAGE_TYPE`) may be
+// different than the one it is responsible for: often the target op type
+// (specified by `OP_TYPE`) depends on a nested field value (such as `oneof`)
+// but the import logic needs the whole context; the message that is passed in
+// is the most deeply nested message that provides the whole context.
+#define DECLARE_IMPORT_FUNC(MESSAGE_TYPE, ARG_TYPE, OP_TYPE)                   \
+  static FailureOr<OP_TYPE> import##MESSAGE_TYPE(                              \
+      ImplicitLocOpBuilder builder, const ::substrait::ARG_TYPE &message);
+
+DECLARE_IMPORT_FUNC(Plan, Plan, PlanOp)
+DECLARE_IMPORT_FUNC(PlanRel, PlanRel, PlanRelOp)
+
+static FailureOr<PlanOp> importPlan(ImplicitLocOpBuilder builder,
+                                    const ::substrait::Plan &message) {
+  const ::substrait::Version &version = message.version();
+  auto planOp = builder.create<PlanOp>(
+      version.major_number(), version.minor_number(), version.patch_number(),
+      version.git_hash(), version.producer());
+  planOp.getBody().push_back(new Block());
+
+  for (int i = 0; i < message.relations_size(); i++) {
+    OpBuilder::InsertionGuard insertGuard(builder);
+    builder.setInsertionPointToEnd(&planOp.getBody().front());
+    if (failed(importPlanRel(builder, message.relations(i))))
+      return failure();
+  }
+
+  return planOp;
+}
+
+static FailureOr<PlanRelOp> importPlanRel(ImplicitLocOpBuilder builder,
+                                          const ::substrait::PlanRel &message) {
+  switch (message.rel_type_case()) {
+  case ::substrait::PlanRel::RelTypeCase::kRel: {
+    auto planRelOp = builder.create<PlanRelOp>();
+    // TODO(ingomueller): import content once defined.
+    return planRelOp;
+  }
+  default:
+    return failure();
+  }
+}
+
+} // namespace
+
+namespace mlir {
+namespace substrait {
+
+OwningOpRef<ModuleOp> translateProtobufToSubstrait(llvm::StringRef input,
+                                                   MLIRContext *context) {
+  auto plan = std::make_unique<::substrait::Plan>();
+  if (!pb::TextFormat::ParseFromString(input.str(), plan.get()))
+    return {};
+
+  // XXX: Is this really the right way/place to do this?
+  context->loadDialect<SubstraitDialect>();
+
+  Location loc = UnknownLoc::get(context);
+  ImplicitLocOpBuilder builder(loc, context);
+  auto module = builder.create<ModuleOp>(loc);
+  auto moduleRef = OwningOpRef<ModuleOp>(module);
+  builder.setInsertionPointToEnd(&module.getBodyRegion().back());
+
+  if (failed(importPlan(builder, *plan)))
+    return {};
+
+  return moduleRef;
+}
+
+} // namespace substrait
+} // namespace mlir

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -48,10 +48,10 @@ static FailureOr<PlanOp> importPlan(ImplicitLocOpBuilder builder,
       version.git_hash(), version.producer());
   planOp.getBody().push_back(new Block());
 
-  for (int i = 0; i < message.relations_size(); i++) {
+  for (const auto &relation : message.relations()) {
     OpBuilder::InsertionGuard insertGuard(builder);
     builder.setInsertionPointToEnd(&planOp.getBody().front());
-    if (failed(importPlanRel(builder, message.relations(i))))
+    if (failed(importPlanRel(builder, relation)))
       return failure();
   }
 

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -82,7 +82,6 @@ OwningOpRef<ModuleOp> translateProtobufToSubstrait(llvm::StringRef input,
   if (!pb::TextFormat::ParseFromString(input.str(), plan.get()))
     return {};
 
-  // XXX: Is this really the right way/place to do this?
   context->loadDialect<SubstraitDialect>();
 
   Location loc = UnknownLoc::get(context);

--- a/lib/ThirdParty/CMakeLists.txt
+++ b/lib/ThirdParty/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Substrait)

--- a/lib/ThirdParty/Substrait/CMakeLists.txt
+++ b/lib/ThirdParty/Substrait/CMakeLists.txt
@@ -1,0 +1,59 @@
+set(SUBSTRAIT_ROOT_DIR ${STRUCTURED_MAIN_SRC_DIR}/third_party/substrait)
+set(SUBSTRAIT_PROTO_DIR ${SUBSTRAIT_ROOT_DIR}/proto)
+set(SUBSTRAIT_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+set(SUBSTRAIT_PROTO_NAMES
+  algebra
+  capabilities
+  extended_expression
+  extensions/extensions
+  function
+  parameterized_types
+  plan
+  type_expressions
+  type
+  )
+
+# Compute file paths.
+set(SUBSTRAIT_PROTO_FILES "")
+foreach(SUBSTRAIT_PROTO_NAME ${SUBSTRAIT_PROTO_NAMES})
+  list(APPEND SUBSTRAIT_PROTO_FILES
+       "${SUBSTRAIT_PROTO_DIR}/substrait/${SUBSTRAIT_PROTO_NAME}.proto")
+endforeach(SUBSTRAIT_PROTO_NAME ${SUBSTRAIT_PROTO_NAMES})
+
+# Add targets for each individual proto file.
+set(SUBSTRAIT_SOURCES "")
+set(SUBSTRAIT_HEADERS "")
+foreach(SUBSTRAIT_PROTO_NAME ${SUBSTRAIT_PROTO_NAMES})
+  set(SUBSTRAIT_SOURCE "${SUBSTRAIT_BINARY_DIR}/substrait/${SUBSTRAIT_PROTO_NAME}.pb.cc")
+  set(SUBSTRAIT_HEADER "${SUBSTRAIT_BINARY_DIR}/substrait/${SUBSTRAIT_PROTO_NAME}.pb.h")
+  set(SUBSTRAIT_PROTO_FILE "${SUBSTRAIT_PROTO_DIR}/substrait/${SUBSTRAIT_PROTO_NAME}.proto")
+  list(APPEND SUBSTRAIT_SOURCES ${SUBSTRAIT_SOURCE})
+  list(APPEND SUBSTRAIT_HEADERS ${SUBSTRAIT_HEADER})
+  add_custom_command(
+    OUTPUT
+    ${SUBSTRAIT_SOURCE}
+    ${SUBSTRAIT_HEADER}
+
+    COMMAND ${Protobuf_PROTOC_EXECUTABLE}
+    "-I${SUBSTRAIT_PROTO_DIR}"
+    "--cpp_out=${SUBSTRAIT_BINARY_DIR}"
+    "${SUBSTRAIT_PROTO_FILE}"
+    DEPENDS ${SUBSTRAIT_PROTO_FILES}
+    )
+endforeach(SUBSTRAIT_PROTO_NAME ${SUBSTRAIT_PROTO_NAMES})
+
+# Library target.
+add_mlir_library(Substrait
+  ${SUBSTRAIT_SOURCES}
+
+  ADDITIONAL_HEADERS
+  ${SUBSTRAIT_HEADERS}
+
+  LINK_LIBS PUBLIC
+  protobuf::libprotobuf
+  )
+target_include_directories(Substrait
+  PUBLIC
+  "$<BUILD_INTERFACE:${SUBSTRAIT_BINARY_DIR}>"
+  )

--- a/test/Target/SubstraitPB/Export/plan-version.mlir
+++ b/test/Target/SubstraitPB/Export/plan-version.mlir
@@ -1,0 +1,19 @@
+// RUN: structured-translate -substrait-to-protobuf %s \
+// RUN: | FileCheck %s
+
+// RUN: structured-translate -substrait-to-protobuf %s \
+// RUN: | structured-translate -protobuf-to-substrait \
+// RUN: | structured-translate -substrait-to-protobuf \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: version {
+// CHECK-DAG:     minor_number: 42
+// CHECK-DAG:     patch_number: 1
+// CHECK-DAG:     git_hash: "hash"
+// CHECK-DAG:     producer: "producer"
+// CHECK-NEXT:  }
+substrait.plan
+  version 0 : 42 : 1
+  git_hash "hash"
+  producer "producer"
+  {}

--- a/test/Target/SubstraitPB/Import/plan-version.textpb
+++ b/test/Target/SubstraitPB/Import/plan-version.textpb
@@ -1,0 +1,17 @@
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN: | FileCheck %s
+
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN: | structured-translate -substrait-to-protobuf \
+# RUN: | structured-translate -protobuf-to-substrait \
+# RUN: | FileCheck %s
+
+# CHECK:      substrait.plan version 0 : 42 : 1
+# CHECK-SAME:   git_hash "hash" producer "producer" {
+# CHECK-NEXT: }
+version {
+  minor_number: 42
+  patch_number: 1
+  git_hash: "hash"
+  producer: "producer"
+}

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -14,7 +14,7 @@ config.name = 'Structured'
 config.test_format = lit.formats.ShTest(not llvm_config.use_lit_shell)
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = ['.mlir', '.py']
+config.suffixes = ['.mlir', '.textpb', '.py']
 
 # test_source_root: The root path where tests are located.
 config.test_source_root = os.path.dirname(__file__)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,3 +3,4 @@ add_dependencies(structured-all structured-tools)
 
 add_subdirectory(structured-lsp-server)
 add_subdirectory(structured-opt)
+add_subdirectory(structured-translate)

--- a/tools/structured-translate/CMakeLists.txt
+++ b/tools/structured-translate/CMakeLists.txt
@@ -1,0 +1,25 @@
+set(LLVM_LINK_COMPONENTS
+  Support
+  )
+
+get_property(translation_libs GLOBAL PROPERTY MLIR_TRANSLATION_LIBS )
+get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
+
+add_llvm_executable(structured-translate
+  structured-translate.cpp
+  )
+add_dependencies(structured-tools structured-translate)
+
+target_link_libraries(structured-translate
+  PRIVATE
+  ${dialect_libs}
+  ${translation_libs}
+  MLIRIR
+  MLIRParser
+  MLIRPass
+  MLIRTargetSubstraitPB
+  MLIRTranslateLib
+  MLIRSupport
+  )
+
+mlir_check_all_link_libraries(structured-translate)

--- a/tools/structured-translate/structured-translate.cpp
+++ b/tools/structured-translate/structured-translate.cpp
@@ -1,0 +1,50 @@
+//===-- structured-translate.cpp - custom mlir-translate --------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/InitAllTranslations.h"
+#include "mlir/Support/LogicalResult.h"
+#include "mlir/Tools/mlir-translate/MlirTranslateMain.h"
+#include "mlir/Tools/mlir-translate/Translation.h"
+#include "structured/Dialect/Substrait/IR/Substrait.h"
+#include "structured/Target/SubstraitPB/Export.h"
+#include "structured/Target/SubstraitPB/Import.h"
+#include "llvm/Support/GraphWriter.h"
+#include "llvm/Support/raw_ostream.h"
+
+namespace mlir {
+namespace substrait {
+
+static void registerSubstraitDialects(DialectRegistry &registry) {
+  registry.insert<mlir::substrait::SubstraitDialect>();
+}
+
+void registerSubstraitToProtobufTranslation() {
+  TranslateFromMLIRRegistration registration(
+      "substrait-to-protobuf", "translate from Substrait MLIR to protobuf",
+      translateSubstraitToProtobuf, registerSubstraitDialects);
+}
+
+void registerProtobufToSubstraitTranslation() {
+  TranslateToMLIRRegistration registration(
+      "protobuf-to-substrait", "translate from protobuf to Substrait MLIR",
+      translateProtobufToSubstrait, registerSubstraitDialects);
+}
+
+} // namespace substrait
+} // namespace mlir
+
+int main(int argc, char **argv) {
+  mlir::registerAllTranslations();
+  mlir::substrait::registerSubstraitToProtobufTranslation();
+  mlir::substrait::registerProtobufToSubstraitTranslation();
+
+  return failed(
+      mlir::mlirTranslateMain(argc, argv, "MLIR Translation Testing Tool"));
+}

--- a/tools/structured-translate/structured-translate.cpp
+++ b/tools/structured-translate/structured-translate.cpp
@@ -1,9 +1,12 @@
-//===-- structured-translate.cpp - custom mlir-translate --------*- C++ -*-===//
+//===-- structured-translate.cpp - "structured" mlir-translate --*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
+//===----------------------------------------------------------------------===//
+// `mlir-stranslate` with translations to and from "structured" dialects, i.e.,
+// dialects from this repository.
 //===----------------------------------------------------------------------===//
 
 #include "mlir/IR/BuiltinOps.h"


### PR DESCRIPTION
This PR is based on and, therefor, includes #794.

This PR adds the new tool `structured-translate` with a translation to
and from the text format of Substrait's protobuf serialization. As the
current dialect, this isn't particularly useful in its current form,
yet, but puts the basic code structure into place.