### PR TITLE
[Substrait] Implement `CallOp` for `ScalarFunction` message.

### DIFF
--- a/include/structured/Dialect/Substrait/IR/SubstraitOps.td
+++ b/include/structured/Dialect/Substrait/IR/SubstraitOps.td
@@ -297,6 +297,43 @@ def Substrait_LiteralOp : Substrait_ExpressionOp<"literal", [
   let assemblyFormat = "$value attr-dict";
 }
 
+def Substrait_CallOp : Substrait_ExpressionOp<"call", [
+    DeclareOpInterfaceMethods<SymbolUserOpInterface>,
+  ]> {
+  let summary = "Function call expression";
+  let description = [{
+    Represents a `ScalarFunction` message (or, in the future, other `*Function`
+    messages) together with all messages it contains and the `Expression`
+    message it is contained in.
+
+    Currently, the specification of the function, which is in an external YAML
+    file, is not taken into account, for example, to verify whether a matching
+    overload exists or to verify/compute the result type.
+
+    Example:
+
+    ```mlir
+    extension_uri @extension at "http://some.url/with/extensions.yml"
+    extension_function @function at @extension["somefunc"]
+    relation {
+      // ...
+      %1 = call @function(%0) : (tuple<si32>) -> si1
+      // ...
+    }
+    ```
+  }];
+  // TODO(ingomueller): Add `FunctionOptions`.
+  // TODO(ingomueller): Add support for `enum` and `type` argument types.
+  let arguments = (ins
+    FlatSymbolRefAttr:$callee,
+    Variadic<Substrait_FieldType>:$args
+  );
+  let results = (outs Substrait_FieldType:$result);
+  let assemblyFormat = [{
+    $callee `(` $args `)` attr-dict `:` `(` type($args) `)` `->` type($result)
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Relations
 //===----------------------------------------------------------------------===//

--- a/lib/Dialect/Substrait/IR/Substrait.cpp
+++ b/lib/Dialect/Substrait/IR/Substrait.cpp
@@ -51,6 +51,16 @@ void SubstraitDialect::initialize() {
 namespace mlir {
 namespace substrait {
 
+/// Implement `SymbolOpInterface`.
+::mlir::LogicalResult
+CallOp::verifySymbolUses(SymbolTableCollection &symbolTables) {
+  if (!symbolTables.lookupNearestSymbolFrom<ExtensionFunctionOp>(
+          *this, getCalleeAttr()))
+    return emitOpError() << "refers to " << getCalleeAttr()
+                         << ", which is not a valid 'extension_function' op";
+  return success();
+}
+
 LogicalResult
 CrossOp::inferReturnTypes(MLIRContext *context, std::optional<Location> loc,
                           ValueRange operands, DictionaryAttr attributes,

--- a/test/Dialect/Substrait/call.mlir
+++ b/test/Dialect/Substrait/call.mlir
@@ -1,0 +1,27 @@
+// RUN: structured-opt -split-input-file %s \
+// RUN: | FileCheck %s
+
+// CHECK-LABEL: substrait.plan
+// CHECK:         relation
+// CHECK:         named_table
+// CHECK-NEXT:    filter
+// CHECK-NEXT:    (%[[ARG0:.*]]: tuple<si32>)
+// CHECK-NEXT:      %[[V0:.*]] = field_reference %[[ARG0]]
+// CHECK-NEXT:      %[[V1:.*]] = call @function(%[[V0]]) : (si32) -> si1
+// CHECK-NEXT:      yield
+// CHECK-NEXT:    }
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @function at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = field_reference %arg[0] : tuple<si32>
+      %3 = call @function(%2) : (si32) -> si1
+      yield %3 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Export/call.mlir
+++ b/test/Target/SubstraitPB/Export/call.mlir
@@ -1,0 +1,51 @@
+// RUN: structured-translate -substrait-to-protobuf --split-input-file %s \
+// RUN: | FileCheck %s
+
+// RUN: structured-translate -substrait-to-protobuf %s \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | structured-translate -protobuf-to-substrait \
+// RUN:   --split-input-file="# -----" --output-split-marker="// ""-----" \
+// RUN: | structured-translate -substrait-to-protobuf \
+// RUN:   --split-input-file --output-split-marker="# -----" \
+// RUN: | FileCheck %s
+
+// CHECK:      extension_uris {
+// CHECK-NEXT:   uri: "http://some.url/with/extensions.yml"
+// CHECK-NEXT: }
+// CHECK-NEXT: extensions {
+// CHECK-NEXT:   extension_function {
+// CHECK-NEXT:     name: "somefunc"
+// CHECK-NEXT:   }
+// CHECK:      extensions {
+// CHECK-NEXT:   extension_function {
+// CHECK-NEXT:     function_anchor: 1
+// CHECK-NEXT:     name: "somefunc"
+// CHECK:      relations {
+// CHECK-NEXT:   rel {
+// CHECK-NEXT:     filter {
+// CHECK-NOT:        condition
+// CHECK:            condition {
+// CHECK-NEXT:         scalar_function {
+// CHECK-NEXT:           function_reference: 1
+// CHECK-NEXT:           output_type {
+// CHECK-NEXT:             bool {
+// CHECK-NEXT:               nullability: NULLABILITY_REQUIRED
+// CHECK:                arguments {
+// CHECK-NEXT:             value {
+// CHECK-NEXT:               selection {
+
+substrait.plan version 0 : 42 : 1 {
+  extension_uri @extension at "http://some.url/with/extensions.yml"
+  extension_function @f1 at @extension["somefunc"]
+  extension_function @f2 at @extension["somefunc"]
+  relation {
+    %0 = named_table @t1 as ["a"] : tuple<si32>
+    %1 = filter %0 : tuple<si32> {
+    ^bb0(%arg : tuple<si32>):
+      %2 = field_reference %arg[0] : tuple<si32>
+      %3 = call @f2(%2) : (si32) -> si1
+      yield %3 : si1
+    }
+    yield %1 : tuple<si32>
+  }
+}

--- a/test/Target/SubstraitPB/Import/call.textpb
+++ b/test/Target/SubstraitPB/Import/call.textpb
@@ -1,0 +1,96 @@
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" \
+# RUN: | FileCheck %s
+
+# RUN: structured-translate -protobuf-to-substrait %s \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | structured-translate -substrait-to-protobuf \
+# RUN:   --split-input-file --output-split-marker="# ""-----" \
+# RUN: | structured-translate -protobuf-to-substrait \
+# RUN:   --split-input-file="# ""-----" --output-split-marker="// -----" \
+# RUN: | FileCheck %s
+
+# CHECK-LABEL: substrait.plan
+# CHECK-NEXT:    extension_uri @[[URI:.*]] at "http://some.url/with/extensions.yml"
+# CHECK-NEXT:    extension_function @[[F1:.*]] at @[[URI]]["somefunc"]
+# CHECK-NEXT:    extension_function @[[F2:.*]] at @[[URI]]["somefunc"]
+# CHECK-NEXT:    relation
+# CHECK-NEXT:      named_table
+# CHECK-NEXT:      filter
+# CHECK-NEXT:      (%[[V0:.*]]: tuple<si32>):
+# CHECK-NEXT:        %[[V1:.*]] = field_reference %[[V0]][0] : tuple<si32>
+# CHECK-NEXT:        %[[V2:.*]] = call @[[F2]](%[[V1]]) : (si32) -> si1
+# CHECK-NEXT:        yield %[[V2]] : si1
+
+extension_uris {
+  uri: "http://some.url/with/extensions.yml"
+}
+extensions {
+  extension_function {
+    name: "somefunc"
+  }
+}
+extensions {
+  extension_function {
+    function_anchor: 1
+    name: "somefunc"
+  }
+}
+relations {
+  rel {
+    filter {
+      common {
+        direct {
+        }
+      }
+      input {
+        read {
+          common {
+            direct {
+            }
+          }
+          base_schema {
+            names: "a"
+            struct {
+              types {
+                i32 {
+                  nullability: NULLABILITY_REQUIRED
+                }
+              }
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          named_table {
+            names: "t1"
+          }
+        }
+      }
+      condition {
+        scalar_function {
+          function_reference: 1
+          output_type {
+            bool {
+              nullability: NULLABILITY_REQUIRED
+            }
+          }
+          arguments {
+            value {
+              selection {
+                direct_reference {
+                  struct_field {
+                  }
+                }
+                root_reference {
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+version {
+  minor_number: 42
+  patch_number: 1
+}


### PR DESCRIPTION
~~This PR depends on and, therefor, includes #853.~~

This allows to use the externally declared functions from #853 as scalar
function calls (which have the semantics of a typical function call).
The current design anticipates that aggregate and window functions can
be modelled with the same op, but future PR will need to show if and how
that is possible.