### PR TITLE
[Substrait] Initial version of emit deduplication pass.

### DIFF
--- a/include/structured/Dialect/Substrait/CMakeLists.txt
+++ b/include/structured/Dialect/Substrait/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/include/structured/Dialect/Substrait/Transforms/CMakeLists.txt
+++ b/include/structured/Dialect/Substrait/Transforms/CMakeLists.txt
@@ -1,0 +1,3 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name Substrait)
+add_public_tablegen_target(MLIRSubstraitTransformsIncGen)

--- a/include/structured/Dialect/Substrait/Transforms/Passes.h
+++ b/include/structured/Dialect/Substrait/Transforms/Passes.h
@@ -1,0 +1,33 @@
+//===- Passes.h - Substrait pass declarations -------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef STRUCTURED_DIALECT_SUBSTRAIT_TRANSFORMS_PASSES_H_
+#define STRUCTURED_DIALECT_SUBSTRAIT_TRANSFORMS_PASSES_H_
+
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace substrait {
+
+#define GEN_PASS_DECL
+#include "structured/Dialect/Substrait/Transforms/Passes.h.inc"
+
+/// Create a pass to eliminate duplicate fields in `emit` ops.
+std::unique_ptr<Pass> createEmitDeduplicationPass();
+
+/// Add patterns that eliminate duplicate fields in `emit` ops.
+void populateEmitDeduplicationPatterns(RewritePatternSet &patterns);
+
+/// Generate the code for registering passes.
+#define GEN_PASS_REGISTRATION
+#include "structured/Dialect/Substrait/Transforms/Passes.h.inc"
+
+} // namespace substrait
+} // namespace mlir
+
+#endif // STRUCTURED_DIALECT_SUBSTRAIT_TRANSFORMS_PASSES_H_

--- a/include/structured/Dialect/Substrait/Transforms/Passes.td
+++ b/include/structured/Dialect/Substrait/Transforms/Passes.td
@@ -1,0 +1,55 @@
+//===-- Passes.td - Substrait pass definition file ---------*- tablegen -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef STRUCTURED_DIALECT_SUBSTRAIT_TRANSFORMS_PASSES
+#define STRUCTURED_DIALECT_SUBSTRAIT_TRANSFORMS_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def SubstraitEmitDeduplicationPass
+    : Pass<"substrait-emit-deduplication"> {
+  let summary = "Remove duplicate emit fields.";
+  let description = [{
+    Removes duplicates in the mapping of `emit` ops. This is somewhat similar to
+    CSE in that it fuses redundant values; however, the redudant values are
+    fields in the tuples/rows/structs inside of a `Relation` rather than SSA
+    values. The deduplication consist of a pattern for each `RelOp` that removes
+    the duplicate fields in a preceeding `emit` op and then re-establishes the
+    original sequence of fields with a subsequent `emit` op (which may be fused
+    with other emit ops and/or enable further deduplication).
+
+    Example:
+
+    ```mlir
+    %0 = ...
+    %1 = ...
+    %2 = emit [0, 0] from %0 : tuple<si32> -> tuple<si32, si32>
+    %3 = cross %1 x %2 : tuple<si1> x tuple<si32, si32>
+    yield $3 : tuple<si1, si32, si32>
+    ```
+
+    Here, the `emit` op introduces a duplicate field by emitting the field `0`
+    twice, so subsequent `RelOp`s have larger inputs than necessary. The pass
+    pushes the duplication through the subsequent op, `cross`, like this:
+
+    ```mlir
+    %0 = ...
+    %1 = ...
+    %2 = emit [0] from %0 : tuple<si32> -> tuple<si32, si32>
+    %3 = cross %1 x %2 : tuple<si1> x tuple<si32>
+    %4 = emit [0, 1, 1] from %0 : tuple<si1, si32> -> tuple<si1, si32, si32>
+    yield $4 : tuple<si1, si32, si32>
+    ```
+
+    The final `emit` cannot be pushed further as the encompassing `relation`
+    needs to keep the fields indicated by the `yield` op.
+  }];
+  let constructor = "::mlir::substrait::createEmitDeduplicationPass()";
+}
+
+#endif // STRUCTURED_DIALECT_SUBSTRAIT_TRANSFORMS_PASSES

