### PR TITLE
[Substrait] Create emit op to represent output mapping.

### DIFF
--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -257,6 +257,40 @@ def Substrait_CrossOp : Substrait_RelOp<"cross", [
   }];
 }
 
+def Substrait_EmitOp : Substrait_RelOp<"emit", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,
+    DeclareOpInterfaceMethods<InferTypeOpInterface>
+  ]> {
+  let summary = "Projection (a.k.a. 'emit') as dedicated operation";
+  let description = [{
+    Represents the `Emit` message of the `emit_kind` field in the `RelCommon`
+    message. While projection is inlined into all relations in the protobuf
+    format, this op separates out this functionality in a dedicated op in order
+    to simplify rewriting.
+
+    Example:
+
+    ```mlir
+    %0 = ...
+    %1 = emit [2, 1] from %0 : tuple<si32, s1, si32> -> tuple<si32, si1>
+    ```
+  }];
+  let arguments = (ins
+    Substrait_Relation:$input,
+    I64ArrayAttr:$mapping
+  );
+  let results = (outs Substrait_Relation:$result);
+  let assemblyFormat = [{
+    $mapping `from` $input attr-dict `:` type($input) `->` type($result)
+  }];
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    ::llvm::StringRef $cppClass::getDefaultDialect() {
+      return SubstraitDialect::getDialectNamespace();
+    }
+  }];
+}
+
 def Substrait_FilterOp : Substrait_RelOp<"filter", [
     SingleBlockImplicitTerminator<"::mlir::substrait::YieldOp">,
     DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>,

--- a/lib/Target/SubstraitPB/CMakeLists.txt
+++ b/lib/Target/SubstraitPB/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_translation_library(MLIRTargetSubstraitPB
   Export.cpp
   Import.cpp
+  ProtobufUtils.cpp
 
   LINK_LIBS PUBLIC
   MLIRIR

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -39,6 +39,7 @@ namespace {
   static FailureOr<std::unique_ptr<MESSAGE_TYPE>> exportOperation(OP_TYPE op);
 
 DECLARE_EXPORT_FUNC(CrossOp, Rel)
+DECLARE_EXPORT_FUNC(EmitOp, Rel)
 DECLARE_EXPORT_FUNC(ExpressionOpInterface, Expression)
 DECLARE_EXPORT_FUNC(FieldReferenceOp, Expression)
 DECLARE_EXPORT_FUNC(FilterOp, Rel)
@@ -50,6 +51,65 @@ DECLARE_EXPORT_FUNC(RelOpInterface, Rel)
 
 FailureOr<std::unique_ptr<pb::Message>> exportOperation(Operation *op);
 FailureOr<std::unique_ptr<Rel>> exportOperation(RelOpInterface op);
+
+/// Creates the `RelCommon` message with the `emit_kind` field for the given
+/// op.
+///
+/// **This function has to be called during the export of every `Rel` case
+/// that has a `RelCommon` message.**
+///
+/// If the result produced by the gien op is an `EmitOp`, then the returned
+/// `RelCommon` message contains an `Emit` message that represents the
+/// output mapping of the `EmitOp`. Otherwise, the returned `RelCommon`
+/// message contains a `Direct` message.
+///
+/// If there is more than one `EmitOp` user or some `EmitOp` users and some
+/// other users, then an error is returned because these cases can't be
+/// expressed by a single `Emit` message. Some corner cases where export
+/// might still be possible are cases with multiple `EmitOp`s that are all
+/// identical and a subset of `EmitOp` users all with identity mappings. All
+/// of these should go away through canonicalization and/or CSE.
+FailureOr<std::unique_ptr<RelCommon>>
+createRelComminWithEmit(RelOpInterface op) {
+  auto relCommon = std::make_unique<RelCommon>();
+
+  Value result = op->getResult(0);
+
+  // Collect all `EmitOp`s that use the result of this operation.
+  SmallVector<EmitOp> emitOps;
+  size_t numUsers = 0;
+  for (Operation *user : result.getUsers()) {
+    numUsers++;
+    if (isa<EmitOp>(user))
+      emitOps.push_back(dyn_cast<EmitOp>(user));
+  }
+
+  // If we don't have an `EmitOp` user, then `op` has direct emit behavior.
+  if (emitOps.empty()) {
+    auto direct = std::make_unique<RelCommon::Direct>();
+    relCommon->set_allocated_direct(direct.release());
+    return relCommon;
+  }
+
+  // If we have more that one `EmitOp` user or fewer `EmitOp` users than total
+  // users, then some mappings are different from the others, which can't be
+  // expressed by a single `Emit` message.
+  if (emitOps.size() > 1 || emitOps.size() != numUsers) {
+    return op->emitOpError("is consumed by different emit ops (try running "
+                           "canonicalization and/or CSE)");
+  }
+
+  // Normal case: we have exactly one `EmitOp` user.
+  EmitOp emitOp = emitOps.front();
+
+  // Build the `Emit` message.
+  auto emit = std::make_unique<RelCommon::Emit>();
+  for (auto intAttr : emitOp.getMapping().getAsRange<IntegerAttr>())
+    emit->add_output_mapping(intAttr.getInt());
+
+  relCommon->set_allocated_emit(emit.release());
+  return relCommon;
+}
 
 FailureOr<std::unique_ptr<proto::Type>> exportType(Location loc,
                                                    mlir::Type mlirType) {
@@ -141,6 +201,25 @@ FailureOr<std::unique_ptr<Rel>> exportOperation(CrossOp op) {
   return rel;
 }
 
+/// We just forward to the overload for `RelOpInterface`, which will have to
+/// export this op. We can't (easily) do it here because the emit op is
+/// represented as part of the `RelCommon` message of one of the cases of the
+/// `Rel` message but there is no generic way to access the `common` field of
+/// the various cases.
+FailureOr<std::unique_ptr<Rel>> exportOperation(EmitOp op) {
+  auto inputOp =
+      dyn_cast_if_present<RelOpInterface>(op.getInput().getDefiningOp());
+  if (!inputOp)
+    return op->emitOpError("input was not produced by Substrait relation op");
+
+  if (dyn_cast<EmitOp>(inputOp.getOperation()))
+    return op->emitOpError(
+        "with input produced by 'substrait.emit' op not supported for export "
+        "(try running canonicalization)");
+
+  return exportOperation(inputOp);
+}
+
 FailureOr<std::unique_ptr<Expression>>
 exportOperation(ExpressionOpInterface op) {
   return llvm::TypeSwitch<Operation *, FailureOr<std::unique_ptr<Expression>>>(
@@ -208,10 +287,12 @@ FailureOr<std::unique_ptr<Expression>> exportOperation(FieldReferenceOp op) {
 }
 
 FailureOr<std::unique_ptr<Rel>> exportOperation(FilterOp op) {
-  // Build `RelCommon` message.
-  auto relCommon = std::make_unique<RelCommon>();
-  auto direct = std::make_unique<RelCommon::Direct>();
-  relCommon->set_allocated_direct(direct.release());
+  // Build `RelCommon` message with emit mapping.
+  FailureOr<std::unique_ptr<RelCommon>> maybeRelCommon =
+      createRelComminWithEmit(op);
+  if (failed(maybeRelCommon))
+    return failure();
+  auto relCommon = std::move(maybeRelCommon.value());
 
   // Build input `Rel` message.
   auto inputOp =
@@ -310,10 +391,12 @@ FailureOr<std::unique_ptr<Rel>> exportOperation(NamedTableOp op) {
     namedTable->add_names(attr.getLeafReference().str());
   }
 
-  // Build `RelCommon` message.
-  auto relCommon = std::make_unique<RelCommon>();
-  auto direct = std::make_unique<RelCommon::Direct>();
-  relCommon->set_allocated_direct(direct.release());
+  // Build `RelCommon` message with emit mapping.
+  FailureOr<std::unique_ptr<RelCommon>> maybeRelCommon =
+      createRelComminWithEmit(op);
+  if (failed(maybeRelCommon))
+    return failure();
+  auto relCommon = std::move(maybeRelCommon.value());
 
   // Build `Struct` message.
   auto struct_ = std::make_unique<proto::Type::Struct>();
@@ -392,7 +475,7 @@ FailureOr<std::unique_ptr<Plan>> exportOperation(PlanOp op) {
 
 FailureOr<std::unique_ptr<Rel>> exportOperation(RelOpInterface op) {
   return llvm::TypeSwitch<Operation *, FailureOr<std::unique_ptr<Rel>>>(op)
-      .Case<CrossOp, FieldReferenceOp, FilterOp, NamedTableOp>(
+      .Case<CrossOp, EmitOp, FieldReferenceOp, FilterOp, NamedTableOp>(
           [&](auto op) { return exportOperation(op); })
       .Default([](auto op) {
         op->emitOpError("not supported for export");

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -1,0 +1,64 @@
+//===-- ProtobufUtils.cpp - Utils for Substrait protobufs -------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ProtobufUtils.h"
+#include "mlir/IR/Diagnostics.h"
+
+#include <substrait/proto/algebra.pb.h>
+
+using namespace mlir;
+using namespace ::substrait;
+using namespace ::substrait::proto;
+
+namespace pb = google::protobuf;
+
+namespace mlir::substrait::protobuf_utils {
+
+template <typename RelType>
+static const RelCommon *getCommon(const RelType &rel) {
+  return &rel.common();
+}
+
+FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
+  Rel::RelTypeCase relType = rel.rel_type_case();
+  switch (relType) {
+  case Rel::RelTypeCase::kCross:
+    return getCommon(rel.cross());
+  case Rel::RelTypeCase::kFilter:
+    return getCommon(rel.filter());
+  case Rel::RelTypeCase::kRead:
+    return getCommon(rel.read());
+  default:
+    const pb::FieldDescriptor *desc =
+        Rel::GetDescriptor()->FindFieldByNumber(relType);
+    return emitError(loc) << Twine("unsupported Rel type: ") + desc->name();
+  }
+}
+
+template <typename RelType>
+static RelCommon *getMutableCommon(RelType *rel) {
+  return rel->mutable_common();
+}
+
+FailureOr<RelCommon *> getMutableCommon(Rel *rel, Location loc) {
+  Rel::RelTypeCase relType = rel->rel_type_case();
+  switch (relType) {
+  case Rel::RelTypeCase::kCross:
+    return getMutableCommon(rel->mutable_cross());
+  case Rel::RelTypeCase::kFilter:
+    return getMutableCommon(rel->mutable_filter());
+  case Rel::RelTypeCase::kRead:
+    return getMutableCommon(rel->mutable_read());
+  default:
+    const pb::FieldDescriptor *desc =
+        Rel::GetDescriptor()->FindFieldByNumber(relType);
+    return emitError(loc) << Twine("unsupported Rel type: ") + desc->name();
+  }
+}
+
+} // namespace mlir::substrait::protobuf_utils

--- a/lib/Target/SubstraitPB/ProtobufUtils.h
+++ b/lib/Target/SubstraitPB/ProtobufUtils.h
@@ -1,0 +1,33 @@
+//===-- ProtobufUtils.h - Utils for Substrait protobufs ---------*- C++ -*-===//
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIB_TARGET_SUBSTRAITPB_PROTOBUFUTILS_H
+#define LIB_TARGET_SUBSTRAITPB_PROTOBUFUTILS_H
+
+#include "mlir/IR/Location.h"
+
+namespace substrait::proto {
+class RelCommon;
+class Rel;
+} // namespace substrait::proto
+
+namespace mlir::substrait::protobuf_utils {
+
+/// Extract the `RelCommon` message from any possible `rel_type` message of the
+/// given `rel`. Reports errors using the given `loc`.
+FailureOr<const ::substrait::proto::RelCommon *>
+getCommon(const ::substrait::proto::Rel &rel, Location loc);
+
+/// Extract the `RelCommon` message from any possible `rel_type` message of the
+/// given `rel`. Reports errors using the given `loc`.
+FailureOr<::substrait::proto::RelCommon *>
+getMutableCommon(::substrait::proto::Rel *rel, Location loc);
+
+} // namespace mlir::substrait::protobuf_utils
+
+#endif // LIB_TARGET_SUBSTRAITPB_PROTOBUFUTILS_H

--- a/test/Dialect/Substrait/emit-invalid.mlir
+++ b/test/Dialect/Substrait/emit-invalid.mlir
@@ -1,0 +1,23 @@
+// RUN: structured-opt -verify-diagnostics -split-input-file %s
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
+    // expected-error@+1 {{1 is not a valid index into 'tuple<si32>'}}
+    %1 = emit [1] from %0 : tuple<si32> -> tuple<si32>
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+2 {{'substrait.emit' op failed to infer returned types}}
+    // expected-error@+1 {{-1 is not a valid index into 'tuple<si32>'}}
+    %1 = emit [-1] from %0 : tuple<si32> -> tuple<si32>
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Dialect/Substrait/emit.mlir
+++ b/test/Dialect/Substrait/emit.mlir
@@ -1,0 +1,48 @@
+// RUN: structured-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
+// CHECK-SAME:          tuple<si1, si32> -> tuple<si32, si1>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    yield %1 : tuple<si32, si1>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [0, 0] from %[[V0]] :
+// CHECK-SAME:          tuple<si32> -> tuple<si32, si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = emit [0, 0] from %0 : tuple<si32> -> tuple<si32, si32>
+    yield %1 : tuple<si32, si32>
+  }
+}
+
+// -----
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]] :
+// CHECK-SAME:          tuple<si32, si1> -> tuple<si1>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si1>
+    %1 = emit [1] from %0 : tuple<si32, si1> -> tuple<si1>
+    yield %1 : tuple<si1>
+  }
+}

--- a/test/Target/SubstraitPB/Export/emit-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/emit-invalid.mlir
@@ -1,41 +1,14 @@
 // RUN: structured-translate -verify-diagnostics -split-input-file %s \
 // RUN:   -substrait-to-protobuf
 
-// Two different `emit` consumers: can't export into a single `Emit` message.
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    // expected-error@+1 {{'substrait.named_table' op is consumed by different emit ops (try running canonicalization and/or CSE)}}
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    %2 = emit [0, 1] from %0 : tuple<si1, si32> -> tuple<si1, si32>
-    yield %1 : tuple<si32, si1>
-  }
-}
-
-// -----
-
-// One `emit` consumer, one other consumer: can't export to a single `Emit`
-// message.
-
-substrait.plan version 0 : 42 : 1 {
-  relation {
-    // expected-error@+1 {{'substrait.named_table' op is consumed by different emit ops (try running canonicalization and/or CSE)}}
-    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
-    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    yield %0 : tuple<si1, si32>
-  }
-}
-
-// -----
-
 // Two subsequent `emit` ops: the export can't deal with that.
 
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    // expected-note@+1 {{op exported to 'input' message}}
     %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
-    // expected-error@+1 {{'substrait.emit' op with input produced by 'substrait.emit' op not supported for export (try running canonicalization)}}
+    // expected-error@+1 {{'substrait.emit' op has 'input' that already has 'emit' message (try running canonicalization?)}}
     %2 = emit [1, 0] from %1 : tuple<si32, si1> -> tuple<si1, si32>
     yield %2 : tuple<si1, si32>
   }

--- a/test/Target/SubstraitPB/Export/emit-invalid.mlir
+++ b/test/Target/SubstraitPB/Export/emit-invalid.mlir
@@ -1,0 +1,42 @@
+// RUN: structured-translate -verify-diagnostics -split-input-file %s \
+// RUN:   -substrait-to-protobuf
+
+// Two different `emit` consumers: can't export into a single `Emit` message.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    // expected-error@+1 {{'substrait.named_table' op is consumed by different emit ops (try running canonicalization and/or CSE)}}
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    %2 = emit [0, 1] from %0 : tuple<si1, si32> -> tuple<si1, si32>
+    yield %1 : tuple<si32, si1>
+  }
+}
+
+// -----
+
+// One `emit` consumer, one other consumer: can't export to a single `Emit`
+// message.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    // expected-error@+1 {{'substrait.named_table' op is consumed by different emit ops (try running canonicalization and/or CSE)}}
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    yield %0 : tuple<si1, si32>
+  }
+}
+
+// -----
+
+// Two subsequent `emit` ops: the export can't deal with that.
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    // expected-error@+1 {{'substrait.emit' op with input produced by 'substrait.emit' op not supported for export (try running canonicalization)}}
+    %2 = emit [1, 0] from %1 : tuple<si32, si1> -> tuple<si1, si32>
+    yield %2 : tuple<si1, si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/emit.mlir
+++ b/test/Target/SubstraitPB/Export/emit.mlir
@@ -1,0 +1,58 @@
+// RUN: structured-translate -substrait-to-protobuf --split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: structured-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | structured-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
+// RUN: | structured-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | FileCheck %s
+
+
+// Checks that the `emit` field of a `named_table` is exported correctly.
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      read {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          emit {
+// CHECK-NEXT:            output_mapping: 1
+// CHECK-NEXT:          }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si1>
+    %1 = emit [1] from %0 : tuple<si32, si1> -> tuple<si1>
+    yield %1 : tuple<si1>
+  }
+}
+
+// -----
+
+// Checks that the `emit` field of a `named_table` is exported correctly.
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      filter {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          emit {
+// CHECK-NEXT:            output_mapping: 1
+// CHECK-NEXT:          }
+// CHECK-LABEL:         input {
+// CHECK-NEXT:            read {
+// CHECK-NEXT:              common {
+// CHECK-NEXT:                direct
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si1>
+    %1 = filter %0 : tuple<si32, si1> {
+    ^bb0(%arg : tuple<si32, si1>):
+      %2 = literal -1 : si1
+      yield %2 : si1
+    }
+    %2 = emit [1] from %1 : tuple<si32, si1> -> tuple<si1>
+    yield %2 : tuple<si1>
+  }
+}

