### PR TITLE
[CI] Fix installing apt dependencies by using action.

### DIFF
--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -35,13 +35,11 @@ jobs:
         path: sandbox/.git
         key: git-folder
 
-    - name: Install protobuf
-      run: |
-        sudo apt-get install -y protobuf-compiler libprotobuf-dev
-
-    - name: Install libcurl
-      run: |
-        sudo apt-get install -y libcurl4-gnutls-dev
+    - name: Install dependencies from apt
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.2
+      with:
+        packages: protobuf-compiler libprotobuf-dev libcurl4-gnutls-dev
+        version: 1.0
 
     - name: Checkout project
       uses: actions/checkout@v3


### PR DESCRIPTION
This PR how CI installs dependencies via apt: the previous code simply ran apt-get install without prio apt-get update. This may make CI break, which happened for some PRs, if the GH runner has a version of a package in cache that just got updated such that the cached URL is invalid and the package cannot be installed. By using a proper GH action, not only is that taken care of but the package is even cached such that installing it may be a bit faster.