### PR TITLE
[Substrait] Add test that executes exported plan in DuckDB.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@
 
 # Testing.
 datafusion==32.0.0
+duckdb
 ibis==3.3.0
 ibis-framework==8.0.0
 ibis-substrait==3.2.0

--- a/test/python/dialects/substrait/e2e_duckdb.py
+++ b/test/python/dialects/substrait/e2e_duckdb.py
@@ -1,0 +1,52 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+import duckdb
+
+from mlir_structured.dialects import substrait as ss
+from mlir_structured import ir
+
+
+def run(f):
+  print("\nTEST:", f.__name__)
+  with ir.Context(), ir.Location.unknown():
+    ss.register_dialect()
+    f()
+  return f
+
+
+# CHECK-LABEL: TEST: testNamedTable
+@run
+def testNamedTable():
+  # Set up test table.
+  con = duckdb.connect()
+  con.install_extension("substrait")
+  con.load_extension("substrait")
+
+  con.execute(query="CREATE TABLE t (a INT NOT NULL, b INT NOT NULL)")
+  con.execute(query="INSERT INTO t VALUES (1, 7)")
+  con.execute(query="INSERT INTO t VALUES (2, 8)")
+  con.execute(query="INSERT INTO t VALUES (3, 9)")
+
+  # Set up test plan in MLIR.
+  plan = ir.Module.parse('''
+    substrait.plan version 0 : 42 : 1 {
+      relation as ["a", "b"] {
+        %0 = named_table @t as ["a", "b"] : tuple<si32, si32>
+        yield %0 : tuple<si32, si32>
+      }
+    }
+  ''')
+
+  # Export MLIR plan to protobuf.
+  pb_plan = ss.to_binpb(plan.operation).encode()
+
+  # Execute in duckdb and print result.
+  query_result = con.from_substrait(proto=pb_plan)
+
+  print(query_result.to_arrow_table())
+  # CHECK-NEXT:          pyarrow.Table
+  # CHECK-NEXT:          a: int32
+  # CHECK-NEXT:          b: int32
+  # CHECK-NEXT:          ----
+  # CHECK-NEXT{LITERAL}: a: [[1,2,3]]
+  # CHECK-NEXT{LITERAL}: b: [[7,8,9]]


### PR DESCRIPTION
~~This PR depends and, therefor, include #821 and its dependencies.~~

This illustrates that plans produced by our compiler can run in
[DuckDB](https://github.com/duckdb/duckdb), an in-process SQL DB system.