--- a/lib/Dialect/Substrait/CMakeLists.txt
+++ b/lib/Dialect/Substrait/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/lib/Dialect/Substrait/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Substrait/Transforms/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_mlir_dialect_library(MLIRSubstraitTransforms
+  EmitDeduplication.cpp
+
+  DEPENDS
+  MLIRSubstraitTransformsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRIR
+  MLIRPass
+  MLIRRewrite
+  MLIRSubstraitDialect
+  MLIRTransformUtils
+)

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -149,7 +149,7 @@ struct PushDuplicateThroughCrossJoinPattern : public OpRewritePattern<CrossOp> {
       idx += numLeftIndices;
 
     if (!leftHasDuplicates && !rightHasDuplicates)
-      // Note: if we end up failing here, then both invokations of
+      // Note: if we end up failing here, then both invocations of
       // `createDeduplicatingEmit` returned without creating a new (`emit`) op.
       return rewriter.notifyMatchFailure(
           op, "none of the 'emit' inputs have duplicates");

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -1,0 +1,185 @@
+//===- EmitDeduplication.cpp - Impl. of emit deduplication ------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "structured/Dialect/Substrait/Transforms/Passes.h"
+
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "structured/Dialect/Substrait/IR/Substrait.h"
+
+namespace mlir::substrait {
+#define GEN_PASS_DEF_SUBSTRAITEMITDEDUPLICATIONPASS
+#include "structured/Dialect/Substrait/Transforms/Passes.h.inc"
+} // namespace mlir::substrait
+
+using namespace llvm;
+using namespace mlir;
+using namespace mlir::substrait;
+
+namespace {
+
+struct SubstraitEmitDeduplicationPass
+    : substrait::impl::SubstraitEmitDeduplicationPassBase<
+          SubstraitEmitDeduplicationPass> {
+  using substrait::impl::SubstraitEmitDeduplicationPassBase<
+      SubstraitEmitDeduplicationPass>::SubstraitEmitDeduplicationPassBase;
+
+  void runOnOperation() override;
+};
+
+void SubstraitEmitDeduplicationPass::runOnOperation() {
+  mlir::RewritePatternSet patterns(&getContext());
+  populateEmitDeduplicationPatterns(patterns);
+  if (failed(mlir::applyPatternsAndFoldGreedily(getOperation(),
+                                                std::move(patterns)))) {
+    Location loc = getOperation()->getLoc();
+    emitError(loc) << "emit deduplication: pattern application failed";
+    signalPassFailure();
+  }
+}
+
+/// If the given `input` was produced by an `emit` op with duplicates, creates a
+/// new `emit` op without duplicates and returns the result of the new `emit`.
+/// Otherwise, i.e., if the `input` was not produced by an `emit` op or that op
+/// did not have duplicates, returns the original `input`. In both cases, also
+/// populates `reverseMapping` with the mapping that re-establishes the original
+/// order of the fields from the deduplicated order and returns the number of
+/// fields after deduplication and whether the `input` was deduplicated.
+std::tuple<Value, int64_t, bool>
+createDeduplicatingEmit(Value input, SmallVector<int64_t> &reverseMapping,
+                        PatternRewriter &rewriter) {
+  // Handles the bases cases where the input either has no `emit` op or an
+  // `emit` op with no duplicates. In that case, the returned value is just the
+  // `input` and the reverse mapping is just the identity.
+  auto handleNoDuplicates = [&]() {
+    int64_t numInputFields = cast<TupleType>(input.getType()).getTypes().size();
+    for (auto i : iota_range<int64_t>(0, numInputFields,
+                                      /*Inclusive=*/false))
+      reverseMapping.push_back(i);
+    return std::tuple<Value, int64_t, bool>{input, numInputFields, false};
+  };
+
+  // Input is not an 'emit' op: handle base case.
+  auto emitOp = llvm::dyn_cast_if_present<EmitOp>(input.getDefiningOp());
+  if (!emitOp)
+    return handleNoDuplicates();
+
+  // Compute the new mapping without duplicates as well as, for each position in
+  // the old mapping, the position in the new mapping.
+  ArrayAttr oldInputMapping = emitOp.getMapping();
+  SmallVector<int64_t> newInputMapping;
+  SmallVector<int64_t> oldToNewInputMapping;
+  {
+    llvm::DenseMap<int64_t, int64_t> indexPositions;
+    oldToNewInputMapping.reserve(oldInputMapping.size());
+    for (auto [i, attr] : enumerate(oldInputMapping)) {
+      int64_t index = cast<IntegerAttr>(attr).getInt();
+      auto [it, success] = indexPositions.try_emplace(index, i);
+      if (success)
+        newInputMapping.push_back(index);
+      oldToNewInputMapping.push_back(it->second);
+    }
+  }
+
+  // If the new and old input mappings have the same size, then there are no
+  // duplicates, so we handle it as a base case.
+  if (newInputMapping.size() == oldInputMapping.size())
+    return handleNoDuplicates();
+
+  // Compute the mapping that re-establishes the original emit order.
+  reverseMapping.reserve(reverseMapping.size() + newInputMapping.size());
+  {
+    // Compute the reverse mapping of the input.
+    SmallVector<int64_t> reverseInputMapping(oldInputMapping.size());
+    for (auto [i, index] : enumerate(newInputMapping))
+      reverseInputMapping[index] = i;
+
+    // The first fields of the reverse mapping reverse the effect of the
+    // deduplication of the emit op on the input.
+    for (auto [i, attr] :
+         enumerate(oldInputMapping.getAsRange<IntegerAttr>())) {
+      int64_t reverseIndex = reverseInputMapping[attr.getInt()];
+      reverseMapping.push_back(reverseIndex);
+    }
+  }
+
+  // If we did have duplicates, add an `emit` op that deduplicates the input.
+  Location loc = emitOp.getLoc();
+  ArrayAttr newInputMappingAttr = rewriter.getI64ArrayAttr(newInputMapping);
+  auto newEmitOp =
+      rewriter.create<EmitOp>(loc, emitOp.getInput(), newInputMappingAttr);
+
+  return {newEmitOp, newInputMapping.size(), true};
+}
+
+/// Pushes duplicates in the mappings of `emit` ops producing either of the two
+/// inputs through the `cross` op. This works by introducing new emit ops
+/// without the duplicates, creating a new `cross` op that uses them, and
+/// finally a new `emit` op that maps back to the original order.
+struct PushDuplicateThroughCrossJoinPattern : public OpRewritePattern<CrossOp> {
+  using OpRewritePattern<CrossOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(CrossOp op,
+                                PatternRewriter &rewriter) const override {
+    bool isLeftEmit = isa_and_present<EmitOp>(op.getLeft().getDefiningOp());
+    bool isRightEmit = isa_and_present<EmitOp>(op.getRight().getDefiningOp());
+    if (!isLeftEmit && !isRightEmit)
+      return rewriter.notifyMatchFailure(
+          op, "none of the operands is an 'emit' op");
+
+    // Create input ops for the new `cross` op. These may be the original inputs
+    // or `emit` ops that remove duplicates.
+
+    // Left input: the reverse mapping of the left input works as the prefix of
+    // the reverse mapping of the new `cross` op.
+    SmallVector<int64_t> reverseMapping;
+    auto [newLeftInput, numLeftIndices, leftHasDuplicates] =
+        createDeduplicatingEmit(op.getLeft(), reverseMapping, rewriter);
+
+    // Right input: the reverse mapping of the right input needs to be adjusted
+    // by the number of deduplicated fields in the left input.
+    int64_t numLeftOriginalindices = reverseMapping.size();
+    auto [newRightInput, numRightIndices, rightHasDuplicates] =
+        createDeduplicatingEmit(op.getRight(), reverseMapping, rewriter);
+    for (int64_t &idx : drop_begin(reverseMapping, numLeftOriginalindices))
+      idx += numLeftIndices;
+
+    if (!leftHasDuplicates && !rightHasDuplicates)
+      // Note: if we end up failing here, then both invokations of
+      // `createDeduplicatingEmit` returned without creating a new (`emit`) op.
+      return rewriter.notifyMatchFailure(
+          op, "none of the 'emit' inputs have duplicates");
+
+    // Create new cross op with the two deduplicated inputs.
+    auto newOp =
+        rewriter.create<CrossOp>(op.getLoc(), newLeftInput, newRightInput);
+
+    // Replace old cross op with emit op that maps back to old emit order.
+    ArrayAttr reverseMappingAttr = rewriter.getI64ArrayAttr(reverseMapping);
+    rewriter.replaceOpWithNewOp<EmitOp>(op, newOp, reverseMappingAttr);
+
+    return success();
+  }
+};
+
+} // namespace
+
+namespace mlir {
+namespace substrait {
+
+void populateEmitDeduplicationPatterns(RewritePatternSet &patterns) {
+  MLIRContext *context = patterns.getContext();
+  patterns.add<PushDuplicateThroughCrossJoinPattern>(context);
+}
+
+std::unique_ptr<Pass> createEmitDeduplicationPass() {
+  return std::make_unique<SubstraitEmitDeduplicationPass>();
+}
+
+} // namespace substrait
+} // namespace mlir

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -58,8 +58,7 @@ createDeduplicatingEmit(Value input, SmallVector<int64_t> &reverseMapping,
   // `input` and the reverse mapping is just the identity.
   auto handleNoDuplicates = [&]() {
     int64_t numInputFields = cast<TupleType>(input.getType()).getTypes().size();
-    for (auto i : iota_range<int64_t>(0, numInputFields,
-                                      /*Inclusive=*/false))
+    for (auto i : seq(numInputFields))
       reverseMapping.push_back(i);
     return std::tuple<Value, int64_t, bool>{input, numInputFields, false};
   };

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -1,0 +1,151 @@
+// RUN: structured-opt -split-input-file %s -substrait-emit-deduplication \
+// RUN: | FileCheck %s
+
+// `cross` op with left `emit` input with duplicates.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
+// CHECK-NEXT:      %[[V2:.*]] = cross %[[V1]] x %[[V0]] :
+// CHECK-NEXT:      %[[V3:.*]] = emit [0, 0, 1, 1, 0, 2, 3] from %[[V2]] :
+// CHECK-NEXT:      yield %[[V3]] : tuple<si32, si32, si1, si1, si32, si1, si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 1, 0, 0, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32, si1, si1, si32>
+    %2 = cross %1 x %0 : tuple<si32, si32, si1, si1, si32> x tuple<si1, si32>
+    yield %2 : tuple<si32, si32, si1, si1, si32, si1, si32>
+  }
+}
+
+// -----
+
+// `cross` op with left `emit` input without duplicates.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
+// CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] :
+// CHECK-NEXT:      yield %[[V2]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    %2 = cross %0 x %1 : tuple<si1, si32> x tuple<si32, si1>
+    yield %2 : tuple<si1,si32, si32, si1>
+  }
+}
+
+// -----
+
+// `cross` op with right `emit` input with duplicates.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
+// CHECK-NEXT:      %[[V2:.*]] = cross %[[V0]] x %[[V1]] :
+// CHECK-NEXT:      %[[V3:.*]] = emit [0, 1, 2, 2, 3, 3, 2] from %[[V2]] :
+// CHECK-NEXT:      yield %[[V3]] : tuple<si1, si32, si32, si32, si1, si1, si32>
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 1, 0, 0, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32, si1, si1, si32>
+    %2 = cross %0 x %1 : tuple<si1, si32> x tuple<si32, si32, si1, si1, si32>
+    yield %2 : tuple<si1, si32, si32, si32, si1, si1, si32>
+  }
+}
+
+// -----
+
+// `cross` op with right `emit` input without duplicates.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [1, 0] from %[[V0]] :
+// CHECK-NEXT:      %[[V2:.*]] = cross %[[V1]] x %[[V0]] :
+// CHECK-NEXT:      yield %[[V2]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    %2 = cross %1 x %0 : tuple<si32, si1> x tuple<si1, si32>
+    yield %2 : tuple<si32, si1, si1, si32>
+  }
+}
+
+// -----
+
+// `cross` op with two `emit` inputs with duplicates.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-DAG:       %[[V1:.*]] = emit [1] from %[[V0]] :
+// CHECK-DAG:       %[[V2:.*]] = emit [0] from %[[V0]] :
+// CHECK-NEXT:      %[[V3:.*]] = cross %[[V1]] x %[[V2]] :
+// CHECK-NEXT:      %[[V4:.*]] = emit [0, 0, 1, 1] from %[[V3]] :
+// CHECK-NEXT:      yield %[[V4]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32>
+    %2 = emit [0, 0] from %0 : tuple<si1, si32> -> tuple<si1, si1>
+    %3 = cross %1 x %2 : tuple<si32, si32> x tuple<si1, si1>
+    yield %3 : tuple<si32, si32, si1, si1>
+  }
+}
+
+// -----
+
+// `cross` op with mixed `emit` duplicates/no duplicates inputs.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-DAG:       %[[V1:.*]] = emit [1, 0] from %[[V0]] :
+// CHECK-DAG:       %[[V2:.*]] = emit [0] from %[[V0]] :
+// CHECK-NEXT:      %[[V3:.*]] = cross %[[V1]] x %[[V2]] :
+// CHECK-NEXT:      %[[V4:.*]] = emit [0, 1, 2, 2] from %[[V3]] :
+// CHECK-NEXT:      yield %[[V4]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    %2 = emit [0, 0] from %0 : tuple<si1, si32> -> tuple<si1, si1>
+    %3 = cross %1 x %2 : tuple<si32, si1> x tuple<si1, si1>
+    yield %3 : tuple<si32, si1, si1, si1>
+  }
+}
+
+// -----
+
+// `cross` op with mixed `emit` duplicates/no duplicates inputs.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-DAG:       %[[V1:.*]] = emit [1, 0] from %[[V0]] :
+// CHECK-DAG:       %[[V2:.*]] = emit [1] from %[[V0]] :
+// CHECK-NEXT:      %[[V3:.*]] = cross %[[V2]] x %[[V1]] :
+// CHECK-NEXT:      %[[V4:.*]] = emit [0, 0, 1, 2] from %[[V3]] :
+// CHECK-NEXT:      yield %[[V4]]
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si1, si32>
+    %1 = emit [1, 1] from %0 : tuple<si1, si32> -> tuple<si32, si32>
+    %2 = emit [1, 0] from %0 : tuple<si1, si32> -> tuple<si32, si1>
+    %3 = cross %1 x %2 : tuple<si32, si32> x tuple<si32, si1>
+    yield %3 : tuple<si32, si32, si32, si1>
+  }
+}

