### PR TITLE
[Substrait] Extend emit deduplication to FilterOp. 

### DIFF
--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -230,7 +230,8 @@ struct PushDuplicatesThroughFilterPattern : public OpRewritePattern<FilterOp> {
 
   LogicalResult matchAndRewrite(FilterOp op,
                                 PatternRewriter &rewriter) const override {
-    if (!isa_and_present<EmitOp>(op.getInput().getDefiningOp()))
+    auto emitOp = op.getInput().getDefiningOp<EmitOp>();
+    if (!emitOp)
       return rewriter.notifyMatchFailure(
           op, "input operand is not produced by an 'emit' op");
 
@@ -253,7 +254,6 @@ struct PushDuplicatesThroughFilterPattern : public OpRewritePattern<FilterOp> {
                                 newOp.getCondition().end());
 
     // Update the `condition` region.
-    auto emitOp = op.getInput().getDefiningOp<EmitOp>();
     deduplicateRegionArgs(newOp.getCondition(), emitOp.getMapping(),
                           newInput.getType(), rewriter);
 

--- a/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
+++ b/lib/Dialect/Substrait/Transforms/EmitDeduplication.cpp
@@ -116,6 +116,60 @@ createDeduplicatingEmit(Value input, SmallVector<int64_t> &reverseMapping,
   return {newEmitOp, newInputMapping.size(), true};
 }
 
+/// Deduplicates the fields of the region with a single `Tuple` argument using
+/// the provided (deduplicating) mapping. This involves changing the type of the
+/// region argument to the provided `newElementType`, which must be the type
+/// obtained by applying deduplication to the argument type of the provided
+/// `region`, as well as changing all `field_reference` ops using the region
+/// argument to work on the deduplicated type.
+// TODO(ingomueller): We could add an overload for this function that computes
+// `newElementType` from the type of the region argument and the mapping.
+void deduplicateRegionArgs(Region &region, ArrayAttr newMapping,
+                           Type newElementType, PatternRewriter &rewriter) {
+  assert(region.getNumArguments() == 1 &&
+         "only regions with 1 argument are supported");
+  auto oldElementType = cast<TupleType>(region.getArgument(0).getType());
+  int64_t numOldFields = oldElementType.getTypes().size();
+
+  // For each position in the original input type, compute which position it
+  // corresponds to in the deduplicated input. This is required for replacing
+  // field references to the original type with references to the deduplicated
+  // type.
+  SmallVector<int64_t> oldToNewPositions;
+  oldToNewPositions.reserve(numOldFields);
+  {
+    llvm::DenseMap<int64_t, int64_t> indexPositions;
+    for (auto attr : newMapping.getAsRange<IntegerAttr>()) {
+      int64_t index = attr.getInt();
+      int64_t pos = indexPositions.size();
+      auto [it, success] = indexPositions.try_emplace(index, pos);
+      oldToNewPositions.push_back(it->second);
+    }
+  }
+
+  // Update field references using the region argument.
+  for (Operation *user : region.getArgument(0).getUsers()) {
+    // We are only interested in `field_reference` ops.
+    if (!isa<FieldReferenceOp>(user))
+      continue;
+    auto refOp = cast<FieldReferenceOp>(user);
+
+    // Compute new position array from the old one.
+    ArrayRef<int64_t> oldPositions = refOp.getPosition();
+    SmallVector<int64_t> newPositions;
+    newPositions.reserve(oldPositions.size());
+    for (auto index : oldPositions)
+      newPositions.push_back(index);
+    newPositions[0] = oldToNewPositions[newPositions[0]];
+
+    // Update op in place.
+    refOp.setPosition(newPositions);
+  }
+
+  // Update argument type of the region.
+  region.getArgument(0).setType(newElementType);
+}
+
 /// Pushes duplicates in the mappings of `emit` ops producing either of the two
 /// inputs through the `cross` op. This works by introducing new emit ops
 /// without the duplicates, creating a new `cross` op that uses them, and
@@ -166,6 +220,52 @@ struct PushDuplicatesThroughCrossPattern : public OpRewritePattern<CrossOp> {
   }
 };
 
+/// Pushes duplicates in the mappings of `emit` ops producing the input through
+/// the `filter` op. This works by introducing a new `emit` op without the
+/// duplicates, creating a new `filter` op updated to work on the deduplicated
+/// element type, and finally a new `emit` op that maps back to the original
+/// order.
+struct PushDuplicatesThroughFilterPattern : public OpRewritePattern<FilterOp> {
+  using OpRewritePattern<FilterOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(FilterOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!isa_and_present<EmitOp>(op.getInput().getDefiningOp()))
+      return rewriter.notifyMatchFailure(
+          op, "input operand is not produced by an 'emit' op");
+
+    // Create input ops for the new `filter` op. These may be the original
+    // inputs or `emit` ops that remove duplicates.
+    SmallVector<int64_t> reverseMapping;
+    auto [newInput, numDedupIndices, hasDuplicates] =
+        createDeduplicatingEmit(op.getInput(), reverseMapping, rewriter);
+
+    if (!hasDuplicates)
+      // Note: if we end up failing here, then the invokation of
+      // `createDeduplicatingEmit` returned without creating a new (`emit`) op.
+      return rewriter.notifyMatchFailure(
+          op, "the 'emit' input does not have duplicates");
+
+    // Create new `filter` op. Move over the `condition` region. This needs to
+    // happen now because replacing the op will destroy the region.
+    auto newOp = rewriter.create<FilterOp>(op.getLoc(), newInput);
+    rewriter.inlineRegionBefore(op.getCondition(), newOp.getCondition(),
+                                newOp.getCondition().end());
+
+    // Update the `condition` region.
+    auto emitOp = op.getInput().getDefiningOp<EmitOp>();
+    deduplicateRegionArgs(newOp.getCondition(), emitOp.getMapping(),
+                          newInput.getType(), rewriter);
+
+    // Replace the old `filter` op with a new `emit` op that maps back to the
+    // original emit order.
+    ArrayAttr reverseMappingAttr = rewriter.getI64ArrayAttr(reverseMapping);
+    rewriter.replaceOpWithNewOp<EmitOp>(op, newOp, reverseMappingAttr);
+
+    return failure();
+  }
+};
+
 } // namespace
 
 namespace mlir {
@@ -173,7 +273,8 @@ namespace substrait {
 
 void populateEmitDeduplicationPatterns(RewritePatternSet &patterns) {
   MLIRContext *context = patterns.getContext();
-  patterns.add<PushDuplicatesThroughCrossPattern>(context);
+  patterns.add<PushDuplicatesThroughCrossPattern,
+               PushDuplicatesThroughFilterPattern>(context);
 }
 
 std::unique_ptr<Pass> createEmitDeduplicationPass() {

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -149,3 +149,48 @@ substrait.plan version 0 : 42 : 1 {
     yield %3 : tuple<si32, si32, si32, si1>
   }
 }
+
+// -----
+
+// `filter` op.
+
+// CHECK-LABEL: substrait.plan
+// CHECK-NEXT:    relation
+// CHECK-NEXT:      %[[V0:.*]] = named_table
+// CHECK-NEXT:      %[[V1:.*]] = emit [1, 2, 0] from %[[V0]] :
+// CHECK-NEXT:      %[[V2:.*]] = filter %[[V1]] : {{.*}} {
+// CHECK-NEXT:      ^{{.*}}(%[[ARG0:.*]]: [[TYPE:.*]]):
+// CHECK-NEXT:        %[[V3:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
+// CHECK-NEXT:        %[[V4:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
+// CHECK-NEXT:        %[[V5:.*]] = field_reference %[[ARG0]]{{\[}}[1, 0]] : [[TYPE]]
+// CHECK-NEXT:        %[[V6:.*]] = field_reference %[[ARG0]]{{\[}}[1]] : [[TYPE]]
+// CHECK-NEXT:        %[[V7:.*]] = field_reference %[[V6]]{{\[}}[1]] :
+// CHECK-NEXT:        %[[V8:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
+// CHECK-NEXT:        %[[V9:.*]] = field_reference %[[ARG0]]{{\[}}[2]] : [[TYPE]]
+// CHECK-NEXT:        %[[Va:.*]] = func.call @f(%[[V3]], %[[V4]], %[[V5]], %[[V7]], %[[V8]], %[[V9]])
+// CHECK-NEXT:        yield %[[Va]] : si1
+// CHECK-NEXT:      }
+// CHECK-NEXT:      %[[Vb:.*]] = emit [0, 0, 1, 0, 2] from %[[V2]]
+
+func.func private @f(si1, si1, si1, si32, si1, si1) -> si1
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : tuple<si1, si1, tuple<si1, si32>>
+    %1 = emit [1, 1, 2, 1, 0] from %0
+        : tuple<si1, si1, tuple<si1, si32>> -> tuple<si1, si1, tuple<si1, si32>, si1, si1>
+    %2 = filter %1 : tuple<si1, si1, tuple<si1, si32>, si1, si1> {
+    ^bb0(%arg0: tuple<si1, si1, tuple<si1, si32>, si1, si1>):
+      %3 = field_reference %arg0[[0]] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+      %4 = field_reference %arg0[[1]] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+      %5 = field_reference %arg0[[2, 0]] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+      %6 = field_reference %arg0[[2]] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+      %7 = field_reference %6[[1]] : tuple<si1, si32>
+      %8 = field_reference %arg0[[3]] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+      %9 = field_reference %arg0[[4]] : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+      %a = func.call @f(%3, %4, %5, %7, %8, %9) : (si1, si1, si1, si32, si1, si1) -> si1
+      yield %a : si1
+    }
+    yield %2 : tuple<si1, si1, tuple<si1, si32>, si1, si1>
+  }
+}

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -152,7 +152,7 @@ substrait.plan version 0 : 42 : 1 {
 
 // -----
 
-// `filter` op.
+// `filter` op (`PushDuplicatesThroughFilterPattern`).
 
 // CHECK-LABEL: substrait.plan
 // CHECK-NEXT:    relation
@@ -177,6 +177,9 @@ func.func private @f(si1, si1, si1, si32, si1, si1) -> si1
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a", "b", "c", "d", "e"] : tuple<si1, si1, tuple<si1, si32>>
+    // Fields in position 1 and 3 are duplicates of field in position 0, so we
+    // expect all references to the former to be replaced by the latter and an
+    // `emit` re-establishing the original fields after the `filter`.
     %1 = emit [1, 1, 2, 1, 0] from %0
         : tuple<si1, si1, tuple<si1, si32>> -> tuple<si1, si1, tuple<si1, si32>, si1, si1>
     %2 = filter %1 : tuple<si1, si1, tuple<si1, si32>, si1, si1> {


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #831 and its dependencies.~~

This adds a new pattern that makes emit deduplication to `filter` ops by
adding a new pattern. This pattern is similar to the previous one in
that it adds a "deduplicating" `emit` op in front of the root `filter`
op and one that re-establishes the original order after it but has the
additional complexity of having to update the region to work on the
deduplicated element type as well.