### PR TITLE
[Substrait] Fix error handling in export of `field_reference`.

### DIFF
--- a/lib/Target/SubstraitPB/Export.cpp
+++ b/lib/Target/SubstraitPB/Export.cpp
@@ -225,6 +225,9 @@ FailureOr<std::unique_ptr<Expression>> exportOperation(FieldReferenceOp op) {
                              "Substrait expression");
 
     FailureOr<std::unique_ptr<Expression>> expression = exportOperation(exprOp);
+    if (failed(expression))
+      return failure();
+
     fieldReference->set_allocated_expression(expression->release());
   } else {
     // Input must be a `BlockArgument`. Only support root references for now.


### PR DESCRIPTION
This PR fixes the error handling in the export logic of `field_reference`, which did not forward errors from importing the input expression of that op.