### PR TITLE
[Substrait] Implement `project` operation.

### DIFF
--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -142,12 +142,13 @@ def Substrait_YieldOp : Substrait_Op<"yield", [
     Terminator,
     ParentOneOf<[
       "::mlir::substrait::FilterOp",
-      "::mlir::substrait::PlanRelOp"
+      "::mlir::substrait::PlanRelOp",
+      "::mlir::substrait::ProjectOp"
     ]>
   ]> {
   let summary = "Yields the result of a `PlanRelOp`";
-  let arguments = (ins AnyType:$value);
-  let assemblyFormat = "$value attr-dict `:` type($value)";
+  let arguments = (ins Variadic<AnyType>:$value);
+  let assemblyFormat = "attr-dict ($value^ `:` type($value))?";
   let builders = [OpBuilder<(ins), [{ /* do nothing */ }]>];
 }
 
@@ -356,6 +357,50 @@ def Substrait_NamedTableOp : Substrait_RelOp<"named_table", [
     $table_name `as` $field_names attr-dict `:` type($result)
   }];
   let hasVerifier = true;
+}
+
+def Substrait_ProjectOp : Substrait_RelOp<"project", [
+    SingleBlockImplicitTerminator<"::mlir::substrait::YieldOp">,
+    DeclareOpInterfaceMethods<OpAsmOpInterface, ["getDefaultDialect"]>
+  ]> {
+  let summary = "Project operation";
+  let description = [{
+    Represents a `ProjectRel` message together with the `RelCommon`, input
+    `Rel`, and `Expression` messages it contains. While in protobuf the
+    different `Expression` messages are distinct trees, the `project` op has
+    a single `expression` region with one terminating `yield` and the values
+    yielded by that terminator correspond to the expressions. Each individual
+    `Expression` thus corresponds to the whole use-def tree of the corresponding
+    yielded value.
+
+    Example:
+
+    ```mlir
+    %0 = ...
+    %1 = project %0 : tuple<si32> -> tuple<si32, si1, si32> {
+    ^bb0(%arg : tuple<si32>):
+      %true = literal -1 : si1
+      %42 = literal 42 : si32
+      yield %true, %42 : si1, si32
+    }
+    ```
+  }];
+  let arguments = (ins Substrait_Relation:$input);
+  let regions = (region AnyRegion:$expressions);
+  let results = (outs Substrait_Relation:$result);
+  // TODO(ingomueller): We could elide/shorten the block argument from the
+  //                    assembly by writing custom printers/parsers similar to
+  //                    `scf.for` etc.
+  let assemblyFormat = [{
+    $input attr-dict `:` type($input) `->` type($result) $expressions
+  }];
+  let hasRegionVerifier = 1;
+  let extraClassDefinition = [{
+    /// Implement OpAsmOpInterface.
+    ::llvm::StringRef $cppClass::getDefaultDialect() {
+      return SubstraitDialect::getDialectNamespace();
+    }
+  }];
 }
 
 #endif // SUBSTRAIT_DIALECT_SUBSTRAIT_IR_SUBSTRAITOPS

--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -48,6 +48,7 @@ DECLARE_EXPORT_FUNC(LiteralOp, Expression)
 DECLARE_EXPORT_FUNC(ModuleOp, Plan)
 DECLARE_EXPORT_FUNC(NamedTableOp, Rel)
 DECLARE_EXPORT_FUNC(PlanOp, Plan)
+DECLARE_EXPORT_FUNC(ProjectOp, Rel)
 DECLARE_EXPORT_FUNC(RelOpInterface, Rel)
 
 FailureOr<std::unique_ptr<pb::Message>> exportOperation(Operation *op);
