### PR TITLE
[Substrait] Add test that imports plan from Ibis.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@
 
 # Testing.
 datafusion==32.0.0
+ibis==3.3.0
+ibis-framework==8.0.0
+ibis-substrait==3.2.0
 lit
 pyarrow
 

--- a/test/python/dialects/substrait/e2e_ibis.py
+++ b/test/python/dialects/substrait/e2e_ibis.py
@@ -1,0 +1,36 @@
+# RUN: %PYTHON %s | FileCheck %s
+
+import ibis
+from ibis_substrait.compiler import core as ibis_ss
+
+from mlir_structured.dialects import substrait as ss
+from mlir_structured import ir
+
+
+def run(f):
+  print("\nTEST:", f.__name__)
+  with ir.Context(), ir.Location.unknown():
+    ss.register_dialect()
+    f()
+  return f
+
+
+# CHECK-LABEL: TEST: testNamedTable
+@run
+def testNamedTable():
+  # Set up test table.
+  table = ibis.table([("a", "int32"), ("b", "int32")], "t")
+
+  # Create Substrait plan from Ibis expression.
+  compiler = ibis_ss.SubstraitCompiler()
+  pb_plan = compiler.compile(table)
+
+  # Import into MLIR and print.
+  plan = ss.from_binpb(pb_plan.SerializeToString())
+  print(plan)
+
+  # CHECK-NEXT: module
+  # CHECK-NEXT:   substrait.plan version {{.*}} producer "ibis-substrait" {
+  # CHECK-NEXT:     relation as ["a", "b"] {
+  # CHECK-NEXT:       %[[V0:.*]] = named_table @t as ["a", "b"] : tuple<si32, si32>
+  # CHECK-NEXT:       yield %[[V0]] : tuple<si32, si32>


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #821.~~

This illustrates that our compiler can import plans from
[Ibis](https://ibis-project.org/), a Python-based dataframe library that
can run its computations on a variety of back-ends, including Substrait.