--- a/test/Target/SubstraitPB/Export/emit.mlir
+++ b/test/Target/SubstraitPB/Export/emit.mlir
@@ -9,6 +9,27 @@
 // RUN:   --split-input-file --output-split-marker="# -----" \
 // RUN: | FileCheck %s
 
+// Checks that the `emit` field of a `crosss` is exported correctly.
+
+// CHECK-LABEL: relations {
+// CHECK-NEXT:    rel {
+// CHECK-NEXT:      cross {
+// CHECK-NEXT:        common {
+// CHECK-NEXT:          emit {
+// CHECK-NEXT:            output_mapping: 1
+// CHECK-NEXT:            output_mapping: 0
+// CHECK-NEXT:          }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = cross %0 x %0 : tuple<si32> x tuple<si32>
+    %2 = emit [1, 0] from %1 : tuple<si32, si32> -> tuple<si32, si32>
+    yield %2 : tuple<si32, si32>
+  }
+}
+
+// -----
 
 // Checks that the `emit` field of a `named_table` is exported correctly.
 

--- a/test/Target/SubstraitPB/Import/emit.textpb
+++ b/test/Target/SubstraitPB/Import/emit.textpb
@@ -1,0 +1,137 @@
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
+# RUN: | FileCheck %s
+
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | structured-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
+# RUN: | structured-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | FileCheck %s
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]]
+# CHECK-NEXT:      yield %[[V1]]
+
+relations {
+  rel {
+    read {
+      common {
+        emit {
+          output_mapping: 1
+          output_mapping: 0
+        }
+      }
+      base_schema {
+        names: "a"
+        names: "b"
+        struct {
+          types {
+            bool {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          types {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = emit [0, 0] from %[[V0]]
+# CHECK-NEXT:      yield %[[V1]]
+
+relations {
+  rel {
+    read {
+      common {
+        emit {
+          output_mapping: 0
+          output_mapping: 0
+        }
+      }
+      base_schema {
+        names: "a"
+        struct {
+          types {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}
+
+# -----
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      %[[V0:.*]] = named_table
+# CHECK-NEXT:      %[[V1:.*]] = emit [1] from %[[V0]]
+# CHECK-NEXT:      yield %[[V1]]
+
+relations {
+  rel {
+    read {
+      common {
+        emit {
+          output_mapping: 1
+        }
+      }
+      base_schema {
+        names: "a"
+        names: "b"
+        struct {
+          types {
+            i32 {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          types {
+            bool {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          nullability: NULLABILITY_REQUIRED
+        }
+      }
+      named_table {
+        names: "t1"
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
This PR is based on and, therefore, includes #820 and its dependencies.

The commit introduces handling for the `emit_kind` field of the
`RelCommon` message, which is a common field of all (?) cases of the
`Rel` message. The current design models this field as a dedicated op
such that the output mapping is only ever present in that op, `emit`.

There are at least two alternatives to this IR design. The first one
consists of making the output mapping part of each of the ops the
represnet `Rel` messages and expose it through the `RelOpInterface`.
However, this would mean that (1) the custom assembly of each op would
have to represent the mapping, which is manual effort and a possible
source for inconsistencies, (2) each op would have to implement type
inference in the presence of a mapping, and (3) most rewrites of all ops
would have to take that mapping into account for their semantics. Having
the mapping in one place makes all of this simpler. The downside is that
what is kept in a single place in the Substrait protobuf format is now
spread across two ops in the MLIR representation. However, I believe
that this is the smaller of two evils and the current import and export
seems to work.

Another alternative would be to combine the two: make the mapping part
of all ops but *also* introduce a dedicated `emit` op. Then, two passes
could move the mapping from one to the other depending on which of the
two representations would be more convenient. However, this would not
get rid of Issues (1) and (2) above and lead to more concepts and code.