@@ -264,8 +265,10 @@ FailureOr<std::unique_ptr<Rel>> exportOperation(FilterOp op) {
   auto yieldOp = llvm::cast<YieldOp>(op.getCondition().front().getTerminator());
   // TODO(ingomueller): There can be cases where there isn't a defining op but
   //                    the region argument is returned directly. Support that.
+  assert(yieldOp.getValue().size() == 1 &&
+         "fitler op must yield exactly one value");
   auto conditionOp = llvm::dyn_cast_if_present<ExpressionOpInterface>(
-      yieldOp.getValue().getDefiningOp());
+      yieldOp.getValue().front().getDefiningOp());
   if (!conditionOp)
     return op->emitOpError("condition not supported for export: yielded op was "
                            "not produced by Substrait expression op");
@@ -427,10 +430,68 @@ FailureOr<std::unique_ptr<Plan>> exportOperation(PlanOp op) {
   return std::move(plan);
 }
 
+FailureOr<std::unique_ptr<Rel>> exportOperation(ProjectOp op) {
+  // Build `RelCommon` message.
+  auto relCommon = std::make_unique<RelCommon>();
+  auto direct = std::make_unique<RelCommon::Direct>();
+  relCommon->set_allocated_direct(direct.release());
+
+  // Build input `Rel` message.
+  auto inputOp =
+      llvm::dyn_cast_if_present<RelOpInterface>(op.getInput().getDefiningOp());
+  if (!inputOp)
+    return op->emitOpError("input was not produced by Substrait relation op");
+
+  FailureOr<std::unique_ptr<Rel>> inputRel = exportOperation(inputOp);
+  if (failed(inputRel))
+    return failure();
+
+  // Build `ProjectRel` message.
+  auto projectRel = std::make_unique<ProjectRel>();
+  projectRel->set_allocated_common(relCommon.release());
+  projectRel->set_allocated_input(inputRel->release());
+
+  // Build `Expression` messages.
+  auto yieldOp =
+      llvm::cast<YieldOp>(op.getExpressions().front().getTerminator());
+  for (Value val : yieldOp.getValue()) {
+    // Make sure the yielded value was produced by an expression op.
+    auto exprRootOp =
+        llvm::dyn_cast_if_present<ExpressionOpInterface>(val.getDefiningOp());
+    if (!exprRootOp)
+      return op->emitOpError(
+          "expression not supported for export: yielded op was "
+          "not produced by Substrait expression op");
+
+    // Export the expression recursively.
+    FailureOr<std::unique_ptr<Expression>> expression =
+        exportOperation(exprRootOp);
+    if (failed(expression))
+      return failure();
+
+    // Add the expression to the `ProjectRel` message.
+    *projectRel->add_expressions() = *expression.value();
+  }
+
+  // Build `Rel` message.
+  auto rel = std::make_unique<Rel>();
+  rel->set_allocated_project(projectRel.release());
+
+  return rel;
+}
+
 FailureOr<std::unique_ptr<Rel>> exportOperation(RelOpInterface op) {
   return llvm::TypeSwitch<Operation *, FailureOr<std::unique_ptr<Rel>>>(op)
-      .Case<CrossOp, EmitOp, FieldReferenceOp, FilterOp, NamedTableOp>(
-          [&](auto op) { return exportOperation(op); })
+      .Case<
+          // clang-format off
+          CrossOp,
+          EmitOp,
+          FieldReferenceOp,
+          FilterOp,
+          NamedTableOp,
+          ProjectOp
+          // clang-format on
+          >([&](auto op) { return exportOperation(op); })
       .Default([](auto op) {
         op->emitOpError("not supported for export");
         return failure();

--- a/lib/Target/SubstraitPB/Import.cpp
+++ b/lib/Target/SubstraitPB/Import.cpp
@@ -54,6 +54,7 @@ DECLARE_IMPORT_FUNC(Literal, Expression::Literal, LiteralOp)
 DECLARE_IMPORT_FUNC(NamedTable, Rel, NamedTableOp)
 DECLARE_IMPORT_FUNC(Plan, Plan, PlanOp)
 DECLARE_IMPORT_FUNC(PlanRel, PlanRel, PlanRelOp)
+DECLARE_IMPORT_FUNC(ProjectRel, Rel, ProjectOp)
 DECLARE_IMPORT_FUNC(ReadRel, Rel, RelOpInterface)
 DECLARE_IMPORT_FUNC(Rel, Rel, RelOpInterface)
 
@@ -203,6 +204,11 @@ importLiteral(ImplicitLocOpBuilder builder,
   case Expression::Literal::LiteralTypeCase::kBoolean: {
     auto attr = IntegerAttr::get(
         IntegerType::get(context, 1, IntegerType::Signed), message.boolean());
+    return builder.create<LiteralOp>(attr);
+  }
+  case Expression::Literal::LiteralTypeCase::kI32: {
+    auto attr = IntegerAttr::get(
+        IntegerType::get(context, 32, IntegerType::Signed), message.i32());
     return builder.create<LiteralOp>(attr);
   }
   default: {
@@ -358,6 +364,58 @@ static FailureOr<PlanRelOp> importPlanRel(ImplicitLocOpBuilder builder,
   return planRelOp;
 }
 
+static mlir::FailureOr<ProjectOp> importProjectRel(ImplicitLocOpBuilder builder,
+                                                   const Rel &message) {
+  const ProjectRel &projectRel = message.project();
+
+  // Import input op.
+  const Rel &inputRel = projectRel.input();
+  mlir::FailureOr<RelOpInterface> inputOp = importRel(builder, inputRel);
+  if (failed(inputOp))
+    return failure();
+
+  // Create `expressions` block.
+  auto conditionBlock = std::make_unique<Block>();
+  auto inputTupleType =
+      cast<TupleType>(inputOp.value()->getResult(0).getType());
+  conditionBlock->addArgument(inputTupleType, inputOp->getLoc());
+
+  // Fill `expressions` block with expression trees.
+  YieldOp yieldOp;
+  {
+    OpBuilder::InsertionGuard guard(builder);
+    builder.setInsertionPointToEnd(conditionBlock.get());
+
+    SmallVector<Value> values;
+    values.reserve(projectRel.expressions_size());
+    for (const Expression &expression : projectRel.expressions()) {
+      // Import expression tree recursively.
+      FailureOr<ExpressionOpInterface> rootExprOp =
+          importExpression(builder, expression);
+      if (failed(rootExprOp))
+        return failure();
+      values.push_back(rootExprOp.value()->getResult(0));
+    }
+
+    // Create final `yield` op with root expression values.
+    yieldOp = builder.create<YieldOp>(values);
+  }
+
+  // Compute output type.
+  SmallVector<mlir::Type> resultFieldTypes;
+  resultFieldTypes.reserve(inputTupleType.size() + yieldOp->getNumOperands());
+  append_range(resultFieldTypes, inputTupleType);
+  append_range(resultFieldTypes, yieldOp->getOperandTypes());
+  auto resultType = TupleType::get(builder.getContext(), resultFieldTypes);
+
+  // Create `project` op.
+  auto projectOp =
+      builder.create<ProjectOp>(resultType, inputOp.value()->getResult(0));
+  projectOp.getExpressions().push_back(conditionBlock.release());
+
+  return projectOp;
+}
+
 static mlir::FailureOr<RelOpInterface>
 importReadRel(ImplicitLocOpBuilder builder, const Rel &message) {
   MLIRContext *context = builder.getContext();
@@ -390,6 +448,9 @@ static mlir::FailureOr<RelOpInterface> importRel(ImplicitLocOpBuilder builder,
     break;
   case Rel::RelTypeCase::kFilter:
     maybeOp = importFilterRel(builder, message);
+    break;
+  case Rel::RelTypeCase::kProject:
+    maybeOp = importProjectRel(builder, message);
     break;
   case Rel::RelTypeCase::kRead:
     maybeOp = importReadRel(builder, message);

--- a/lib/Target/SubstraitPB/ProtobufUtils.cpp
+++ b/lib/Target/SubstraitPB/ProtobufUtils.cpp
@@ -31,6 +31,8 @@ FailureOr<const RelCommon *> getCommon(const Rel &rel, Location loc) {
     return getCommon(rel.cross());
   case Rel::RelTypeCase::kFilter:
     return getCommon(rel.filter());
+  case Rel::RelTypeCase::kProject:
+    return getCommon(rel.project());
   case Rel::RelTypeCase::kRead:
     return getCommon(rel.read());
   default:
@@ -52,6 +54,8 @@ FailureOr<RelCommon *> getMutableCommon(Rel *rel, Location loc) {
     return getMutableCommon(rel->mutable_cross());
   case Rel::RelTypeCase::kFilter:
     return getMutableCommon(rel->mutable_filter());
+  case Rel::RelTypeCase::kProject:
+    return getMutableCommon(rel->mutable_project());
   case Rel::RelTypeCase::kRead:
     return getMutableCommon(rel->mutable_read());
   default:

--- a/test/Dialect/Substrait/filter-invalid.mlir
+++ b/test/Dialect/Substrait/filter-invalid.mlir
@@ -3,6 +3,21 @@
 substrait.plan version 0 : 42 : 1 {
   relation {
     %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding one value (yields 2)}}
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = literal 0 : si1
+      yield %2, %2 : si1, si1
+    }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
     // expected-error@+1 {{'substrait.filter' op must have 'condition' region yielding 'si1' (yields 'si32')}}
     %1 = filter %0 : tuple<si32> {
     ^bb0(%arg : tuple<si32>):

--- a/test/Dialect/Substrait/plan-relation-invalid.mlir
+++ b/test/Dialect/Substrait/plan-relation-invalid.mlir
@@ -34,3 +34,14 @@ substrait.plan version 0 : 42 : 1 {
     yield %0 : tuple<si32, si32>
   }
 }
+
+// -----
+
+// Test error on wrong number of yielded values.
+substrait.plan version 0 : 42 : 1 {
+  // expected-error@+1 {{'substrait.relation' op must have 'body' region yielding one value (yields 2)}}
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
+    yield %0, %0 : tuple<si32, si32>, tuple<si32, si32>
+  }
+}

--- a/test/Dialect/Substrait/project-invalid.mlir
+++ b/test/Dialect/Substrait/project-invalid.mlir
@@ -1,0 +1,58 @@
+// RUN: structured-opt -verify-diagnostics -split-input-file %s
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32' vs 'si1')}}
+    %1 = project %0 : tuple<si32> -> tuple<si1, si32> {
+    ^bb0(%arg : tuple<si32>):
+      %42 = literal 42 : si32
+      yield %42 : si32
+    }
+    yield %1 : tuple<si1, si32>
+  }
+}
+
+// -----
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a", "b"] : tuple<si32, si32>
+    // expected-error@+1 {{'substrait.project' op has output field type whose prefix is different from input field types ('si32', 'si32' vs 'si32')}}
+    %1 = project %0 : tuple<si32, si32> -> tuple<si32> {
+    ^bb0(%arg : tuple<si32, si32>):
+      %42 = literal 42 : si32
+      yield %42 : si32
+    }
+    yield %1 : tuple<si32>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.project' op has output field type whose new fields are different from the yielded operand types ('si1' vs 'si32')}}
+    %1 = project %0 : tuple<si32> -> tuple<si32, si1> {
+    ^bb0(%arg : tuple<si32>):
+      %42 = literal 42 : si32
+      yield %42 : si32
+    }
+    yield %1 : tuple<si32, si1>
+  }
+}
+
+// -----
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    // expected-error@+1 {{'substrait.project' op has 'expressions' region with mismatching argument type (has: 'tuple<si1>', expected: 'tuple<si32>')}}
+    %1 = project %0 : tuple<si32> -> tuple<si32, si1> {
+    ^bb0(%arg : tuple<si1>):
+      %3 = field_reference %arg[[0]] : tuple<si1>
+      yield %3 : si1
+    }
+    yield %1 : tuple<si32, si1>
+  }
+}

--- a/test/Dialect/Substrait/project.mlir
+++ b/test/Dialect/Substrait/project.mlir
@@ -1,0 +1,46 @@
+// RUN: structured-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32, si1, si32> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
+// CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32
+// CHECK-NEXT:      yield %[[V2]], %[[V3]] : si1, si32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] :
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = project %0 : tuple<si32> -> tuple<si32, si1, si32> {
+    ^bb0(%arg : tuple<si32>):
+      %true = literal -1 : si1
+      %42 = literal 42 : si32
+      yield %true, %42 : si1, si32
+    }
+    yield %1 : tuple<si32, si1, si32>
+  }
+}
+
+// -----
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:    }
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = project %0 : tuple<si32> -> tuple<si32> {
+    ^bb0(%arg0: tuple<si32>):
+      yield
+    }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/project.mlir
+++ b/test/Target/SubstraitPB/Export/project.mlir
@@ -1,0 +1,26 @@
+// RUN: structured-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK:      substrait.plan version 0 : 42 : 1 {
+// CHECK-NEXT:   relation
+// CHECK:         %[[V0:.*]] = named_table
+// CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32, si1, si32> {
+// CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+// CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
+// CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32
+// CHECK-NEXT:      yield %[[V2]], %[[V3]] : si1, si32
+// CHECK-NEXT:    }
+// CHECK-NEXT:    yield %[[V1]] :
+
+substrait.plan version 0 : 42 : 1 {
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = project %0 : tuple<si32> -> tuple<si32, si1, si32> {
+    ^bb0(%arg : tuple<si32>):
+      %true = literal -1 : si1
+      %42 = literal 42 : si32
+      yield %true, %42 : si1, si32
+    }
+    yield %1 : tuple<si32, si1, si32>
+  }
+}

