### PR TITLE
[Substrait] Add to_* export functions to PlanOp Python bindings.

### DIFF
--- a/python/mlir_structured/dialects/substrait.py
+++ b/python/mlir_structured/dialects/substrait.py
@@ -37,6 +37,15 @@ class PlanOp(PlanOp):
   def body(self) -> ir.Block:
     return self.regions[0].blocks[0]
 
+  def to_json(self, pretty: bool = False) -> str:
+    return to_json(self.operation, pretty)
+
+  def to_binpb(self) -> str:
+    return to_binpb(self.operation)
+
+  def to_textpb(self) -> str:
+    return to_textpb(self.operation)
+
 
 @_ods_cext.register_operation(_Dialect, replace=True)
 class PlanRelOp(PlanRelOp):

--- a/test/python/dialects/substrait/translate.py
+++ b/test/python/dialects/substrait/translate.py
@@ -34,6 +34,10 @@ def testJsonFormat():
   print(json_plan)
   # CHECK: {"version":{"minorNumber":42,"patchNumber":1}}
 
+  plan_op = plan_module.body.operations[0]
+  print(plan_op.to_json())
+  # CHECK: {"version":{"minorNumber":42,"patchNumber":1}}
+
   json_plan = json.dumps(json.loads(json_plan))
   print(json_plan)
   # CHECK: {"version": {"minorNumber": 42, "patchNumber": 1}}
@@ -56,6 +60,10 @@ def testTextPB():
   # CHECK-NEXT:   minor_number: 42
   # CHECK-NEXT:   patch_number: 1
 
+  plan_op = plan_module.body.operations[0]
+  print(plan_op.to_textpb())
+  # CHECK:      version {
+
   plan_module = ss.from_textpb(text_plan)
   print(plan_module)
   # CHECK: substrait.plan version
@@ -68,6 +76,10 @@ def testBinPB():
 
   bin_plan = ss.to_binpb(plan_module.operation)
   print(bin_plan)
+  # CHECK: 2
+
+  plan_op = plan_module.body.operations[0]
+  print(plan_op.to_binpb())
   # CHECK: 2
 
   plan_module = ss.from_binpb(bin_plan)


### PR DESCRIPTION
This PR depends on and, therefor, includes ~~#798, #800, and~~ #804 as well as their dependencies.