### PR TITLE
[Substrait] Implement first version of FilterOp and Expression ops.

### DIFF
--- a/include/structured/Dialect/Substrait/IR/SubstraitInterfaces.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitInterfaces.td
@@ -11,6 +11,16 @@
 
 include "mlir/IR/OpBase.td"
 
+def Substrait_ExpressionOpInterface : OpInterface<"ExpressionOpInterface"> {
+  let description = [{
+    Interface for any expression in a Substrait plan. This corresponds to an
+    `Expression` message, which only consists of the `rex_type` field, which, in
+    turn, holds a more specialized message with the information specific to the
+    concrete expression.
+  }];
+  let cppNamespace = "::mlir::substrait";
+}
+
 def Substrait_RelOpInterface : OpInterface<"RelOpInterface"> {
   let description = [{
     Interface for any relational operation in a Substrait plan. This corresponds

--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -138,12 +138,50 @@ def Substrait_PlanRelOp : Substrait_Op<"relation", [
 }
 
 def Substrait_YieldOp : Substrait_Op<"yield", [
-    Terminator, HasParent<"::mlir::substrait::PlanRelOp">
+    Terminator,
+    ParentOneOf<[
+      "::mlir::substrait::PlanRelOp",
+      "::mlir::substrait::FilterOp"
+    ]>
   ]> {
   let summary = "Yields the result of a `PlanRelOp`";
   let arguments = (ins AnyType:$value);
   let assemblyFormat = "$value attr-dict `:` type($value)";
   let builders = [OpBuilder<(ins), [{ /* do nothing */ }]>];
+}
+
+//===----------------------------------------------------------------------===//
+// Expressions
+//===----------------------------------------------------------------------===//
+// The definitions in this section are related to the various `Expression`
+// message types. See https://substrait.io/expressions/field_references/ and
+// https://github.com/substrait-io/substrait/blob/main/proto/substrait/algebra.proto.
+//===----------------------------------------------------------------------===//
+
+// TODO(ingomueller): Make this a proper base for expressions.
+class Substrait_ExpressionOp<string mnemonic, list<Trait> traits = []> :
+  Substrait_Op<mnemonic, traits # [
+    Substrait_ExpressionOpInterface
+  ]>;
+
+def Substrait_LiteralOp : Substrait_ExpressionOp<"literal", [
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]> {
+  let summary = "Literal expression";
+  let description = [{
+    Represents a `Literal` message together with all messages it contains and
+    the `Expression` message it is contained in.
+
+    Example:
+
+    ```mlir
+    %0 = literal true
+    ```
+  }];
+  // TODO(ingomueller): extend to other types.
+  let arguments = (ins Substrait_AtomicAttribute:$value);
+  let results = (outs Substrait_AtomicType:$result);
+  let assemblyFormat = "$value attr-dict";
 }
 
 //===----------------------------------------------------------------------===//
@@ -189,6 +227,45 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   let results = (outs Substrait_Relation:$result);
   let assemblyFormat = [{
     $left `x` $right attr-dict `:` type($left) `x` type($right)
+  }];
+}
+
+def Substrait_FilterOp : Substrait_RelOp<"filter", [
+    SingleBlockImplicitTerminator<"::mlir::substrait::YieldOp">,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    SameOperandsAndResultType
+  ]> {
+  let summary = "Filter operation";
+  let description = [{
+    Represents a `FilterRel` message together with the `RelCommon`, input `Rel`,
+    and `Expression` messages it contains.
+
+    Example:
+
+    ```mlir
+    %0 = ...
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %true = literal true
+      yield %true : si1
+    }
+    ```
+  }];
+  let arguments = (ins Substrait_Relation:$input);
+  let regions = (region AnyRegion:$condition);
+  let results = (outs Substrait_Relation:$result);
+  // TODO(ingomueller): We could elide/shorten the block argument from the
+  //                    assembly by writing custom printers/parsers similar to
+  //                    `scf.for` etc.
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) $condition
+  }];
+  let hasRegionVerifier = 1;
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    ::llvm::StringRef $cppClass::getDefaultDialect() {
+      return SubstraitDialect::getDialectNamespace();
+    }
   }];
 }
 