--- a/test/Target/SubstraitPB/Import/project.textpb
+++ b/test/Target/SubstraitPB/Import/project.textpb
@@ -1,0 +1,65 @@
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN: | FileCheck %s
+
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN: | structured-translate -substrait-to-protobuf \
+# RUN: | structured-translate -protobuf-to-substrait \
+# RUN: | FileCheck %s
+
+# CHECK:      substrait.plan version 0 : 42 : 1 {
+# CHECK-NEXT:   relation
+# CHECK:         %[[V0:.*]] = named_table
+# CHECK-NEXT:    %[[V1:.*]] = project %[[V0]] : tuple<si32> -> tuple<si32, si1, si32> {
+# CHECK-NEXT:    ^[[BB0:.*]](%[[ARG0:.*]]: tuple<si32>):
+# CHECK-NEXT:      %[[V2:.*]] = literal -1 : si1
+# CHECK-NEXT:      %[[V3:.*]] = literal 42 : si32
+# CHECK-NEXT:      yield %[[V2]], %[[V3]] : si1, si32
+# CHECK-NEXT:    }
+# CHECK-NEXT:    yield %[[V1]] :
+
+relations {
+  rel {
+    project {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      expressions {
+        literal {
+          boolean: true
+        }
+      }
+      expressions {
+        literal {
+          i32: 42
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
The design takes the decision to encode all `Expression` messages of the `expressions` field of the `ProjectRel` message as a single, combined region, where each expression corresponds to one of the yielded values. A possible alternative would be to have one region per `expression`. However, the current design not only seems more readable and more idiomatic MLIR but, in particular, allows for out-of-the-box CSE within a single `project` op.

Since the `yield` op only supported a single operand, this PR also changes that op plus a few usages to a variadic `value` operand.