### PR TITLE
[CI] Update base image of Github runners. (NFC)

### DIFF
--- a/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
+++ b/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
     steps:

--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Structured Build and Test (Release Asserts)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       LLVM_SYMBOLIZER_PATH: /usr/lib/llvm-11/bin/llvm-symbolizer
     steps:


### PR DESCRIPTION
I will need a protobuf version that is more recent than the one provided by the current image, Ubuntu 20.04.