### PR TITLE
[Substrait] Make all `RelOp`s `Pure`. 

### DIFF
--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -13,6 +13,7 @@ include "structured/Dialect/Substrait/IR/SubstraitDialect.td"
 include "structured/Dialect/Substrait/IR/SubstraitInterfaces.td"
 include "structured/Dialect/Substrait/IR/SubstraitTypes.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/BuiltinAttributes.td"
 include "mlir/IR/CommonAttrConstraints.td"
 include "mlir/IR/OpBase.td"
@@ -222,7 +223,7 @@ def Substrait_LiteralOp : Substrait_ExpressionOp<"literal", [
 /// Attaches all traits that ops representing a `Rel` message type should have.
 class Substrait_RelOp<string mnemonic, list<Trait> traits = []> :
   Substrait_Op<mnemonic, traits # [
-    Substrait_RelOpInterface,
+    Substrait_RelOpInterface, Pure,
     PredOpTrait<"result must be extactly one Relation",
       And<[
         CPred<"$_op.getNumResults() == 1">,

--- a/test/Dialect/Substrait/canonicalize.mlir
+++ b/test/Dialect/Substrait/canonicalize.mlir
@@ -59,8 +59,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-LABEL: substrait.plan
 // CHECK-NEXT:    relation
 // CHECK-NEXT:      %[[V0:.*]] = named_table
-// TODO(ingomueller): check for DCE once implemented.
-// CHECK:           yield %[[V0]]
+// CHECK-NEXT:      yield %[[V0]]
 
 substrait.plan version 0 : 42 : 1 {
   relation {


### PR DESCRIPTION
This PR depends on and, therefore, includes #830 ~~and its dependencies~~.

This allows canonicalization to remove ops whose results aren't used.
The commit also adapts one test to make sure that that is actually the
case.