--- a/tools/structured-opt/structured-opt.cpp
+++ b/tools/structured-opt/structured-opt.cpp
@@ -20,6 +20,7 @@
 #include "structured/Dialect/Iterators/IR/Iterators.h"
 #include "structured/Dialect/Iterators/Transforms/Passes.h"
 #include "structured/Dialect/Substrait/IR/Substrait.h"
+#include "structured/Dialect/Substrait/Transforms/Passes.h"
 #include "structured/Dialect/Tabular/IR/Tabular.h"
 #include "structured/Dialect/Tuple/IR/Tuple.h"
 #include "structured/Dialect/Tuple/Transforms/Passes.h"
@@ -31,6 +32,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 
 using namespace mlir;
+using namespace mlir::substrait;
 
 static void registerIteratorDialects(DialectRegistry &registry) {
   registry.insert<
@@ -56,6 +58,7 @@ int main(int argc, char **argv) {
   registerAllPasses();
   registerStructuredConversionPasses();
   registerIteratorsPasses();
+  registerSubstraitPasses();
   registerTuplePasses();
 
   DialectRegistry registry;


### PR DESCRIPTION
This PR is based on and, therefor, contains #828 ~~and #829~~.

This pass removes redundant values introduced by duplicated fields in
the `mapping`s of `emit` ops. This commit puts the boilerplate into
place and implements a pattern to handle `emit` ops around `cross` ops.
More work is needed to make the pass work with other ops.