--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -140,8 +140,8 @@ def Substrait_PlanRelOp : Substrait_Op<"relation", [
 def Substrait_YieldOp : Substrait_Op<"yield", [
     Terminator,
     ParentOneOf<[
-      "::mlir::substrait::PlanRelOp",
-      "::mlir::substrait::FilterOp"
+      "::mlir::substrait::FilterOp",
+      "::mlir::substrait::PlanRelOp"
     ]>
   ]> {
   let summary = "Yields the result of a `PlanRelOp`";

--- a/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
@@ -29,6 +29,17 @@ def Substrait_AtomicTypes {
   ];
 }
 
+/// Attributes of currently supported atomic types.
+def Substrait_AtomicAttributes {
+  list<Attr> attrs = [
+    SI1Attr, // Boolean
+    SI32Attr // I32
+  ];
+}
+
+/// Attrbitue of one of the currently supported atomic types.
+def Substrait_AtomicAttribute : AnyAttrOf<Substrait_AtomicAttributes.attrs>;
+
 /// One of the currently supported atomic types.
 def Substrait_AtomicType : AnyTypeOf<Substrait_AtomicTypes.types>;
 

--- a/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
@@ -37,7 +37,7 @@ def Substrait_AtomicAttributes {
   ];
 }
 
-/// Attrbitue of one of the currently supported atomic types.
+/// Attribute of one of the currently supported atomic types.
 def Substrait_AtomicAttribute : AnyAttrOf<Substrait_AtomicAttributes.attrs>;
 
 /// One of the currently supported atomic types.

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -108,13 +108,11 @@ LiteralOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
                             OpaqueProperties properties, RegionRange regions,
                             llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
   auto *typedProperties = properties.as<Properties *>();
-  if (!loc)
-    loc = UnknownLoc::get(context);
 
   auto attr = llvm::dyn_cast<TypedAttr>(typedProperties->getValue());
   if (!attr)
-    ::emitError(loc.value()) << "unsuited attribute for literal value: "
-                             << typedProperties->getValue();
+    return emitOptionalError(loc, "unsuited attribute for literal value: ",
+                             typedProperties->getValue());
 
   Type resultType = attr.getType();
   inferredReturnTypes.emplace_back(resultType);

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -72,6 +72,56 @@ CrossOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
   return success();
 }
 
