### PR TITLE
[Substrait] Add folder for EmitOp with identity mapping.

### DIFF
--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -283,6 +283,7 @@ def Substrait_EmitOp : Substrait_RelOp<"emit", [
   let assemblyFormat = [{
     $mapping `from` $input attr-dict `:` type($input) `->` type($result)
   }];
+  let hasFolder = 1;
   let extraClassDefinition = [{
     /// Implement OpAsmOpInterface.
     ::llvm::StringRef $cppClass::getDefaultDialect() {

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -72,6 +72,24 @@ CrossOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
   return success();
 }
 
+OpFoldResult EmitOp::fold(FoldAdaptor adaptor) {
+  // Return if the mapping is not the identity mapping.
+  int64_t numFields = cast<TupleType>(getInput().getType()).size();
+  int64_t numIndices = getMapping().size();
+  if (numFields != numIndices)
+    return {};
+  for (int64_t i = 0; i < numIndices; ++i) {
+    auto attr = getMapping()[i];
+    int64_t index = cast<IntegerAttr>(attr).getInt();
+    if (index != i)
+      return {};
+  }
+
+  // The `emit` op *has* an identity mapping, so it does not have any effect.
+  // Return its input instead.
+  return getInput();
+}
+
 LogicalResult
 EmitOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
                          ValueRange operands, DictionaryAttr attributes,

--- a/test/Dialect/Substrait/canonicalize.mlir
+++ b/test/Dialect/Substrait/canonicalize.mlir
@@ -1,0 +1,53 @@
+// RUN: structured-opt -split-input-file %s -canonicalize \
+// RUN: | FileCheck %s
+
+// Check that identiy mapping is folded.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      yield %[[V0]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [0, 1] from %0 : tuple<si1, si32> -> tuple<si1, si32>
+    yield %1 : tuple<si1, si32>
+  }
+}
+
+// -----
+
+// Check that non-identiy mapping is not folded.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit {{.*}} from %[[V0]]
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    yield %1 : tuple<si32, si1>
+  }
+}
+
+// -----
+
+// Check that identiy prefix is not folded.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [0] from %[[V0]]
+// CHECK-NEXT:      yield %[[V1]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [0] from %0 : tuple<si1, si32> -> tuple<si1>
+    yield %1 : tuple<si1>
+  }
+}


### PR DESCRIPTION
This PR is based on and, therefor, includes #825 and its dependencies.

This folds the result of an `emit` op with identity mapping to its
input. For example, it folds the following snippet:

```mlir
%0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
%1 = emit [0, 1] from %0 : tuple<si1, si32> -> tuple<si1, si32>
// usages of %1
```

into

```mlir
%0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
// usages of %0 instead of %1
```