### PR TITLE
[Substrait] Run CSE in emit deduplication patterns. 

### DIFF
--- a/lib/Dialect/Substrait/Transforms/CMakeLists.txt
+++ b/lib/Dialect/Substrait/Transforms/CMakeLists.txt
@@ -9,5 +9,6 @@ add_mlir_dialect_library(MLIRSubstraitTransforms
   MLIRPass
   MLIRRewrite
   MLIRSubstraitDialect
+  MLIRTransforms
   MLIRTransformUtils
 )

--- a/test/Transforms/Substrait/emit-deduplication.mlir
+++ b/test/Transforms/Substrait/emit-deduplication.mlir
@@ -161,13 +161,11 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = filter %[[V1]] : {{.*}} {
 // CHECK-NEXT:      ^{{.*}}(%[[ARG0:.*]]: [[TYPE:.*]]):
 // CHECK-NEXT:        %[[V3:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
-// CHECK-NEXT:        %[[V4:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
 // CHECK-NEXT:        %[[V5:.*]] = field_reference %[[ARG0]]{{\[}}[1, 0]] : [[TYPE]]
 // CHECK-NEXT:        %[[V6:.*]] = field_reference %[[ARG0]]{{\[}}[1]] : [[TYPE]]
 // CHECK-NEXT:        %[[V7:.*]] = field_reference %[[V6]]{{\[}}[1]] :
-// CHECK-NEXT:        %[[V8:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
 // CHECK-NEXT:        %[[V9:.*]] = field_reference %[[ARG0]]{{\[}}[2]] : [[TYPE]]
-// CHECK-NEXT:        %[[Va:.*]] = func.call @f(%[[V3]], %[[V4]], %[[V5]], %[[V7]], %[[V8]], %[[V9]])
+// CHECK-NEXT:        %[[Va:.*]] = func.call @f(%[[V3]], %[[V3]], %[[V5]], %[[V7]], %[[V3]], %[[V9]])
 // CHECK-NEXT:        yield %[[Va]] : si1
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[Vb:.*]] = emit [0, 0, 1, 0, 2] from %[[V2]]
@@ -209,8 +207,7 @@ substrait.plan version 0 : 42 : 1 {
 // CHECK-NEXT:      %[[V2:.*]] = project %[[V1]] : tuple<si32> -> tuple<si32, si1> {
 // CHECK-NEXT:      ^{{.*}}(%[[ARG0:.*]]: [[TYPE:.*]]):
 // CHECK-NEXT:        %[[V3:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
-// CHECK-NEXT:        %[[V4:.*]] = field_reference %[[ARG0]]{{\[}}[0]] : [[TYPE]]
-// CHECK-NEXT:        %[[V5:.*]] = func.call @f(%[[V3]], %[[V4]]) :
+// CHECK-NEXT:        %[[V5:.*]] = func.call @f(%[[V3]], %[[V3]]) :
 // CHECK-NEXT:        yield %[[V5]] : si1
 // CHECK-NEXT:      }
 // CHECK-NEXT:      %[[V6:.*]] = emit [0, 0, 1] from %[[V2]]


### PR DESCRIPTION
This PR depends on and, therefor, includes #837 and #836 and their dependencies.

This commits adds calls to two patterns that may create common
subexpressions during emit deduplication. By deduplicating their
regions, field references to duplicated fields end up referring to the
same field, thus creating common subexpressions. The patterns, thus
call CSE right away. An alternative would be to call CSE in one or
several dedicated patterns but that would either require (1) to test for
duplicate field references before application or (2) run CSE blindly and
return `success()` iff that made changes.