+LogicalResult FilterOp::verifyRegions() {
+  MLIRContext *context = getContext();
+  Type si1 = IntegerType::get(context, /*width=*/1, IntegerType::Signed);
+  Region &condition = getCondition();
+
+  // Verify that type of yielded value is Boolean.
+  auto yieldOp = llvm::cast<YieldOp>(condition.front().getTerminator());
+  Type yieldedType = yieldOp.getValue().getType();
+  if (yieldedType != si1)
+    return emitOpError()
+           << " must have 'condition' region yielding 'si1' (yields "
+           << yieldedType << ")";
+
+  // Verify that block has argument of input tuple type.
+  Type tupleType = getResult().getType();
+  if (condition.getNumArguments() != 1 ||
+      condition.getArgument(0).getType() != tupleType) {
+    InFlightDiagnostic diag = emitOpError()
+                              << "must have 'condition' region taking "
+                              << tupleType << " as argument (takes ";
+    if (condition.getNumArguments() == 0)
+      diag << "no arguments)";
+    else
+      diag << condition.getArgument(0).getType() << ")";
+    return diag;
+  }
+
+  return success();
+}
+
+LogicalResult
+LiteralOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
+                            ValueRange operands, DictionaryAttr attributes,
+                            OpaqueProperties properties, RegionRange regions,
+                            llvm::SmallVectorImpl<Type> &inferredReturnTypes) {
+  auto *typedProperties = properties.as<Properties *>();
+  if (!loc)
+    loc = UnknownLoc::get(context);
+
+  auto attr = llvm::dyn_cast<TypedAttr>(typedProperties->getValue());
+  if (!attr)
+    ::emitError(loc.value()) << "unsuited attribute for literal value: "
+                             << typedProperties->getValue();
+
+  Type resultType = attr.getType();
+  inferredReturnTypes.emplace_back(resultType);
+
+  return success();
+}
+
 /// Verifies that the provided field names match the provided field types. While
 /// the field types are potentially nested, the names are given in a single,
 /// flat list and correspond to the field types in depth first order (where each

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -39,6 +39,9 @@ namespace {
   static FailureOr<std::unique_ptr<MESSAGE_TYPE>> exportOperation(OP_TYPE op);
 
 DECLARE_EXPORT_FUNC(CrossOp, Rel)
+DECLARE_EXPORT_FUNC(ExpressionOpInterface, Expression)
+DECLARE_EXPORT_FUNC(FilterOp, Rel)
+DECLARE_EXPORT_FUNC(LiteralOp, Expression)
 DECLARE_EXPORT_FUNC(ModuleOp, Plan)
 DECLARE_EXPORT_FUNC(NamedTableOp, Rel)
 DECLARE_EXPORT_FUNC(PlanOp, Plan)
@@ -135,6 +138,78 @@ FailureOr<std::unique_ptr<Rel>> exportOperation(CrossOp op) {
   rel->set_allocated_cross(crossRel.release());
 
   return rel;
+}
+
+FailureOr<std::unique_ptr<Expression>>
+exportOperation(ExpressionOpInterface op) {
+  return llvm::TypeSwitch<Operation *, FailureOr<std::unique_ptr<Expression>>>(
+             op)
+      .Case<LiteralOp>([&](auto op) { return exportOperation(op); })
+      .Default(
+          [](auto op) { return op->emitOpError("not supported for export"); });
+}
+
+FailureOr<std::unique_ptr<Rel>> exportOperation(FilterOp op) {
+  // Build `RelCommon` message.
+  auto relCommon = std::make_unique<RelCommon>();
+  auto direct = std::make_unique<RelCommon::Direct>();
+  relCommon->set_allocated_direct(direct.release());
+
+  // Build input `Rel` message.
+  auto inputOp =
+      llvm::dyn_cast_if_present<RelOpInterface>(op.getInput().getDefiningOp());
+  if (!inputOp)
+    return op->emitOpError("input was not produced by Substrait relation op");
+
+  FailureOr<std::unique_ptr<Rel>> inputRel = exportOperation(inputOp);
+  if (failed(inputRel))
+    return failure();
+
+  // Build condition `Expression` message.
+  auto yieldOp = llvm::cast<YieldOp>(op.getCondition().front().getTerminator());
+  // TODO(ingomueller): There can be cases where there isn't a defining op but
+  //                    the region argument is returned directly. Support that.
+  auto conditionOp = llvm::dyn_cast_if_present<ExpressionOpInterface>(
+      yieldOp.getValue().getDefiningOp());
+  if (!conditionOp)
+    return op->emitOpError("condition not supported for export: yielded op was "
+                           "not produced by Substrait expression op");
+  FailureOr<std::unique_ptr<Expression>> condition =
+      exportOperation(conditionOp);
+  if (failed(condition))
+    return failure();
+
+  // Build `FilterRel` message.
+  auto filterRel = std::make_unique<FilterRel>();
+  filterRel->set_allocated_common(relCommon.release());
+  filterRel->set_allocated_input(inputRel->release());
+  filterRel->set_allocated_condition(condition->release());
+
+  // Build `Rel` message.
+  auto rel = std::make_unique<Rel>();
+  rel->set_allocated_filter(filterRel.release());
+
+  return rel;
+}
+
+FailureOr<std::unique_ptr<Expression>> exportOperation(LiteralOp op) {
+  auto si1 = IntegerType::get(op.getContext(), 1, IntegerType::Signed);
+  auto si32 = IntegerType::get(op.getContext(), 32, IntegerType::Signed);
+
+  // Build `Literal` message.
+  auto value = llvm::cast<TypedAttr>(op.getValue());
+  mlir::Type literalType = value.getType();
+  auto literal = std::make_unique<Expression::Literal>();
+  if (literalType == si1 || literalType == si32)
+    literal->set_boolean(value.cast<IntegerAttr>().getSInt());
+  else
+    op->emitOpError("has unsupported value");
+
+  // Build `Expression` message.
+  auto expression = std::make_unique<Expression>();
+  expression->set_allocated_literal(literal.release());
+
+  return expression;
 }
 
 FailureOr<std::unique_ptr<Plan>> exportOperation(ModuleOp op) {
@@ -248,7 +323,8 @@ FailureOr<std::unique_ptr<Plan>> exportOperation(PlanOp op) {
 
 FailureOr<std::unique_ptr<Rel>> exportOperation(RelOpInterface op) {
   return llvm::TypeSwitch<Operation *, FailureOr<std::unique_ptr<Rel>>>(op)
-      .Case<CrossOp, NamedTableOp>([&](auto op) { return exportOperation(op); })
+      .Case<CrossOp, FilterOp, NamedTableOp>(
+          [&](auto op) { return exportOperation(op); })
       .Default([](auto op) {
         op->emitOpError("not supported for export");
         return failure();

--- a/test/Dialect/Substrait/filter-invalid.mlir
+++ b/test/Dialect/Substrait/filter-invalid.mlir
@@ -1,0 +1,43 @@
+// RUN: structured-opt -verify-diagnostics -split-input-file %s
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.filter' op  must have 'condition' region yielding 'si1' (yields 'si32')}}
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal 42 : si32
+      yield %2 : si32
+    }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes no arguments)}}
+    %1 = filter %0 : tuple<si32> {
+      %2 = literal 0 : si1
+      yield %2 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.filter' op must have 'condition' region taking 'tuple<si32>' as argument (takes 'tuple<>')}}
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<>):
+      %2 = literal 0 : si1
+      yield %2 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/filter.mlir
+++ b/test/Dialect/Substrait/filter.mlir
@@ -1,0 +1,24 @@
+// RUN: structured-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = filter %[[V0]] : tuple<si32> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
+// CHECK-NEXT:      yield %[[V2]] : si1
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] :
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal -1 : si1
+      yield %2 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/literal-invalid.mlir
+++ b/test/Dialect/Substrait/literal-invalid.mlir
@@ -1,0 +1,5 @@
+// RUN: structured-opt -verify-diagnostics -split-input-file %s
+
+
+// expected-error@+1 {{unsuited attribute for literal value: unit}}
+%0 = substrait.literal unit

--- a/test/Target/SubstraitPB/Export/filter.mlir
+++ b/test/Target/SubstraitPB/Export/filter.mlir
@@ -1,0 +1,29 @@
+// RUN: structured-translate -substrait-to-protobuf %s \
+// RUN: | FileCheck %s
+
+// RUN: structured-translate -substrait-to-protobuf %s \
+// RUN: | structured-translate -protobuf-to-substrait \
+// RUN: | structured-translate -substrait-to-protobuf \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      filter {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK:             input {
+// CHECK:             condition {
+// CHECK-NEXT:          literal {
+// CHECK-NEXT:            boolean: true
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal -1 : si1
+      yield %2 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Import/filter.textpb
+++ b/test/Target/SubstraitPB/Import/filter.textpb
@@ -1,0 +1,59 @@
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN: | FileCheck %s
+
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN: | structured-translate -substrait-to-protobuf \
+# RUN: | structured-translate -protobuf-to-substrait \
+# RUN: | FileCheck %s
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation {
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = filter %[[V0]] : tuple<si32>
+# CHECK-NEXT:      ^bb0(%[[ARG0:.*]]: tuple<si32>):
+# CHECK-NEXT:        %[[V2:.*]] = literal -1 : si1
+# CHECK-NEXT:        yield %[[V2]] : si1
+# CHECK-NEXT:      }
+# CHECK-NEXT:      yield %[[V1]] : tuple<si32>
+
+relations {
+  rel {
+    filter {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      condition {
+        literal {
+          boolean: true
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #817 and its dependencies.~~

This corresponds to the `FilterRel` message and the ones contained in
it. Since one of the messages is an `Expression` message, this PR also
introduces the `ExpressionOpInterface` as well as the `LiteralOp` as
well as the basic import/export infrastructure for such ops/messages.
The `LiteralOp` corresponds to the `Expression.Literal` message type,
and the `ExpressionOpInterface` encapsualtes common properties and
functionality of all types of `Expression` messages. Finally, the PR
also adds attribute constraints for typed attributes of the currently
supported types.