### PR TITLE
Pin (and update) actions

### DIFF
--- a/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
+++ b/.github/workflows/buildAndTestDatabaseIteratorsStandalone.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: 3.11
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         path: sandbox
 

--- a/.github/workflows/buildAndTestStructured.yml
+++ b/.github/workflows/buildAndTestStructured.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: 3.11
 
     - name: Cache git folder
-      uses: actions/cache@v3
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.0.3
       with:
         path: sandbox/.git
         key: git-folder
@@ -42,7 +42,7 @@ jobs:
         version: 1.0
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         path: sandbox
         submodules: recursive
@@ -105,7 +105,7 @@ jobs:
         ${GITHUB_WORKSPACE}/sandbox/benchmarks/inner_product/plot.sh -i /tmp/result.jsonl
 
     - name: Archive benchmark plots
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: structured-benchmark-plots
         path: |

--- a/trunk/.github/workflows/buildAndTestIreeDialects.yml
+++ b/trunk/.github/workflows/buildAndTestIreeDialects.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: 3.9
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         path: sandbox
         submodules: recursive

--- a/trunk/.github/workflows/testSQLDialect.yml
+++ b/trunk/.github/workflows/testSQLDialect.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: "3.10"
 
     - name: Checkout project
-      uses: actions/checkout@v3
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
         path: sandbox
 


### PR DESCRIPTION
Pins actions to a hash instead of using a tag as suggested among others by the OpenSSF Scorecard project.