### PR TITLE
[Substrait] Extend FieldReferenceOp to the expression case.

### DIFF
--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -185,7 +185,7 @@ def Substrait_FieldReferenceOp : Substrait_ExpressionOp<"field_reference", [
     Substrait_ContainerType:$container,
     I64ArrayAttr:$position
   );
-  let results = (outs Substrait_AtomicType:$result);
+  let results = (outs Substrait_FieldType:$result);
   let assemblyFormat = [{
     $container `[` $position `]` attr-dict `:` type($container)
   }];

--- a/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitTypes.td
@@ -46,6 +46,12 @@ def Substrait_AtomicType : AnyTypeOf<Substrait_AtomicTypes.types>;
 /// Any container type, i.e., structs, maps, lists, and nestings thereof.
 def Substrait_ContainerType : NestedTupleOf<Substrait_AtomicTypes.types>;
 
+/// One of the currently supported atomic or nested types.
+def Substrait_FieldType : AnyTypeOf<[
+  Substrait_AtomicType,
+  Substrait_ContainerType
+]>;
+
 /// Placeholder for a proper relation type, the result of any `RelOpInterface`
 /// op.
 // TODO(ingomueller): Transform this into a proper relation type.

--- a/test/Dialect/Substrait/field-reference.mlir
+++ b/test/Dialect/Substrait/field-reference.mlir
@@ -42,3 +42,27 @@ substrait.plan version 0 : 42 : 1 {
     yield %1 : tuple<si1, tuple<si1>>
   }
 }
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      named_table
+// CHECK-NEXT:      filter
+// CHECK-NEXT:      (%[[ARG0:.*]]: tuple<si1, tuple<si1>>):
+// CHECK-NEXT:        %[[V0:.*]] = field_reference %[[ARG0]]{{\[}}[1]] : tuple<si1, tuple<si1>>
+// CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]]{{\[}}[0]] : tuple<si1>
+// CHECK-NEXT:        yield %[[V1]] : si1
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
+    %1 = filter %0 : tuple<si1, tuple<si1>> {
+    ^bb0(%arg : tuple<si1, tuple<si1>>):
+      %2 = field_reference %arg[[1]] : tuple<si1, tuple<si1>>
+      %3 = field_reference %2[[0]] : tuple<si1>
+      yield %3 : si1
+    }
+    yield %1 : tuple<si1, tuple<si1>>
+  }
+}

--- a/test/Target/SubstraitPB/Export/field-reference.mlir
+++ b/test/Target/SubstraitPB/Export/field-reference.mlir
@@ -1,9 +1,12 @@
-// RUN: structured-translate -substrait-to-protobuf %s \
+// RUN: structured-translate -substrait-to-protobuf --split-input-file %s \
 // RUN: | FileCheck %s
 
 // RUN: structured-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | structured-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
 // RUN: | structured-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | FileCheck %s
 
 // CHECK-LABEL: relations {
@@ -29,6 +32,44 @@ substrait.plan version 0 : 42 : 1 {
     ^bb0(%arg : tuple<si1, tuple<si1>>):
       %2 = field_reference %arg[[1, 0]] : tuple<si1, tuple<si1>>
       yield %2 : si1
+    }
+    yield %1 : tuple<si1, tuple<si1>>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      filter {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          direct {
+// CHECK:             input {
+// CHECK:             condition {
+// CHECK-NEXT:          selection {
+// CHECK-NEXT:            direct_reference {
+// CHECK-NEXT:              struct_field {
+// CHECK-NEXT:              }
+// CHECK-NEXT:            }
+// CHECK-NEXT:            expression {
+// CHECK-NEXT:              selection {
+// CHECK-NEXT:                direct_reference {
+// CHECK-NEXT:                  struct_field {
+// CHECK-NEXT:                    field: 1
+// CHECK-NEXT:                  }
+// CHECK-NEXT:                }
+// CHECK-NEXT:                root_reference {
+// CHECK-NEXT:                }
+// CHECK-NEXT:              }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b", "c"] : tuple<si1, tuple<si1>>
+    %1 = filter %0 : tuple<si1, tuple<si1>> {
+    ^bb0(%arg : tuple<si1, tuple<si1>>):
+      %2 = field_reference %arg[[1]] : tuple<si1, tuple<si1>>
+      %3 = field_reference %2[[0]] : tuple<si1>
+      yield %3 : si1
     }
     yield %1 : tuple<si1, tuple<si1>>
   }

--- a/test/Target/SubstraitPB/Import/field-reference.textpb
+++ b/test/Target/SubstraitPB/Import/field-reference.textpb
@@ -1,9 +1,13 @@
 # RUN: structured-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
 # RUN: | FileCheck %s
 
 # RUN: structured-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | structured-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
 # RUN: | structured-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
 # RUN: | FileCheck %s
 
 # CHECK-LABEL: substrait.plan
@@ -67,6 +71,86 @@ relations {
             }
           }
           root_reference {
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      named_table
+# CHECK-NEXT:      filter
+# CHECK-NEXT:        (%[[ARG0:.*]]: tuple<si1, tuple<si1>>)
+# CHECK-NEXT:          %[[V0:.*]] = field_reference %[[ARG0]]{{\[}}[1]]
+# CHECK-SAME:            : tuple<si1, tuple<si1>>
+# CHECK-NEXT:          %[[V1:.*]] = field_reference %[[V0]]{{\[}}[0]]
+# CHECK-SAME:            : tuple<si1>
+# CHECK-NEXT:          yield %[[V1]] : si1
+
+relations {
+  rel {
+    filter {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            names: "b"
+            names: "c"
+            struct {
+              types {
+                bool {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              types {
+                struct {
+                  types {
+                    bool {
+                      nullability: NULLABILITY_REQUIRED
+                    }
+                  }
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      condition {
+        selection {
+          direct_reference {
+            struct_field {
+            }
+          }
+          expression {
+            selection {
+              direct_reference {
+                struct_field {
+                  field: 1
+                }
+              }
+              root_reference {
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR depends on and, therefor, includes #818.

Until now, we only had the case of the `FieldReference` message
implemented that referend to a whole row of the current input relation
(i.e., the `root_reference` case). This PR extends the corresponding op
to support also the `expression` case, where an arbitrary expression
(producing a container) can be the input.